### PR TITLE
Fix Markdown indent issue in RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,9 +7,9 @@
 * Update version in `mix.exs`
 * Create a commit:
 
-      git commit -a -m "Bump version to 0.X.Y"
-      git tag v0.X.Y
-      mix test --warnings-as-errors && mix hex.publish
-      git push origin master --tags
+        git commit -a -m "Bump version to 0.X.Y"
+        git tag v0.X.Y
+        mix test --warnings-as-errors && mix hex.publish
+        git push origin master --tags
 
 * Enjoy!


### PR DESCRIPTION
Something that was bothering me when I opened up the rendered `RELEASING.md` file on GitHub 😄 

* [Before](https://github.com/remiprev/credo/blob/master/RELEASING.md)
* [After](https://github.com/remiprev/credo/blob/18cc7377a7602e80109dfc0c15707625da93d2e5/RELEASING.md)