### PR TITLE
Whitespace changes to eliminate Consistency messages

### DIFF
--- a/lib/credo/check/consistency/exception_names.ex
+++ b/lib/credo/check/consistency/exception_names.ex
@@ -62,22 +62,26 @@ defmodule Credo.Check.Consistency.ExceptionNames do
     source_file = IssueMeta.source_file(issue_meta)
     case expected_prop do
       {prefix, :prefix} ->
-        find_exception_modules_without_prefix(source_file, prefix)
+        source_file
+        |> find_exception_modules_without_prefix(prefix)
         |> issues_for_wrong(:prefix, issue_meta, prefix)
       {suffix, :suffix} ->
-        find_exception_modules_without_suffix(source_file, suffix)
+        source_file
+        |> find_exception_modules_without_suffix(suffix)
         |> issues_for_wrong(:suffix, issue_meta, suffix)
       _ -> nil
     end
   end
 
   defp find_exception_modules_without_suffix(%SourceFile{ast: ast}, suffix) do
-    Credo.Code.traverse(ast, &find_exception_modules(&1, &2))
+    ast
+    |> Credo.Code.traverse(&find_exception_modules(&1, &2))
     |> Enum.reject(&name_with_suffix?(&1, suffix))
   end
 
   defp find_exception_modules_without_prefix(%SourceFile{ast: ast}, prefix) do
-    Credo.Code.traverse(ast, &find_exception_modules(&1, &2))
+    ast
+    |> Credo.Code.traverse(&find_exception_modules(&1, &2))
     |> Enum.reject(&name_with_prefix?(&1, prefix))
   end
 

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -64,7 +64,8 @@ defmodule Credo.Check.Readability.LargeNumbers do
     line_ending = String.slice(line, 0..column1 - 1)
 
     underscore_count =
-      Regex.run(~r/\d_\d/, line_ending)
+      ~r/\d_\d/
+      |> Regex.run(line_ending)
       |> List.wrap
       |> Enum.count
 

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -61,7 +61,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
       |> IssueMeta.source_file
       |> SourceFile.line_at(line_no)
 
-    line_ending = String.slice(line, 0..column1-1)
+    line_ending = String.slice(line, 0..column1 - 1)
 
     underscore_count =
       Regex.run(~r/\d_\d/, line_ending)
@@ -70,7 +70,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
 
     temp_string =
       line
-      |> String.slice(column1-1+underscore_count..-1)
+      |> String.slice(column1 - 1 + underscore_count..-1)
 
     found_string =
       ~r/([0-9\_]*\.[0-9]+|[0-9\_]+)/

--- a/lib/credo/check/readability/module_names.ex
+++ b/lib/credo/check/readability/module_names.ex
@@ -41,7 +41,7 @@ defmodule Credo.Check.Readability.ModuleNames do
   defp issues_for_def(body, issues, issue_meta) do
     case Enum.at(body, 0) do
       {:__aliases__, meta, names} ->
-        Enum.join(names, ".") |> issues_for_name(meta, issues, issue_meta)
+        names |> Enum.join(".") |> issues_for_name(meta, issues, issue_meta)
       {name, meta, nil} ->
         name |> issues_for_name(meta, issues, issue_meta)
       _ ->

--- a/lib/credo/check/refactor/abc_size.ex
+++ b/lib/credo/check/refactor/abc_size.ex
@@ -40,7 +40,7 @@ defmodule Credo.Check.Refactor.ABCSize do
   end
   for op <- @def_ops do
     defp traverse({unquote(op), meta, arguments} = ast, issues, issue_meta, max_abc_size) when is_list(arguments) do
-      abc_size = abc_size_for(ast) |> round
+      abc_size = ast |> abc_size_for |> round
       if abc_size > max_abc_size do
         fun_name = CodeHelper.def_name(ast)
         {ast, [issue_for(issue_meta, meta[:line], fun_name, max_abc_size, abc_size) | issues]}

--- a/lib/credo/check/refactor/nesting.ex
+++ b/lib/credo/check/refactor/nesting.ex
@@ -44,7 +44,8 @@ defmodule Credo.Check.Refactor.Nesting do
 
   for op <- @def_ops do
     defp traverse({unquote(op) = op, meta, arguments} = ast, issues, issue_meta, max_nesting) when is_list(arguments) do
-      find_depth(arguments, [], meta[:line], op)
+      arguments
+      |> find_depth([], meta[:line], op)
       |> handle_depth(ast, issue_meta, issues, max_nesting)
     end
   end

