### PR TITLE
Change refactor tag @ `--one-line` from [R] to [F]

### DIFF
--- a/lib/credo/cli/output.ex
+++ b/lib/credo/cli/output.ex
@@ -1,8 +1,14 @@
 defmodule Credo.CLI.Output do
   alias Credo.CLI.Output.UI
 
+  @category_to_tag %{"consistency" => "C",
+                     "readability" => "R",
+                     "design"      => "D",
+                     "refactor"    => "F",
+                     "warning"     => "W"}
+
   def check_tag(category) when is_binary(category) do
-    "[#{category |> String.at(0) |> String.upcase}]"
+    "[#{Map.fetch!(@category_to_tag, category) |> String.upcase}]"
   end
   def check_tag(category) when is_atom(category) do
     category |> to_string |> check_tag


### PR DESCRIPTION
When running `mix credo --one-line` both `readability checks` and
`refactoring checks` were tagged with [R].

This commit change the `refactoring` tags to [F] in order to avoid
ambiguity and help users who would like to feed `credo` 's output to
other programs.

![screenshot from 2015-12-27 02 05 09](https://cloud.githubusercontent.com/assets/4231743/12008857/47e6dcec-ac42-11e5-9a72-e3b7a9f33d95.png)


Closes #29