### PR TITLE
Better long number checking

### DIFF
--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -94,9 +94,26 @@ defmodule Credo.Check.Readability.LargeNumbers do
     find_issues(t, acc, issue_meta)
   end
 
-  defp number_with_underscores(number) do
+  defp number_with_underscores(number) when is_integer(number) do
     number
     |> to_string
+    |> add_underscores_to_number_string
+  end
+
+  # TODO: this would better be done using the text from the code rather
+  # than the floating point value as we're bound to be bitten by rounding
+  # errors...
+  defp number_with_underscores(number) when is_number(number) do
+    [num, decimal] =
+      number
+      |> to_string
+      |> String.split(".", parts: 2)
+
+    [num |> add_underscores_to_number_string, decimal] |> Enum.join(".")
+  end
+
+  defp add_underscores_to_number_string(string) do
+    string
     |> String.reverse
     |> String.replace(~r/(\d{3})(?=\d)/, "\\1_")
     |> String.reverse

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -62,7 +62,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
     underscored_number = number_with_underscores(number, source)
 
     new_issue =
-      if source != underscored_number do
+      if decimal_in_source?(source) && source != underscored_number do
         [issue_for(
           issue_meta, line_no, column1, source, underscored_number
         )]
@@ -100,6 +100,15 @@ defmodule Credo.Check.Readability.LargeNumbers do
       line_no: line_no,
       column: column,
       trigger: trigger
+  end
+
+  defp decimal_in_source?(source) do
+    case String.slice(source, 0, 2) do
+      "0b" -> false
+      "0o" -> false
+      "0x" -> false
+      _ -> true
+    end
   end
 
   defp source_fragment({line_no, column1, column2} = tuple, issue_meta) do

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -55,35 +55,16 @@ defmodule Credo.Check.Readability.LargeNumbers do
   defp find_issues([], acc, _issue_meta) do
     acc
   end
-  defp find_issues([{:number, {line_no, column1, _column2}, number} | t], acc, issue_meta) do
-    line =
-      issue_meta
-      |> IssueMeta.source_file
-      |> SourceFile.line_at(line_no)
 
-    line_ending = String.slice(line, 0..column1 - 1)
+  defp find_issues([{:number, {line_no, column1, _column2} = location, number} | t], acc, issue_meta) do
+    source = source_fragment(location, issue_meta)
 
-    underscore_count =
-      ~r/\d_\d/
-      |> Regex.run(line_ending)
-      |> List.wrap
-      |> Enum.count
-
-    temp_string =
-      line
-      |> String.slice(column1 - 1 + underscore_count..-1)
-
-    found_string =
-      ~r/([0-9\_]*\.[0-9]+|[0-9\_]+)/
-      |> Regex.run(temp_string)
-      |> List.first
-
-    underscored_number = number_with_underscores(number)
+    underscored_number = number_with_underscores(number, source)
 
     new_issue =
-      if found_string != underscored_number do
+      if source != underscored_number do
         [issue_for(
-          issue_meta, line_no, column1, found_string, underscored_number
+          issue_meta, line_no, column1, source, underscored_number
         )]
       else
         []
@@ -94,20 +75,14 @@ defmodule Credo.Check.Readability.LargeNumbers do
     find_issues(t, acc, issue_meta)
   end
 
-  defp number_with_underscores(number) when is_integer(number) do
+  defp number_with_underscores(number, _) when is_integer(number) do
     number
     |> to_string
     |> add_underscores_to_number_string
   end
 
-  # TODO: this would better be done using the text from the code rather
-  # than the floating point value as we're bound to be bitten by rounding
-  # errors...
-  defp number_with_underscores(number) when is_number(number) do
-    [num, decimal] =
-      number
-      |> to_string
-      |> String.split(".", parts: 2)
+  defp number_with_underscores(number, source_fragment) when is_number(number) do
+    [num, decimal] = String.split(source_fragment, ".", parts: 2)
 
     [num |> add_underscores_to_number_string, decimal] |> Enum.join(".")
   end
@@ -125,5 +100,38 @@ defmodule Credo.Check.Readability.LargeNumbers do
       line_no: line_no,
       column: column,
       trigger: trigger
+  end
+
+  defp source_fragment({line_no, column1, column2} = tuple, issue_meta) do
+    fragment =
+      issue_meta
+      |> IssueMeta.source_file
+      |> SourceFile.line_at(line_no)
+      |> String.slice((column1 - 1)..(column2 - 2))
+
+    if System.version |> Version.compare("1.3.2") == :lt do
+      source_fragment_pre_132(tuple, issue_meta, fragment)
+    else
+      fragment
+    end
+  end
+
+  # There's a bug in the :elixir_tokenizer.tokenize/3 in versions prior to
+  # 1.3.2 where the _ in the source code is not included in the token's
+  # length, so that means we have to re-calculate the token if it has _ in it.
+  #
+  # Unfortuately this leaves the line and column counts out of sync so this
+  # "fix" only works "reliably" for the first number with _ in the line.
+  defp source_fragment_pre_132({line_no, column1, column2}, issue_meta, first_fragment) do
+    underscores = (first_fragment |> String.split("_") |> Enum.count) - 1
+
+    if underscores > 0 do
+      issue_meta
+      |> IssueMeta.source_file
+      |> SourceFile.line_at(line_no)
+      |> String.slice((column1 - 1)..(column2 - 2 + underscores))
+    else
+      first_fragment
+    end
   end
 end

