### PR TITLE
Add note that predicates should not start with 'is'

### DIFF
--- a/lib/credo/check/readability/predicate_function_names.ex
+++ b/lib/credo/check/readability/predicate_function_names.ex
@@ -70,7 +70,7 @@ defmodule Credo.Check.Readability.PredicateFunctionNames do
 
   defp issue_for(_, line_no, trigger, issue_meta) do
     format_issue issue_meta,
-      message: "Predicate function names should end in a question mark.",
+      message: "Predicate function names should not start with 'is', and should end in a question mark.",
       trigger: trigger,
       line_no: line_no
   end


### PR DESCRIPTION
The message didn't fully explain what would flag a function as having poor predicate naming.