### PR TITLE
Ignore metadata in OperationOnSameValues and BoolOperationOnSameValue checks

### DIFF
--- a/lib/credo/check/warning/bool_operation_on_same_values.ex
+++ b/lib/credo/check/warning/bool_operation_on_same_values.ex
@@ -26,7 +26,7 @@ defmodule Credo.Check.Warning.BoolOperationOnSameValues do
 
   for op <- @ops do
     defp traverse({unquote(op), meta, [lhs, rhs]} = ast, issues, issue_meta) do
-      if lhs == rhs do
+      if CodeHelper.remove_metadata(lhs) == CodeHelper.remove_metadata(rhs) do
         new_issue = issue_for(issue_meta, meta[:line], unquote(op))
         {ast, issues ++ [new_issue]}
       else

--- a/lib/credo/check/warning/operation_on_same_values.ex
+++ b/lib/credo/check/warning/operation_on_same_values.ex
@@ -39,7 +39,7 @@ defmodule Credo.Check.Warning.OperationOnSameValues do
 
   for {op, operation_name, constant_result} <- @ops_and_constant_results do
     defp traverse({unquote(op), meta, [lhs, rhs]} = ast, issues, issue_meta) do
-      if lhs == rhs do
+      if CodeHelper.remove_metadata(lhs) == CodeHelper.remove_metadata(rhs) do
         new_issue = issue_for(issue_meta, meta[:line], unquote(op), unquote(operation_name),
                                     unquote(constant_result))
         {ast, issues ++ [new_issue]}

--- a/test/credo/check/code_helper_test.exs
+++ b/test/credo/check/code_helper_test.exs
@@ -58,4 +58,53 @@ end
     assert expected == source_file |> CodeHelper.clean_strings_sigils_and_comments
   end
 
+
+  test "returns ast without metadata" do
+    ast =
+      {:__block__, [],
+ [{:defmodule, [line: 1],
+   [{:__aliases__, [counter: 0, line: 1], [:M1]},
+    [do: {:def, [line: 2],
+      [{:when, [line: 2],
+        [{:myfun, [line: 2], [{:p1, [line: 2], nil}, {:p2, [line: 2], nil}]},
+         {:is_list, [line: 2], [{:p2, [line: 2], nil}]}]},
+       [do: {:if, [line: 3],
+         [{:==, [line: 3], [{:p1, [line: 3], nil}, {:p2, [line: 3], nil}]},
+          [do: {:p1, [line: 4], nil},
+           else: {:+, [line: 6],
+            [{:p2, [line: 6], nil}, {:p1, [line: 6], nil}]}]]}]]}]]},
+  {:defmodule, [line: 11],
+   [{:__aliases__, [counter: 0, line: 11], [:M2]},
+    [do: {:def, [line: 12],
+      [{:myfun2, [line: 12], [{:p1, [line: 12], nil}, {:p2, [line: 12], nil}]},
+       [do: {:if, [line: 13],
+         [{:==, [line: 13], [{:p1, [line: 13], nil}, {:p2, [line: 13], nil}]},
+          [do: {:p1, [line: 14], nil},
+           else: {:+, [line: 16],
+            [{:p2, [line: 16], nil}, {:p1, [line: 16], nil}]}]]}]]}]]}]}
+    expected =
+      {:__block__, [],
+       [{:defmodule, [],
+         [{:__aliases__, [], [:M1]},
+          [do: {:def, [],
+            [{:when, [],
+              [{:myfun, [], [{:p1, [], nil}, {:p2, [], nil}]},
+               {:is_list, [], [{:p2, [], nil}]}]},
+             [do: {:if, [],
+               [{:==, [], [{:p1, [], nil}, {:p2, [], nil}]},
+                [do: {:p1, [], nil},
+                 else: {:+, [],
+                  [{:p2, [], nil}, {:p1, [], nil}]}]]}]]}]]},
+        {:defmodule, [],
+         [{:__aliases__, [], [:M2]},
+          [do: {:def, [],
+            [{:myfun2, [], [{:p1, [], nil}, {:p2, [], nil}]},
+             [do: {:if, [],
+               [{:==, [], [{:p1, [], nil}, {:p2, [], nil}]},
+                [do: {:p1, [], nil},
+                 else: {:+, [],
+                  [{:p2, [], nil}, {:p1, [], nil}]}]]}]]}]]}]}
+    assert expected == CodeHelper.remove_metadata(ast)
+  end
+
 end

