### PR TITLE
Credo should not be a production dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add as a dependency in your mix.exs file:
 ```elixir
 defp deps do
   [
-    {:credo, "~> 0.1.4"}
+    {:credo, "~> 0.1.4", only: [:dev, :test]}
   ]
 end
 ```


### PR DESCRIPTION
Hey there,

I noticed that the readme recommends you install credo without specifying which environment it will run in - to me it seems that credo should only ever be run in development and test environments, and is not particularly useful in production.