### PR TITLE
Minor clean-ups on credo

### DIFF
--- a/lib/credo/check/code_helper.ex
+++ b/lib/credo/check/code_helper.ex
@@ -45,7 +45,7 @@ defmodule Credo.Check.CodeHelper do
   def scope_for(source_file, [line: line_no]) do
     source_file
     |> scope_list
-    |> Enum.at(line_no-1)
+    |> Enum.at(line_no - 1)
   end
 
   @doc """

--- a/lib/credo/check/consistency/helper.ex
+++ b/lib/credo/check/consistency/helper.ex
@@ -65,7 +65,7 @@ defmodule Credo.Check.Consistency.Helper do
 
           prop_size =
             all_property_values
-            |> Enum.filter(fn(property_value)->
+            |> Enum.filter(fn(property_value) ->
                 PropertyValue.get(property_value) == current_property_value
               end)
             |> Enum.count

--- a/lib/credo/check/design/duplicated_code.ex
+++ b/lib/credo/check/design/duplicated_code.ex
@@ -213,7 +213,7 @@ defmodule Credo.Check.Design.DuplicatedCode do
   end
 
   defp calc_mass(ast, acc) when is_tuple(ast) do
-    {ast, acc+1}
+    {ast, acc + 1}
   end
   defp calc_mass(ast, acc) do
     {ast, acc}
@@ -231,7 +231,7 @@ defmodule Credo.Check.Design.DuplicatedCode do
       format_issue issue_meta,
         message: "Duplicate code found in #{filenames} (mass: #{mass}).",
         line_no: line_no,
-        severity: Severity.compute(1+Enum.count(other_nodes), 1)
+        severity: Severity.compute(1 + Enum.count(other_nodes), 1)
     end
   end
 

--- a/lib/credo/check/design/tag_helper.ex
+++ b/lib/credo/check/design/tag_helper.ex
@@ -23,7 +23,7 @@ defmodule Credo.Check.Design.TagHelper do
       |> List.wrap
       |> Enum.map(&String.strip/1)
 
-    {index+1, line, tag_list |> List.first}
+    {index + 1, line, tag_list |> List.first}
   end
 
   defp tags?({_line_no, _line, nil}), do: false

--- a/lib/credo/check/readability/max_line_length.ex
+++ b/lib/credo/check/readability/max_line_length.ex
@@ -68,7 +68,7 @@ defmodule Credo.Check.Readability.MaxLineLength do
   defp issue_for(line_no, max_length, line, issue_meta) do
     length = String.length(line)
     column = max_length + 1
-    trigger = String.slice(line, max_length, length-max_length)
+    trigger = String.slice(line, max_length, length - max_length)
 
     format_issue issue_meta,
       message: "Line is too long (max is #{max_length}, was #{length}).",

--- a/lib/credo/check/readability/trailing_white_space.ex
+++ b/lib/credo/check/readability/trailing_white_space.ex
@@ -16,7 +16,7 @@ defmodule Credo.Check.Readability.TrailingWhiteSpace do
   defp traverse_line([{line_no, line} | tail], issues, issue_meta) do
     case Regex.run(~r/\s+$/, line, return: :index) do
       [{column, line_length}] ->
-        issues = [issue_for(issue_meta, line_no, column+1, line_length) | issues]
+        issues = [issue_for(issue_meta, line_no, column + 1, line_length) | issues]
       nil -> nil
     end
     traverse_line(tail, issues, issue_meta)

--- a/lib/credo/check/refactor/abc_size.ex
+++ b/lib/credo/check/refactor/abc_size.ex
@@ -79,7 +79,7 @@ defmodule Credo.Check.Refactor.ABCSize do
                                               initial_acc)
     #IO.inspect [a: a, b: b, c: c]
     #IO.inspect ast
-    :math.sqrt(a*a+b*b+c*c)
+    :math.sqrt(a * a + b * b + c * c)
   end
 
   def get_parameters(arguments) do

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -52,7 +52,7 @@ defmodule Credo.CLI.Output.Explain do
     [
       :bright, "#{color}_background" |> String.to_atom, color, " ",
         Output.foreground_color(color), :normal,
-      " #{scope_name}" |> String.ljust(term_width-1),
+      " #{scope_name}" |> String.ljust(term_width - 1),
     ]
     |> UI.puts
 
@@ -121,12 +121,13 @@ defmodule Credo.CLI.Output.Explain do
     |> UI.puts
 
     if issue.line_no do
-      {_, line} = Enum.at(source_file.lines, issue.line_no-1)
+      {_, line} = Enum.at(source_file.lines, issue.line_no - 1)
 
       displayed_line = String.strip(line)
       if String.length(displayed_line) > term_width do
         ellipsis = " ..."
-        displayed_line = String.slice(displayed_line, 0, term_width-@indent-String.length(ellipsis)) <> ellipsis
+        chars_to_display = term_width - @indent - String.length(ellipsis)
+        displayed_line = String.slice(displayed_line, 0, chars_to_display) <> ellipsis
       end
 
       UI.edge([outer_color, :faint])

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -123,13 +123,6 @@ defmodule Credo.CLI.Output.Explain do
     if issue.line_no do
       {_, line} = Enum.at(source_file.lines, issue.line_no - 1)
 
-      displayed_line = String.strip(line)
-      if String.length(displayed_line) > term_width do
-        ellipsis = " ..."
-        chars_to_display = term_width - @indent - String.length(ellipsis)
-        displayed_line = String.slice(displayed_line, 0, chars_to_display) <> ellipsis
-      end
-
       UI.edge([outer_color, :faint])
       |> UI.puts
 
@@ -144,7 +137,8 @@ defmodule Credo.CLI.Output.Explain do
 
       [
         UI.edge([outer_color, :faint]), :reset, :cyan, :bright,
-          String.duplicate(" ", @indent-2), displayed_line
+          String.duplicate(" ", @indent-2),
+          UI.trim_to_length(line, term_width - @indent)
       ]
       |> UI.puts
 

--- a/lib/credo/cli/output/issue_helper.ex
+++ b/lib/credo/cli/output/issue_helper.ex
@@ -87,12 +87,13 @@ defmodule Credo.CLI.Output.IssueHelper do
     nil
   end
   defp print_issue_line(%Issue{} = issue, source_file, inner_color, outer_color, term_width) do
-    {_, line} = Enum.at(source_file.lines, issue.line_no-1)
+    {_, line} = Enum.at(source_file.lines, issue.line_no - 1)
 
     displayed_line = String.strip(line)
     if String.length(displayed_line) > term_width do
       ellipsis = " ..."
-      displayed_line = String.slice(displayed_line, 0, term_width-@indent-String.length(ellipsis)) <> ellipsis
+      chars_to_display = term_width - @indent - String.length(ellipsis)
+      displayed_line = String.slice(displayed_line, 0, chars_to_display) <> ellipsis
     end
 
     [outer_color, :faint]

--- a/lib/credo/cli/output/issue_helper.ex
+++ b/lib/credo/cli/output/issue_helper.ex
@@ -89,20 +89,14 @@ defmodule Credo.CLI.Output.IssueHelper do
   defp print_issue_line(%Issue{} = issue, source_file, inner_color, outer_color, term_width) do
     {_, line} = Enum.at(source_file.lines, issue.line_no - 1)
 
-    displayed_line = String.strip(line)
-    if String.length(displayed_line) > term_width do
-      ellipsis = " ..."
-      chars_to_display = term_width - @indent - String.length(ellipsis)
-      displayed_line = String.slice(displayed_line, 0, chars_to_display) <> ellipsis
-    end
-
     [outer_color, :faint]
     |> UI.edge
     |> UI.puts
 
     [
       UI.edge([outer_color, :faint]), :cyan, :faint,
-        String.duplicate(" ", @indent-2), displayed_line
+        String.duplicate(" ", @indent-2),
+        UI.trim_to_length(line, term_width - @indent)
     ]
     |> UI.puts
 

--- a/lib/credo/cli/output/issues_by_scope.ex
+++ b/lib/credo/cli/output/issues_by_scope.ex
@@ -51,7 +51,7 @@ defmodule Credo.CLI.Output.IssuesByScope do
       [
         :bright, "#{color}_background" |> String.to_atom, color, " ",
           Output.foreground_color(color), :normal,
-        " #{scope_name}" |> String.ljust(term_width-1),
+        " #{scope_name}" |> String.ljust(term_width - 1),
       ]
       |> UI.puts
 
@@ -89,12 +89,13 @@ defmodule Credo.CLI.Output.IssuesByScope do
     |> UI.puts
 
     if issue.line_no do
-      {_, line} = Enum.at(source_file.lines, issue.line_no-1)
+      {_, line} = Enum.at(source_file.lines, issue.line_no - 1)
 
       displayed_line = String.strip(line)
       if String.length(displayed_line) > term_width do
         ellipsis = " ..."
-        displayed_line = String.slice(displayed_line, 0, term_width-@indent-String.length(ellipsis)) <> ellipsis
+        chars_to_display = term_width - @indent - String.length(ellipsis)
+        displayed_line = String.slice(displayed_line, 0, chars_to_display) <> ellipsis
       end
 
       UI.edge([outer_color, :faint])
@@ -102,7 +103,7 @@ defmodule Credo.CLI.Output.IssuesByScope do
 
       [
         UI.edge([outer_color, :faint]), :cyan, :faint,
-          String.duplicate(" ", @indent-2), displayed_line
+          String.duplicate(" ", @indent - 2), displayed_line
       ]
       |> UI.puts
 

--- a/lib/credo/cli/output/issues_by_scope.ex
+++ b/lib/credo/cli/output/issues_by_scope.ex
@@ -91,19 +91,13 @@ defmodule Credo.CLI.Output.IssuesByScope do
     if issue.line_no do
       {_, line} = Enum.at(source_file.lines, issue.line_no - 1)
 
-      displayed_line = String.strip(line)
-      if String.length(displayed_line) > term_width do
-        ellipsis = " ..."
-        chars_to_display = term_width - @indent - String.length(ellipsis)
-        displayed_line = String.slice(displayed_line, 0, chars_to_display) <> ellipsis
-      end
-
       UI.edge([outer_color, :faint])
       |> UI.puts
 
       [
         UI.edge([outer_color, :faint]), :cyan, :faint,
-          String.duplicate(" ", @indent - 2), displayed_line
+          String.duplicate(" ", @indent - 2),
+          UI.trim_to_length(line, term_width - @indent)
       ]
       |> UI.puts
 

--- a/lib/credo/cli/output/issues_grouped_by_category.ex
+++ b/lib/credo/cli/output/issues_grouped_by_category.ex
@@ -103,7 +103,7 @@ defmodule Credo.CLI.Output.IssuesGroupedByCategory do
     [
       :bright, "#{color}_background" |> String.to_atom, color, " ",
         Output.foreground_color(color), :normal,
-      " #{title}" |> String.ljust(term_width-1),
+      " #{title}" |> String.ljust(term_width - 1),
     ]
     |> UI.puts
 

--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -70,7 +70,7 @@ defmodule Credo.CLI.Output.Summary do
             if index == 0 do
               :green
             else
-              {category, _, _} = @category_wording |> Enum.at(index-1)
+              {category, _, _} = @category_wording |> Enum.at(index - 1)
               Output.check_color(category)
             end
           [color, String.duplicate("=", round(quota * width))]
@@ -121,7 +121,7 @@ defmodule Credo.CLI.Output.Summary do
       |> Enum.flat_map(&summary_part(&1, issues))
 
     parts =
-      parts |> List.update_at(Enum.count(parts)-1, fn(last_part) ->
+      parts |> List.update_at(Enum.count(parts) - 1, fn(last_part) ->
         String.replace(last_part, ", ", "")
        end)
 

--- a/lib/credo/cli/output/ui.ex
+++ b/lib/credo/cli/output/ui.ex
@@ -10,11 +10,43 @@ defmodule Credo.CLI.Output.UI do
   defdelegate puts(v), to: Bunt
   def puts(v, color), do: Bunt.puts([color, v])
 
-
   def wrap_at(text, number) do
     Regex.compile!("(?:((?>.{1,#{number}}(?:(?<=[^\\S\\r\\n])[^\\S\\r\\n]?|(?=\\r?\\n)|$|[^\\S\\r\\n]))|.{1,#{number}})(?:\\r?\\n)?|(?:\\r?\\n|$))")
     |> Regex.scan(text)
     |> Enum.map(&List.first/1)
     |> List.delete_at(-1)
   end
+
+  @doc """
+  Trim and possibly truncate a line to fit within a specified maximum length.
+  Truncation is indicated by a trailing ellipsis (…), and you can override this
+  using an optional third argument.
+
+      iex> Credo.CLI.Output.UI.trim_to_length("  7 chars\\n", 7)
+      "7 chars"
+      iex> Credo.CLI.Output.UI.trim_to_length("  more than 7\\n", 7)
+      "more t…"
+      iex> Credo.CLI.Output.UI.trim_to_length("  more than 7\\n", 7, " ...")
+      "mor ..."
+  """
+  def trim_to_length(_line, max_length) when max_length <= 0, do: ""
+  def trim_to_length(line, max_length) when max_length > 0 do
+    trim_to_length(line, max_length, "…")
+  end
+
+  def trim_to_length(_line, max_length, _ellipsis) when max_length <= 0, do: ""
+  def trim_to_length(line, max_length, ellipsis) when max_length > 0 do
+    display_line = String.strip(line)
+
+    cond do
+      String.length(display_line) <= max_length -> display_line
+
+      String.length(ellipsis) >= max_length -> ellipsis
+
+      true ->
+        chars_to_display = max_length - String.length(ellipsis)
+        String.slice(display_line, 0, chars_to_display) <> ellipsis
+    end
+  end
+
 end

--- a/lib/credo/code/scope.ex
+++ b/lib/credo/code/scope.ex
@@ -14,7 +14,7 @@ defmodule Credo.Code.Scope do
   def mod_name(scope_name) do
     names = scope_name |> String.split(".")
     if names |> List.last |> String.match?(~r/^[a-z]/) do
-      names |> Enum.slice(0..length(names)-2) |> Enum.join(".")
+      names |> Enum.slice(0..length(names) - 2) |> Enum.join(".")
     else
       scope_name
     end

--- a/lib/credo/priority.ex
+++ b/lib/credo/priority.ex
@@ -21,7 +21,7 @@ defmodule Credo.Priority do
           case list do
             [] -> nil
             _ ->
-              {_, scope_name} = Scope.name(source_file.ast, line: index+1)
+              {_, scope_name} = Scope.name(source_file.ast, line: index + 1)
               {scope_name, sum(list)}
           end
         end)
@@ -35,7 +35,7 @@ defmodule Credo.Priority do
     |> Enum.map(fn({scope_name, prio}) ->
         names = scope_name |> String.split(".")
         if names |> List.last |> String.match?(~r/^[a-z]/) do
-          mod_name = names |> Enum.slice(0..length(names)-2) |> Enum.join(".")
+          mod_name = names |> Enum.slice(0..length(names) - 2) |> Enum.join(".")
           mod_prio = lookup[mod_name]
           {scope_name, prio + mod_prio}
         else
@@ -47,18 +47,18 @@ defmodule Credo.Priority do
 
   defp sum(list, acc \\ 0)
   defp sum([], acc), do: acc
-  defp sum([head|tail], acc), do: sum(tail, acc+head)
+  defp sum([head|tail], acc), do: sum(tail, acc + head)
 
   defp traverse({:defmodule, meta, _} = ast, acc) do
     added_prio = priority_for(ast)
 
-    {ast, List.update_at(acc, meta[:line]-1, &(&1 ++ [added_prio]))}
+    {ast, List.update_at(acc, meta[:line] - 1, &(&1 ++ [added_prio]))}
   end
   for op <- @def_ops do
     defp traverse({unquote(op), meta, arguments} = ast, acc) when is_list(arguments) do
       added_prio = priority_for(ast)
 
-      {ast, List.update_at(acc, meta[:line]-1, &(&1 ++ [added_prio]))}
+      {ast, List.update_at(acc, meta[:line] - 1, &(&1 ++ [added_prio]))}
     end
   end
   defp traverse(ast, acc) do

--- a/test/credo/cli/output/ui_test.exs
+++ b/test/credo/cli/output/ui_test.exs
@@ -3,6 +3,8 @@ defmodule Credo.CLI.Output.UITest do
 
   alias Credo.CLI.Output.UI
 
+  doctest Credo.CLI.Output.UI
+
   test "it should break up a long line into two elements" do
     lines =
 """
@@ -23,5 +25,20 @@ These checks take a look at your code and ensure a consistent coding style. Usin
       "These checks take a look at your code and ensure a consistent coding style.",
     ]
     assert expected == lines
+  end
+
+  test "trim_to_length when max_length > ellipsis length and truncation required" do
+    # Even if the ellipsis is longer than the max lenght we should not
+    # truncate the ellipsis so the human reader doesn't have to figure out
+    # that the "." they're seeing is part of a truncated "..."
+    assert UI.trim_to_length("hello", 1, "...") == "..."
+  end
+
+  test "trim_to_length with max_length of 0" do
+    assert UI.trim_to_length("hello", 0) == ""
+  end
+
+  test "trim_to_length with max_length < 0" do
+    assert UI.trim_to_length("hello", -5) == ""
   end
 end


### PR DESCRIPTION
This came about because I ran `credo` on itself as an experiment, and these seemed like harmless changes to eliminate a whole class of messages.