--- a/test/credo/check/design/duplicated_code_test.exs
+++ b/test/credo/check/design/duplicated_code_test.exs
@@ -141,55 +141,6 @@ end
   end
 
 
-  test "returns ast without metadata" do
-    ast =
-      {:__block__, [],
- [{:defmodule, [line: 1],
-   [{:__aliases__, [counter: 0, line: 1], [:M1]},
-    [do: {:def, [line: 2],
-      [{:when, [line: 2],
-        [{:myfun, [line: 2], [{:p1, [line: 2], nil}, {:p2, [line: 2], nil}]},
-         {:is_list, [line: 2], [{:p2, [line: 2], nil}]}]},
-       [do: {:if, [line: 3],
-         [{:==, [line: 3], [{:p1, [line: 3], nil}, {:p2, [line: 3], nil}]},
-          [do: {:p1, [line: 4], nil},
-           else: {:+, [line: 6],
-            [{:p2, [line: 6], nil}, {:p1, [line: 6], nil}]}]]}]]}]]},
-  {:defmodule, [line: 11],
-   [{:__aliases__, [counter: 0, line: 11], [:M2]},
-    [do: {:def, [line: 12],
-      [{:myfun2, [line: 12], [{:p1, [line: 12], nil}, {:p2, [line: 12], nil}]},
-       [do: {:if, [line: 13],
-         [{:==, [line: 13], [{:p1, [line: 13], nil}, {:p2, [line: 13], nil}]},
-          [do: {:p1, [line: 14], nil},
-           else: {:+, [line: 16],
-            [{:p2, [line: 16], nil}, {:p1, [line: 16], nil}]}]]}]]}]]}]}
-    expected =
-      {:__block__, [],
-       [{:defmodule, [],
-         [{:__aliases__, [], [:M1]},
-          [do: {:def, [],
-            [{:when, [],
-              [{:myfun, [], [{:p1, [], nil}, {:p2, [], nil}]},
-               {:is_list, [], [{:p2, [], nil}]}]},
-             [do: {:if, [],
-               [{:==, [], [{:p1, [], nil}, {:p2, [], nil}]},
-                [do: {:p1, [], nil},
-                 else: {:+, [],
-                  [{:p2, [], nil}, {:p1, [], nil}]}]]}]]}]]},
-        {:defmodule, [],
-         [{:__aliases__, [], [:M2]},
-          [do: {:def, [],
-            [{:myfun2, [], [{:p1, [], nil}, {:p2, [], nil}]},
-             [do: {:if, [],
-               [{:==, [], [{:p1, [], nil}, {:p2, [], nil}]},
-                [do: {:p1, [], nil},
-                 else: {:+, [],
-                  [{:p2, [], nil}, {:p1, [], nil}]}]]}]]}]]}]}
-    assert expected == DuplicatedCode.remove_metadata(ast)
-  end
-
-
   test "returns correct mass" do
     {:ok, ast} = """
 defmodule M1 do

--- a/test/credo/check/warning/bool_operation_on_same_values_test.exs
+++ b/test/credo/check/warning/bool_operation_on_same_values_test.exs
@@ -26,11 +26,13 @@ defmodule CredoSampleModule do
     x or x
     x && x
     x || x
+    x &&
+      x # on different lines
   end
 end
 """ |> to_source_file
     |> assert_issues(@described_check, fn(issues) ->
-        assert 4 == Enum.count(issues)
+        assert 5 == Enum.count(issues)
       end)
   end
 

--- a/test/credo/check/warning/operation_on_same_values_test.exs
+++ b/test/credo/check/warning/operation_on_same_values_test.exs
@@ -44,11 +44,13 @@ defmodule CredoSampleModule do
     x > x   # always false
     y / y   # always 1
     y - y   # always 0
+    y -
+      y # on different lines
   end
 end
 """ |> to_source_file
     |> assert_issues(@described_check, fn(issues) ->
-        assert 7 == Enum.count(issues)
+        assert 8 == Enum.count(issues)
       end)
   end
 


### PR DESCRIPTION
I've noticed that `OperationOnSameValues` and `BoolOperationOnSameValue` checks don't work when `lhs` and `rhs` are on different lines and `metadata` values inside ast are different.

Not sure if `CodeHelper` is good place for `remove_metadata`. Feedback is highly appreciated!