### PR TITLE
Circumvent exception for explain without file

### DIFF
--- a/lib/credo/cli/command/explain.ex
+++ b/lib/credo/cli/command/explain.ex
@@ -13,6 +13,7 @@ defmodule Credo.CLI.Command.Explain do
   # TODO: explain used config options
 
   def run(_args, %Config{help: true}), do: print_help
+  def run([], _), do: print_help
   def run([file | _], config) do
     {_, source_files} = load_and_validate_source_files(config)
     {_, {source_files, config}}  = run_checks(source_files, config)
@@ -74,7 +75,7 @@ defmodule Credo.CLI.Command.Explain do
 
 
   defp print_help do
-    ["Usage: ", :olive, "mix credo explain [path_line_no_column] [options]"]
+    ["Usage: ", :olive, "mix credo explain path_line_no_column [options]"]
     |> UI.puts
     """
 


### PR DESCRIPTION
Currently (0.4.3) `mix credo explain` will fail because of a missing function clause. Running `mix credo explain --help` suggests that files are optional ( `[path_line_no_column]` ). I'm not sure what future plans are, but to prevent this error from showing up, this fix prints help in case of no supplied files, with a slightly different help message to prevent confusion.

Just FYI, this is the current error (first part):
```
$ mix credo explain
** (FunctionClauseError) no function clause matching in Credo.CLI.Command.Explain.run/2
    lib/credo/cli/command/explain.ex:15: Credo.CLI.Command.Explain.run([], %Credo.Config{all: false, check_for_updates: true, checks: [{Credo.Check.Consistency.ExceptionNames}, ... etc .. help: false })
    lib/credo/cli.ex:58: Credo.CLI.main/1
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
    (elixir) lib/code.ex:363: Code.require_file/2
```