### PR TITLE
Release 0.4.0 - cleanup lib/credo/priority.ex

### DIFF
--- a/lib/credo/priority.ex
+++ b/lib/credo/priority.ex
@@ -12,7 +12,9 @@ defmodule Credo.Priority do
       1..length(source_file.lines)
       |> Enum.map(fn(_) -> [] end)
 
-    priority_list = Credo.Code.traverse(source_file, &traverse/2, empty_priorities)
+    priority_list =
+      source_file
+      |> Credo.Code.traverse(&traverse/2, empty_priorities)
 
     base_map =
       priority_list

--- a/lib/credo/priority.ex
+++ b/lib/credo/priority.ex
@@ -36,10 +36,6 @@ defmodule Credo.Priority do
     |> Enum.into(%{})
   end
 
-  defp sum(list, acc \\ 0)
-  defp sum([], acc), do: acc
-  defp sum([head|tail], acc), do: sum(tail, acc + head)
-
   defp make_base_map(priority_list, %SourceFile{} = source_file) do
     priority_list
     |> Enum.with_index
@@ -48,7 +44,7 @@ defmodule Credo.Priority do
         [] -> nil
         _ ->
           {_, scope_name} = Scope.name(source_file.ast, line: index + 1)
-          {scope_name, sum(list)}
+          {scope_name, Enum.sum(list)}
       end
     end)
     |> Enum.reject(&is_nil/1)

--- a/lib/credo/priority.ex
+++ b/lib/credo/priority.ex
@@ -16,16 +16,7 @@ defmodule Credo.Priority do
 
     base_map =
       priority_list
-      |> Enum.with_index
-      |> Enum.map(fn({list, index}) ->
-          case list do
-            [] -> nil
-            _ ->
-              {_, scope_name} = Scope.name(source_file.ast, line: index + 1)
-              {scope_name, sum(list)}
-          end
-        end)
-      |> Enum.reject(&is_nil/1)
+      |> make_base_map(source_file)
 
     lookup =
       base_map
@@ -48,6 +39,20 @@ defmodule Credo.Priority do
   defp sum(list, acc \\ 0)
   defp sum([], acc), do: acc
   defp sum([head|tail], acc), do: sum(tail, acc + head)
+
+  defp make_base_map(priority_list, %SourceFile{} = source_file) do
+    priority_list
+    |> Enum.with_index
+    |> Enum.map(fn({list, index}) ->
+      case list do
+        [] -> nil
+        _ ->
+          {_, scope_name} = Scope.name(source_file.ast, line: index + 1)
+          {scope_name, sum(list)}
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
 
   defp traverse({:defmodule, meta, _} = ast, acc) do
     added_prio = priority_for(ast)


### PR DESCRIPTION
I'm not sure what should go in `@moduledoc` but this eliminates all the other warnings for `priority.ex`.

I was puzzled by the long lines which snuck past `credo` mentioned in the commit message for eb49a29, but as my goal is to eliminate warning messages I'll not dig into that *now* 😀