### PR TITLE
Problem: Credo.Consistency.HelperTest was not executed

### DIFF
--- a/test/credo/check/consistency/helper_test.exs
+++ b/test/credo/check/consistency/helper_test.exs
@@ -1,7 +1,7 @@
-defmodule Credo.Consistency.HelperTest do
+defmodule Credo.Check.Consistency.HelperTest do
   use Credo.TestHelper
 
-  alias Credo.Consistency.Helper
+  alias Credo.Check.Consistency.Helper
 
   test "it should report the correct most picked prop_value" do
     prop_list = [
@@ -12,7 +12,7 @@ defmodule Credo.Consistency.HelperTest do
       {[:prop1], "M5.ex"},
       {[:prop1, :prop2, :prop3], "M6.ex"},
     ]
-    assert :prop1 == Helper.most_picked_prop_value(prop_list)
+    assert {:prop1, 5, 9} == Helper.most_picked_prop_value(prop_list)
   end
 
   test "it should report the correct most picked prop_value if its a keyword list" do
@@ -24,7 +24,7 @@ defmodule Credo.Consistency.HelperTest do
       {[[prefix: "Invalid"]], "M5.ex"},
       {[[prefix: "Invalid"], [suffix: "Error"], [prefix: "Undefined"]], "M6.ex"},
     ]
-    assert [prefix: "Invalid"] == Helper.most_picked_prop_value(prop_list)
+    assert {[prefix: "Invalid"], 5, 9} == Helper.most_picked_prop_value(prop_list)
   end
 
 end


### PR DESCRIPTION
Running `mix test` produces the warning:

```
test/credo/check/consistency/helper_test.ex does not match "*_test.exs" and won't be loaded
```

Solution:

1. Rename `helper_test.ex` to `helper_test.exs`
2. Rename test to `Credo.Check.Consistency.HelperTest`
3. Fix alias to `Credo.Check.Consistency.Helper`
4. Fix asserts to reflect changed return format of `most_picked_prop_value/1`