### PR TITLE
Improve source file loading

### DIFF
--- a/lib/credo/cli/command/explain.ex
+++ b/lib/credo/cli/command/explain.ex
@@ -30,11 +30,9 @@ defmodule Credo.CLI.Command.Explain do
   defp load_and_validate_source_files(config) do
     {time_load, {valid_source_files, invalid_source_files}} =
       :timer.tc fn ->
-        source_files = config |> Sources.find
-        valid_source_files = Enum.filter(source_files, &(&1.valid?))
-        invalid_source_files = Enum.filter(source_files, &(!&1.valid?))
-
-        {valid_source_files, invalid_source_files}
+        config
+        |> Sources.find
+        |> Enum.partition(&(&1.valid?))
       end
 
     invalid_source_files

--- a/lib/credo/cli/command/list.ex
+++ b/lib/credo/cli/command/list.ex
@@ -26,11 +26,9 @@ defmodule Credo.CLI.Command.List do
   def load_and_validate_source_files(config) do
     {time_load, {valid_source_files, invalid_source_files}} =
       :timer.tc fn ->
-        source_files = config |> Sources.find
-        valid_source_files = Enum.filter(source_files, &(&1.valid?))
-        invalid_source_files = Enum.filter(source_files, &(!&1.valid?))
-
-        {valid_source_files, invalid_source_files}
+        config
+        |> Sources.find
+        |> Enum.partition(&(&1.valid?))
       end
 
     invalid_source_files

--- a/lib/credo/cli/command/suggest.ex
+++ b/lib/credo/cli/command/suggest.ex
@@ -37,11 +37,9 @@ defmodule Credo.CLI.Command.Suggest do
   def load_and_validate_source_files(config) do
     {time_load, {valid_source_files, invalid_source_files}} =
       :timer.tc fn ->
-        source_files = config |> Sources.find
-        valid_source_files = Enum.filter(source_files, &(&1.valid?))
-        invalid_source_files = Enum.filter(source_files, &(!&1.valid?))
-
-        {valid_source_files, invalid_source_files}
+        config
+        |> Sources.find
+        |> Enum.partition(&(&1.valid?))
       end
 
     invalid_source_files


### PR DESCRIPTION
Making use of [`Enum.partition/2`](http://elixir-lang.org/docs/stable/elixir/Enum.html#partition/2) we avoid looping twice over the list of source files when filtering out invalid source files. Apart from improved legibility, in a sufficiently large list these changes may even mean a perceptible performance improvement.