### PR TITLE
Add app/ to default config's included files

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -16,7 +16,7 @@
         #
         # you can give explicit globs or simply directories
         # in the latter case `**/*.{ex,exs}` will be used
-        included: ["lib/", "src/", "web/"],
+        included: ["lib/", "src/", "web/", "apps/"],
         excluded: []
       },
       #


### PR DESCRIPTION
This way, if you add credo to the top level of an umbrella app and have it run
over all source files.