--- a/test/credo/check/readability/large_numbers_test.exs
+++ b/test/credo/check/readability/large_numbers_test.exs
@@ -131,4 +131,16 @@ end
       assert Regex.run(~r/[\d\._]+/, message) |> hd ==  "10_000.000010"
     end)
   end
+
+  test "it should not complain about non-decimal numbers" do
+"""
+def numbers do
+  0xFFFF
+  0b1111_1111_1111_1111
+  0o777_777
+end
+"""
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
 end

--- a/test/credo/check/readability/large_numbers_test.exs
+++ b/test/credo/check/readability/large_numbers_test.exs
@@ -96,4 +96,15 @@ end
 """ |> to_source_file
     |> assert_issue(@described_check)
   end
+
+  test "it should format floating point numbers nicely" do
+"""
+def numbers do
+  10000.00001
+end
+""" |> to_source_file
+    |> assert_issue(@described_check, fn(%Credo.Issue{message: message}) ->
+      assert Regex.run(~r/[\d\._]+/, message) |> hd ==  "10_000.00001"
+    end)
+  end
 end

--- a/test/credo/check/readability/large_numbers_test.exs
+++ b/test/credo/check/readability/large_numbers_test.exs
@@ -143,4 +143,38 @@ end
     |> to_source_file
     |> refute_issues(@described_check)
   end
+
+  test "check old false positive is fixed /1" do
+    " defmacro oid_ansi_x9_62, do: quote do: {1,2,840,10_045}"
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  test "check old false positive is fixed /2" do
+    if System.version |> Version.compare("1.3.2") == :lt do
+"""
+%{
+  bounds: [
+    0, 1, 2, 5, 10, 20, 30, 65, 85,
+    100, 200, 400, 800,
+    1_000,
+    2_000,
+    4_000,
+    8_000,
+    16_000]
+}
+"""
+    else
+"""
+%{
+  bounds: [
+    0, 1, 2, 5, 10, 20, 30, 65, 85,
+    100, 200, 400, 800,
+    1_000, 2_000, 4_000, 8_000, 16_000]
+}
+"""
+    end
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
 end

--- a/test/credo/check/readability/large_numbers_test.exs
+++ b/test/credo/check/readability/large_numbers_test.exs
@@ -4,16 +4,29 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
   @described_check Credo.Check.Readability.LargeNumbers
 
   test "it should NOT report expected code" do
+    if System.version |> Version.compare("1.3.2") == :lt do
+"""
+def numbers do
+  1024 +
+  1_000_000 +
+  11_000 +
+  22_000 +
+  33_000
+  10_000..
+  20_000
+end
+"""
+    else
 """
 def numbers do
   1024 + 1_000_000 + 11_000 + 22_000 + 33_000
   10_000..20_000
 end
-""" |> to_source_file
+"""
+  end
+    |> to_source_file
     |> refute_issues(@described_check)
   end
-
-
 
   test "it should report a violation" do
 """
@@ -105,6 +118,17 @@ end
 """ |> to_source_file
     |> assert_issue(@described_check, fn(%Credo.Issue{message: message}) ->
       assert Regex.run(~r/[\d\._]+/, message) |> hd ==  "10_000.00001"
+    end)
+  end
+
+  test "it should report all digits from the source" do
+"""
+def numbers do
+  10000.000010
+end
+""" |> to_source_file
+    |> assert_issue(@described_check, fn(%Credo.Issue{message: message}) ->
+      assert Regex.run(~r/[\d\._]+/, message) |> hd ==  "10_000.000010"
     end)
   end
 end


### PR DESCRIPTION
René, I'm not sure if this *should* be merged into `credo`, I think it illustrates some useful ideas.

I was irritated by the long number checks telling me that 0xFFFF might be better written as 65_535, and by the poor formatting of the fractional part of long floats in error messages.

To do a proper fix we need to use elixir 1.3.2 or 1.4.x where https://github.com/elixir-lang/elixir/commit/301aa6eddce60c02a7fd11a7c1426aec97338878 has taken effect, otherwise we need some heuristic to figure out where the number tokens come from.  Believe that being able to reliably get the source text will be useful anyway.

So the basic changes were:

- don't expect _ in the fractional part of floating point numbers
- don't check non-decimal numbers

Let me know what you think, and how we can move this forward.