### PR TITLE
Problem: Compilation errors on Elixir 1.2.0-dev

### DIFF
--- a/lib/credo/check/design/duplicated_code.ex
+++ b/lib/credo/check/design/duplicated_code.ex
@@ -119,7 +119,7 @@ defmodule Credo.Check.Design.DuplicatedCode do
       first_node
       |> hashes(%{}, filename)
       |> Map.keys
-      |> List.delete my_hash # don't count self
+      |> List.delete(my_hash) # don't count self
 
     subhashes
   end

--- a/lib/credo/check/readability/trailing_white_space.ex
+++ b/lib/credo/check/readability/trailing_white_space.ex
@@ -17,7 +17,7 @@ defmodule Credo.Check.Readability.TrailingWhiteSpace do
     case Regex.run(~r/\s+$/, line, return: :index) do
       [{column, line_length}] ->
         issues = [issue_for(line_no, column+1, line_length, issue_meta) | issues]
-      nil -> #
+      nil -> nil
     end
     traverse_line(tail, issues, issue_meta)
   end

--- a/lib/credo/cli/output/issues_short_list.ex
+++ b/lib/credo/cli/output/issues_short_list.ex
@@ -12,7 +12,7 @@ defmodule Credo.CLI.Output.IssuesShortList do
   def print_before_info(source_files) do
     case Enum.count(source_files) do
       0 -> UI.puts "No files found!"
-      _ -> # pass
+      _ -> :ok
     end
   end
 

--- a/lib/credo/config.ex
+++ b/lib/credo/config.ex
@@ -84,7 +84,7 @@ defmodule Credo.Config do
     end)
   end
 
-  defp from_exs(dir, config_name, exs_string \\ "%{}") do
+  defp from_exs(dir, config_name, exs_string) do
     exs_string
     |> Credo.ExsLoader.parse
     |> from_data(dir, config_name)


### PR DESCRIPTION
Latest Elixir master introduces additional compilation warnings.
This patch fixes some of them:

---

lib/credo/check/design/duplicated_code.ex:122:
warning: you are piping into a function call without parentheses, which is ambiguous. Please wrap the function you are piping into in parentheses. For example:

    foo 1 |> bar 2 |> baz 3

Should be written as:

    foo(1) |> bar(2) |> baz(3)

---

lib/credo/check/readability/trailing_white_space.ex:20:
warning: an expression is always required on the right side of ->. Please provide a value after ->

---

lib/credo/cli/output/issues_short_list.ex:15:
warning: an expression is always required on the right side of ->. Please provide a value after ->

---

lib/credo/config.ex:87:
warning: default arguments in from_exs/3 are never used