### PR TITLE
Fix `mix do` behaviour

### DIFF
--- a/lib/credo/cli.ex
+++ b/lib/credo/cli.ex
@@ -66,7 +66,7 @@ defmodule Credo.CLI do
     end
   end
 
-  defp run(argv) do
+  def run(argv) do
     {command_mod, dir, config} = parse_options(argv)
 
     command_mod.run(dir, config)

--- a/lib/mix/tasks/credo.ex
+++ b/lib/mix/tasks/credo.ex
@@ -6,6 +6,8 @@ defmodule Mix.Tasks.Credo do
 
   @doc false
   def run(argv) do
-    Credo.CLI.main(argv)
+    Credo.start nil, nil
+
+    Credo.CLI.run(argv)
   end
 end


### PR DESCRIPTION
This PR fixes #41.

I would like to refactor much more by completely moving those stuff in to a “sublib” which is then used by cli and mix instead of the current situation where mix is just a wrapper to cli. But unfortunately I'm missing the necessary time.