### PR TITLE
allow module names when parsing config in safe mode

### DIFF
--- a/lib/credo/exs_loader.ex
+++ b/lib/credo/exs_loader.ex
@@ -43,6 +43,14 @@ defmodule Credo.ExsLoader do
     process_tuple(body, {})
   end
 
+  defp process_exs({:__aliases__, _meta, name_list}) do
+    Module.safe_concat(name_list)
+  end
+
+  defp process_exs({{:__aliases__, _meta, name_list}, options}) do
+    {Module.safe_concat(name_list), process_exs(options)}
+  end
+
   defp process_exs({key, value}) when is_atom(key) or is_binary(key) do
     {process_exs(key), process_exs(value)}
   end

--- a/test/credo/exs_loader_test.exs
+++ b/test/credo/exs_loader_test.exs
@@ -8,8 +8,8 @@ defmodule Credo.ExsLoaderTest do
         "dirs": ["lib", "src", "test"],
         "dirs_sigil": ~w(lib src test),
         checks: [
-          {"Style.MaxLineLength", max_length: 100},
-          {"Style.TrailingBlankLine"},
+          {Style.MaxLineLength, max_length: 100},
+          {Style.TrailingBlankLine},
         ]
       }
     """
@@ -19,8 +19,8 @@ defmodule Credo.ExsLoaderTest do
         "dirs": ["lib", "src", "test"],
         "dirs_sigil": ~w(lib src test),
         checks: [
-          {"Style.MaxLineLength", max_length: 100},
-          {"Style.TrailingBlankLine"},
+          {Style.MaxLineLength, max_length: 100},
+          {Style.TrailingBlankLine},
         ]
       }
 


### PR DESCRIPTION
Hi @rrrene, I was trying to load a config in safe mode, using default credo config and it was not working because of module names. 

What do you think about this change?