--- a/lib/credo/check/warning/name_redeclaration_by_case.ex
+++ b/lib/credo/check/warning/name_redeclaration_by_case.ex
@@ -135,7 +135,8 @@ defmodule Credo.Check.Warning.NameRedeclarationByCase do
   def run(source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
 
-    Credo.Code.traverse(source_file, &traverse(&1, &2, issue_meta, @excluded_names))
+    source_file
+    |> Credo.Code.traverse(&traverse(&1, &2, issue_meta, @excluded_names))
     |> List.flatten
     |> Enum.reject(&is_nil/1)
   end

--- a/lib/credo/check/warning/name_redeclaration_by_def.ex
+++ b/lib/credo/check/warning/name_redeclaration_by_def.ex
@@ -131,7 +131,8 @@ defmodule Credo.Check.Warning.NameRedeclarationByDef do
   def run(source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
 
-    Credo.Code.traverse(source_file, &traverse(&1, &2, issue_meta, @excluded_names))
+    source_file
+    |> Credo.Code.traverse(&traverse(&1, &2, issue_meta, @excluded_names))
     |> List.flatten
     |> Enum.reject(&is_nil/1)
   end

--- a/lib/credo/check/warning/name_redeclaration_by_fn.ex
+++ b/lib/credo/check/warning/name_redeclaration_by_fn.ex
@@ -132,7 +132,8 @@ defmodule Credo.Check.Warning.NameRedeclarationByFn do
   def run(source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
 
-    Credo.Code.traverse(source_file, &traverse(&1, &2, issue_meta, @excluded_names))
+    source_file
+    |> Credo.Code.traverse(&traverse(&1, &2, issue_meta, @excluded_names))
     |> List.flatten
     |> Enum.reject(&is_nil/1)
   end

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -56,8 +56,7 @@ defmodule Credo.CLI.Output.Explain do
     ]
     |> UI.puts
 
-    UI.edge(color)
-    |> UI.puts
+    UI.puts_edge(color)
 
     issues
     |> Enum.each(&print_issue(&1, source_file, term_width))
@@ -108,9 +107,7 @@ defmodule Credo.CLI.Output.Explain do
     ]
     |> UI.puts
 
-    outer_color
-    |> UI.edge
-    |> UI.puts
+    UI.puts_edge(outer_color)
 
     [
       UI.edge(outer_color),
@@ -132,8 +129,7 @@ defmodule Credo.CLI.Output.Explain do
     if issue.line_no do
       {_, line} = Enum.at(source_file.lines, issue.line_no - 1)
 
-      UI.edge([outer_color, :faint])
-      |> UI.puts
+      UI.puts_edge([outer_color, :faint])
 
       [
         UI.edge([outer_color, :faint]), :reset, :color239,
@@ -141,8 +137,7 @@ defmodule Credo.CLI.Output.Explain do
       ]
       |> UI.puts
 
-      UI.edge([outer_color, :faint])
-      |> UI.puts
+      UI.puts_edge([outer_color, :faint])
 
       code_color = :faint
       print_source_line(source_file, issue.line_no - 2, term_width, code_color, outer_color)
@@ -169,8 +164,7 @@ defmodule Credo.CLI.Output.Explain do
       print_source_line(source_file, issue.line_no + 2, term_width, code_color, outer_color)
     end
 
-    UI.edge([outer_color, :faint], @indent)
-    |> UI.puts
+    UI.puts_edge([outer_color, :faint], @indent)
 
     [
       UI.edge([outer_color, :faint]), :reset, :color239,
@@ -178,8 +172,7 @@ defmodule Credo.CLI.Output.Explain do
     ]
     |> UI.puts
 
-    UI.edge([outer_color, :faint])
-    |> UI.puts
+    UI.puts_edge([outer_color, :faint])
 
     (issue.check.explanation || "TODO: Insert explanation")
     |> String.strip
@@ -188,14 +181,12 @@ defmodule Credo.CLI.Output.Explain do
     |> Enum.slice(0..-2)
     |> UI.puts
 
-    UI.edge([outer_color, :faint])
-    |> UI.puts
+    UI.puts_edge([outer_color, :faint])
 
     issue.check.explanation_for_params
     |> print_params_explanation(outer_color)
 
-    UI.edge([outer_color, :faint])
-    |> UI.puts
+    UI.puts_edge([outer_color, :faint])
   end
 
   defp print_source_line(source_file, line_no, term_width, color, outer_color) do
@@ -244,8 +235,7 @@ defmodule Credo.CLI.Output.Explain do
     ]
     |> UI.puts
 
-    UI.edge([outer_color, :faint])
-    |> UI.puts
+    UI.puts_edge([outer_color, :faint])
 
     keywords
     |> Enum.each(fn({param, text}) ->
@@ -258,5 +248,4 @@ defmodule Credo.CLI.Output.Explain do
         |> UI.puts
       end)
   end
-
 end

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -145,8 +145,8 @@ defmodule Credo.CLI.Output.Explain do
       |> UI.puts
 
       code_color = :faint
-      print_source_line(source_file, issue.line_no-2, term_width, code_color, outer_color)
-      print_source_line(source_file, issue.line_no-1, term_width, code_color, outer_color)
+      print_source_line(source_file, issue.line_no - 2, term_width, code_color, outer_color)
+      print_source_line(source_file, issue.line_no - 1, term_width, code_color, outer_color)
       print_source_line(source_file, issue.line_no, term_width, [:cyan, :bright], outer_color)
 
       if issue.column do
@@ -165,8 +165,8 @@ defmodule Credo.CLI.Output.Explain do
         ]
         |> UI.puts
       end
