### PR TITLE
fixed : UnicodeConversionError when a comment has UTF 8 character

### DIFF
--- a/lib/credo/code/sigils.ex
+++ b/lib/credo/code/sigils.ex
@@ -44,7 +44,7 @@ defmodule Credo.Code.Sigils do
     parse_string_literal(t, acc <> "\"", replacement)
   end
   defp parse_code(<< h::utf8, t::binary >>, acc, replacement) do
-    parse_code(t, acc <> <<h>>, replacement)
+    parse_code(t, acc <> <<h :: utf8>>, replacement)
   end
   defp parse_code(str, acc, replacement) when is_binary(str) do
     {h, t} = str |> String.next_codepoint

--- a/test/credo/code/sigils_test.exs
+++ b/test/credo/code/sigils_test.exs
@@ -51,6 +51,7 @@ defmodule Credo.CLI.Command.List do
     Arrows (↑ ↗ → ↘ ↓) hint at the importance of the object being looked at.
     \"\"\"
     |> UI.puts
+    # ↑
   end
 end
 """
@@ -62,6 +63,7 @@ defmodule Credo.CLI.Command.List do
     Arrows (↑ ↗ → ↘ ↓) hint at the importance of the object being looked at.
     \"\"\"
     |> UI.puts
+    # ↑
   end
 end
 """


### PR DESCRIPTION
i fixed UnicodeConversionError occurs when a comment has UTF 8 character (ex : ```↑```, ```エリクサー```).

Thanks