### PR TITLE
Fox minor clause warning for a missing value

### DIFF
--- a/lib/credo/cli/command/help.ex
+++ b/lib/credo/cli/command/help.ex
@@ -45,7 +45,7 @@ defmodule Credo.CLI.Command.Help do
         {:shortdoc, [shortdesc]} ->
           UI.puts "  " <> name2 <> shortdesc
         _ ->
-          # skip commands without @shortdesc
+          nil # skip commands without @shortdesc
       end
     end)
 


### PR DESCRIPTION
Inserts an explicit `nil` value instead of an implicit `nil` value where a catch-all clause matches and only has a comment in place.