-      print_source_line(source_file, issue.line_no+1, term_width, code_color, outer_color)
-      print_source_line(source_file, issue.line_no+2, term_width, code_color, outer_color)
+      print_source_line(source_file, issue.line_no + 1, term_width, code_color, outer_color)
+      print_source_line(source_file, issue.line_no + 2, term_width, code_color, outer_color)
     end
 
     UI.edge([outer_color, :faint], @indent)

--- a/lib/credo/cli/output/issue_helper.ex
+++ b/lib/credo/cli/output/issue_helper.ex
@@ -53,8 +53,7 @@ defmodule Credo.CLI.Output.IssueHelper do
     if config.verbose do
       print_issue_line(issue, source_file, inner_color, outer_color, term_width)
 
-      UI.edge([outer_color, :faint])
-      |> UI.puts
+      UI.puts_edge([outer_color, :faint])
     end
   end
 

--- a/lib/credo/cli/output/issues_by_scope.ex
+++ b/lib/credo/cli/output/issues_by_scope.ex
@@ -91,8 +91,7 @@ defmodule Credo.CLI.Output.IssuesByScope do
     if issue.line_no do
       {_, line} = Enum.at(source_file.lines, issue.line_no - 1)
 
-      UI.edge([outer_color, :faint])
-      |> UI.puts
+      UI.puts_edge([outer_color, :faint])
 
       [
         UI.edge([outer_color, :faint]), :cyan, :faint,
@@ -119,8 +118,7 @@ defmodule Credo.CLI.Output.IssuesByScope do
       end
     end
 
-    UI.edge([outer_color, :faint], @indent)
-    |> UI.puts
+    UI.puts_edge([outer_color, :faint], @indent)
   end
 
 end

--- a/lib/credo/cli/output/ui.ex
+++ b/lib/credo/cli/output/ui.ex
@@ -11,8 +11,15 @@ defmodule Credo.CLI.Output.UI do
   defdelegate puts(v), to: Bunt
   def puts(v, color), do: Bunt.puts([color, v])
 
+  def puts_edge(color, indent \\ 2) when is_integer(indent) do
+    [color, indent]
+    |> edge
+    |> puts
+  end
+
   def wrap_at(text, number) do
-    Regex.compile!("(?:((?>.{1,#{number}}(?:(?<=[^\\S\\r\\n])[^\\S\\r\\n]?|(?=\\r?\\n)|$|[^\\S\\r\\n]))|.{1,#{number}})(?:\\r?\\n)?|(?:\\r?\\n|$))")
+    "(?:((?>.{1,#{number}}(?:(?<=[^\\S\\r\\n])[^\\S\\r\\n]?|(?=\\r?\\n)|$|[^\\S\\r\\n]))|.{1,#{number}})(?:\\r?\\n)?|(?:\\r?\\n|$))"
+    |> Regex.compile!
     |> Regex.scan(text)
     |> Enum.map(&List.first/1)
     |> List.delete_at(-1)

--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -64,7 +64,8 @@ defmodule Credo.Sources do
     |> Enum.any?(&matches?(file, &1))
   end
   defp matches?(file, string) when is_binary(string) do
-    find(string)
+    string
+    |> find
     |> Enum.member?(file)
   end
   defp matches?(file, regex) do


### PR DESCRIPTION
Make credo run more cleanly on itself.