### PR TITLE
Last tweaks to large numbers testing

### DIFF
--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -118,7 +118,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
       |> SourceFile.line_at(line_no)
       |> String.slice((column1 - 1)..(column2 - 2))
 
-    if System.version |> Version.compare("1.3.2") == :lt do
+    if System.version |> Version.match?("< 1.3.2-dev") do
       source_fragment_pre_132(tuple, issue_meta, fragment)
     else
       fragment

--- a/test/credo/check/readability/large_numbers_test.exs
+++ b/test/credo/check/readability/large_numbers_test.exs
@@ -3,27 +3,14 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
 
   @described_check Credo.Check.Readability.LargeNumbers
 
+  @tag needs_elixir: "1.3.2"
   test "it should NOT report expected code" do
-    if System.version |> Version.compare("1.3.2") == :lt do
-"""
-def numbers do
-  1024 +
-  1_000_000 +
-  11_000 +
-  22_000 +
-  33_000
-  10_000..
-  20_000
-end
-"""
-    else
 """
 def numbers do
   1024 + 1_000_000 + 11_000 + 22_000 + 33_000
   10_000..20_000
 end
 """
-  end
     |> to_source_file
     |> refute_issues(@described_check)
   end
@@ -150,21 +137,8 @@ end
     |> refute_issues(@described_check)
   end
 
+  @tag needs_elixir: "1.3.2"
   test "check old false positive is fixed /2" do
-    if System.version |> Version.compare("1.3.2") == :lt do
-"""
-%{
-  bounds: [
-    0, 1, 2, 5, 10, 20, 30, 65, 85,
-    100, 200, 400, 800,
-    1_000,
-    2_000,
-    4_000,
-    8_000,
-    16_000]
-}
-"""
-    else
 """
 %{
   bounds: [
@@ -173,7 +147,6 @@ end
     1_000, 2_000, 4_000, 8_000, 16_000]
 }
 """
-    end
     |> to_source_file
     |> refute_issues(@described_check)
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,10 +5,16 @@ Credo.Test.Application.start([], [])
 ExUnit.start()
 
 check_version =
-  cond do
-    System.version |> Version.compare("1.2.0") == :lt -> [needs_elixir: "1.2.0"]
-    true -> []
-  end
+  ~w(1.2.0 1.3.2)
+  |> Enum.reduce([], fn(version, acc) ->
+    # allow -dev versions so we can test before the Elixir release.
+    if System.version |> Version.match?("< #{version}-dev") do
+      acc ++ [needs_elixir: version]
+    else
+      acc
+    end
+  end)
+
 exclude = Keyword.merge([to_be_implemented: true], check_version)
 
 ExUnit.configure(exclude: exclude)


### PR DESCRIPTION
Minor cleanups prompted by testing with 1.3.2-dev.

* Compare version against 1.3.2-dev so that we can test against the -dev
version
* Remove special data for pre-1.3.2 test cases, tag the ones which
needed special data with `@tag needs_elixir: "1.3.2"`
* Add check in test helper to set the `needs_elixir: "1.2.3"` exclusion
if necessary.