### PR TITLE
Set minimum Elixir version to 1.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Credo.Mixfile do
     [
       app: :credo,
       version: "0.3.13",
-      elixir: "~> 1.0",
+      elixir: "~> 1.1",
       escript: [main_module: Credo.CLI],
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Credo errors with Elixir versions less than v1.1 because the tokenizer did not supply column positions until v1.1. 

Here is the output of the error when running `mix credo` on Elixir v1.0.5.

```
** (MatchError) no match of right hand side value: {:ok, 3, [{:identifier, 1, :defmodule}, {:aliases, 1, [:CredoTest]}, {:do, 1}, {:eol, 1}, {:end, 2}, {:eol, 2}]}
    lib/credo/code.ex:60: Credo.Code.to_tokens/1
    lib/credo/check/consistency/space_around_operators/with_space.ex:16: Credo.Check.Consistency.SpaceAroundOperators.WithSpace.property_values_for/2
    lib/credo/check/consistency/helper.ex:152: anonymous fn/4 in Credo.Check.Consistency.Helper.collect_property_values/3
    (elixir) lib/enum.ex:1261: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/credo/check/consistency/helper.ex:144: Credo.Check.Consistency.Helper.property_list_for/3
    lib/credo/check/consistency/helper.ex:138: Credo.Check.Consistency.Helper.create_property_tuples/3
    (elixir) lib/enum.ex:977: anonymous fn/3 in Enum.map/2
    (elixir) lib/enum.ex:1261: Enum."-reduce/3-lists^foldl/2-0-"/3
```