### PR TITLE
Do not use `:white` as the color for filenames.

### DIFF
--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -69,7 +69,7 @@ defmodule Credo.CLI.Output.Explain do
     outer_color = Output.check_color(issue)
     inner_color = Output.check_color(issue)
     message_color  = inner_color
-    filename_color = :white
+    filename_color = :default_color
     tag_style = if outer_color == inner_color, do: :faint, else: :bright
 
     [

--- a/lib/credo/cli/output/issue_helper.ex
+++ b/lib/credo/cli/output/issue_helper.ex
@@ -11,7 +11,7 @@ defmodule Credo.CLI.Output.IssueHelper do
                     %Config{one_line: true} = _config, _term_width) do
     inner_color = Output.check_color(issue)
     message_color  = inner_color
-    filename_color = :white
+    filename_color = :default_color
 
     [
       inner_color,
@@ -26,7 +26,7 @@ defmodule Credo.CLI.Output.IssueHelper do
     outer_color = Output.check_color(issue)
     inner_color = Output.issue_color(issue)
     message_color  = outer_color
-    filename_color = :white
+    filename_color = :default_color
     tag_style = if outer_color == inner_color, do: :faint, else: :bright
 
     message

--- a/lib/credo/cli/output/issues_by_scope.ex
+++ b/lib/credo/cli/output/issues_by_scope.ex
@@ -67,7 +67,7 @@ defmodule Credo.CLI.Output.IssuesByScope do
     outer_color = Output.check_color(issue)
     inner_color = Output.issue_color(issue)
     message_color  = inner_color
-    filename_color = :white
+    filename_color = :default_color
     tag_style = if outer_color == inner_color, do: :faint, else: :bright
 
     [

--- a/lib/credo/cli/output/issues_short_list.ex
+++ b/lib/credo/cli/output/issues_short_list.ex
@@ -41,7 +41,7 @@ defmodule Credo.CLI.Output.IssuesShortList do
     outer_color = Output.check_color(issue)
     inner_color = Output.check_color(issue)
     message_color  = inner_color
-    filename_color = :white
+    filename_color = :default_color
 
     [
       inner_color,


### PR DESCRIPTION
The fixed `:white` color makes credo a bit unhelpful when using light backgrounds:

![](https://dl.dropboxusercontent.com/s/w3o7ynd6ig54hwh/2016-02-03%20at%207.51%20PM.png). 

Using the `:default_color` leaves this up for your terminal to decide:

![](https://dl.dropboxusercontent.com/s/0g7ns3tanxr75ro/2016-02-03%20at%207.56%20PM.png)

![](https://dl.dropboxusercontent.com/s/z8ubatapqogf0tp/2016-02-03%20at%207.58%20PM.png)