### PR TITLE
Prevent Credo from processing the same file multiple times

### DIFF
--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -23,12 +23,14 @@ defmodule Credo.Sources do
   def find(%Credo.Config{files: files}) do
     files.included
     |> Enum.flat_map(&find/1)
+    |> Enum.uniq
     |> exclude(files.excluded)
     |> to_source_files
   end
   def find(paths) when is_list(paths) do
     paths
     |> Enum.flat_map(&find/1)
+    |> Enum.uniq
   end
   def find(path) when is_binary(path) do
     path

--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -5,13 +5,15 @@ defmodule Credo.Sources do
   @stdin_filename "stdin"
 
   @doc """
-  Finds sources for a given Config, List or String.
+  Finds sources for a given `Credo.Config`.
 
-  iex> Sources.find(%Credo.Config{files: %{excluded: [], included: ["*.ex"]}})
+  Through the `files` key, configs may contain a list of `included` and `excluded`
+  patterns. For `included`, patterns can be file paths, directory paths and globs.
+  For `excluded`, patterns can also be specified as regular expressions.
 
-  iex> Sources.find(["lib/credo_*.ex", "lib/credo/*.ex"])
+  iex> Sources.find(%Credo.Config{files: %{excluded: ["not_me.ex"], included: ["*.ex"]}})
 
-  iex> Sources.find("*.ex")
+  iex> Sources.find(%Credo.Config{files: %{excluded: [/messy/], included: ["lib/mix", "root.ex"]}})
 
   """
   def find(%Credo.Config{files: %{excluded: [], included: [filename]}, read_from_stdin: true}) do
@@ -21,57 +23,54 @@ defmodule Credo.Sources do
     @stdin_filename |> source_file_from_stdin() |> List.wrap
   end
   def find(%Credo.Config{files: files}) do
-    files.included
-    |> Enum.flat_map(&find/1)
-    |> Enum.uniq
+    MapSet.new
+    |> include(files.included)
     |> exclude(files.excluded)
-    |> to_source_files
-  end
-  def find(paths) when is_list(paths) do
-    paths
-    |> Enum.flat_map(&find/1)
-    |> Enum.uniq
-  end
-  def find(path) when is_binary(path) do
-    path
-    |> to_glob
-    |> Path.wildcard
+    |> Enum.map(&to_source_file/1)
   end
 
-  def exclude(files, patterns \\ []) do
-    Enum.reject(files, &matches?(&1, patterns))
+  defp include(files, []), do: files
+  defp include(files, [path | remaining_paths]) do
+    include_paths = recurse_path(path) |> MapSet.new
+
+    files
+    |> MapSet.union(include_paths)
+    |> include(remaining_paths)
   end
 
-  defp to_glob(path) do
-    if File.dir?(path) do
-      [path | @default_sources_glob]
-      |> Path.join
-    else
-      path
+  defp exclude(files, []), do: files
+  defp exclude(files, [pattern | remaining_patterns]) when is_binary(pattern) do
+    exclude_paths = recurse_path(pattern) |> MapSet.new
+
+    files
+    |> MapSet.difference(exclude_paths)
+    |> exclude(remaining_patterns)
+  end
+  defp exclude(files, [pattern | remaining_patterns]) do
+    files
+    |> Enum.reject(&(String.match?(&1, pattern)))
+    |> exclude(remaining_patterns)
+  end
+
+  defp recurse_path(path) do
+    cond do
+      File.regular?(path) ->
+        [path]
+      File.dir?(path) ->
+        [path | @default_sources_glob]
+        |> Path.join
+        |> Path.wildcard
+      true ->
+        path
+        |> Path.wildcard
+        |> Enum.flat_map(&recurse_path/1)
     end
-  end
-
-  def to_source_files(files) do
-    Enum.map(files, &to_source_file(&1))
   end
 
   defp to_source_file(filename) do
     filename
     |> File.read!
     |> SourceFile.parse(filename)
-  end
-
-  defp matches?(file, patterns) when is_list(patterns) do
-    patterns
-    |> Enum.any?(&matches?(file, &1))
-  end
-  defp matches?(file, string) when is_binary(string) do
-    string
-    |> find
-    |> Enum.member?(file)
-  end
-  defp matches?(file, regex) do
-    String.match?(file, regex)
   end
 
   defp source_file_from_stdin(filename) do

--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -31,7 +31,7 @@ defmodule Credo.Sources do
 
   defp include(files, []), do: files
   defp include(files, [path | remaining_paths]) do
-    include_paths = recurse_path(path) |> MapSet.new
+    include_paths = recurse_path(path) |> Enum.into(MapSet.new)
 
     files
     |> MapSet.union(include_paths)
@@ -40,7 +40,7 @@ defmodule Credo.Sources do
 
   defp exclude(files, []), do: files
   defp exclude(files, [pattern | remaining_patterns]) when is_binary(pattern) do
-    exclude_paths = recurse_path(pattern) |> MapSet.new
+    exclude_paths = recurse_path(pattern) |> Enum.into(MapSet.new)
 
     files
     |> MapSet.difference(exclude_paths)

--- a/test/credo/sources_test.exs
+++ b/test/credo/sources_test.exs
@@ -18,10 +18,31 @@ defmodule Credo.SourcesTest do
     assert expected == Credo.Sources.find(config)
   end
 
+  test "Credo.Sources.find with credo config with duplicate paths" do
+    config = %Credo.Config{
+      files: %{
+        excluded: [],
+        included: ["lib/credo/s*.ex", "lib/credo/sources.ex"]
+      }
+    }
+
+    expected = ["lib/credo/severity.ex", "lib/credo/source_file.ex", "lib/credo/sources.ex"]
+    found = Credo.Sources.find(config) |> Enum.map(&(&1.filename))
+
+    assert expected == found
+  end
+
   test "Credo.Sources.find with list of paths" do
     paths = ["lib/credo.ex", "lib/credo/cli.ex"]
 
     expected = paths
+    assert expected == Credo.Sources.find(paths)
+  end
+
+  test "Credo.Sources.find with duplicate paths" do
+    paths = ["lib/credo/s*.ex", "lib/credo/sources.ex"]
+
+    expected = ["lib/credo/severity.ex", "lib/credo/source_file.ex", "lib/credo/sources.ex"]
     assert expected == Credo.Sources.find(paths)
   end
 

--- a/test/credo/sources_test.exs
+++ b/test/credo/sources_test.exs
@@ -11,18 +11,18 @@ defmodule Credo.SourcesTest do
     assert %Credo.SourceFile{} = (Credo.Sources.find(config) |> List.first)
   end
 
-  test "Credo.Sources.find with credo config with exclueded files" do
+  test "Credo.Sources.find with credo config with excluded files" do
     config = %Credo.Config{files: %{excluded: ["lib/credo.ex"], included: ["lib/credo.ex"]}}
 
     expected = []
     assert expected == Credo.Sources.find(config)
   end
 
-  test "Credo.Sources.find with list of pathes" do
-    pathes = ["lib/credo.ex", "lib/credo/cli.ex"]
+  test "Credo.Sources.find with list of paths" do
+    paths = ["lib/credo.ex", "lib/credo/cli.ex"]
 
-    expected = pathes
-    assert expected == Credo.Sources.find(pathes)
+    expected = paths
+    assert expected == Credo.Sources.find(paths)
   end
 
   test "Credo.Sources.find with binary path" do

--- a/test/credo/sources_test.exs
+++ b/test/credo/sources_test.exs
@@ -1,77 +1,126 @@
 defmodule Credo.SourcesTest do
   use ExUnit.Case
 
-  #
-  # find
-  #
+  test "it finds all files inside directories recursively" do
+    config = %Credo.Config{files: %{excluded: [], included: ["lib/mix"]}}
 
-  test "Credo.Sources.find with credo config with included files" do
-    config = %Credo.Config{files: %{excluded: [], included: ["lib/credo.ex"]}}
+    expected = [
+      "lib/mix/tasks/credo.ex",
+      "lib/mix/tasks/credo.gen.check.ex",
+      "lib/mix/tasks/credo.gen.config.ex"
+    ]
 
-    assert %Credo.SourceFile{} = (Credo.Sources.find(config) |> List.first)
+    files = Credo.Sources.find(config) |> Enum.map(&(&1.filename))
+
+    assert expected == files
   end
 
-  test "Credo.Sources.find with credo config with excluded files" do
-    config = %Credo.Config{files: %{excluded: ["lib/credo.ex"], included: ["lib/credo.ex"]}}
+  test "it accepts glob patterns that expand to files" do
+    config = %Credo.Config{files: %{excluded: [], included: ["lib/mix/**/*gen*.ex"]}}
 
-    expected = []
-    assert expected == Credo.Sources.find(config)
+    expected = [
+      "lib/mix/tasks/credo.gen.check.ex",
+      "lib/mix/tasks/credo.gen.config.ex"
+    ]
+
+    files = Credo.Sources.find(config) |> Enum.map(&(&1.filename))
+
+    assert expected == files
   end
 
-  test "Credo.Sources.find with credo config with duplicate paths" do
-    config = %Credo.Config{
-      files: %{
-        excluded: [],
-        included: ["lib/credo/s*.ex", "lib/credo/sources.ex"]
-      }
-    }
+  test "it accepts glob patterns that expand to directories" do
+    config = %Credo.Config{files: %{excluded: [], included: ["lib/**/tasks/"]}}
 
-    expected = ["lib/credo/severity.ex", "lib/credo/source_file.ex", "lib/credo/sources.ex"]
-    found = Credo.Sources.find(config) |> Enum.map(&(&1.filename))
+    expected = [
+      "lib/mix/tasks/credo.ex",
+      "lib/mix/tasks/credo.gen.check.ex",
+      "lib/mix/tasks/credo.gen.config.ex"
+    ]
 
-    assert expected == found
+    files = Credo.Sources.find(config) |> Enum.map(&(&1.filename))
+
+    assert expected == files
   end
 
-  test "Credo.Sources.find with list of paths" do
-    paths = ["lib/credo.ex", "lib/credo/cli.ex"]
+  test "it accepts full file paths" do
+    full_paths = ["lib/credo.ex", "lib/mix/tasks/credo.ex"]
+    config = %Credo.Config{files: %{excluded: [], included: full_paths}}
 
-    expected = paths
-    assert expected == Credo.Sources.find(paths)
+    files = Credo.Sources.find(config) |> Enum.map(&(&1.filename))
+
+    assert full_paths == files
   end
 
-  test "Credo.Sources.find with duplicate paths" do
-    paths = ["lib/credo/s*.ex", "lib/credo/sources.ex"]
+  test "it rejects duplicate paths" do
+    paths = ["lib/mix/tasks/credo.ex", "lib/mix", "lib/mix/tasks/credo.gen.check.ex"]
+    config = %Credo.Config{files: %{excluded: [], included: paths}}
 
-    expected = ["lib/credo/severity.ex", "lib/credo/source_file.ex", "lib/credo/sources.ex"]
-    assert expected == Credo.Sources.find(paths)
+    expected = [
+      "lib/mix/tasks/credo.ex",
+      "lib/mix/tasks/credo.gen.check.ex",
+      "lib/mix/tasks/credo.gen.config.ex"
+    ]
+
+    files = Credo.Sources.find(config) |> Enum.map(&(&1.filename))
+
+    assert expected == files
   end
 
-  test "Credo.Sources.find with binary path" do
-    path = "lib/*.ex"
+  test "it reads and parses found source files" do
+    config = %Credo.Config{files: %{excluded: [], included: ["lib/mix/tasks/credo.ex"]}}
 
-    expected = ["lib/credo.ex"]
-    assert expected == Credo.Sources.find(path)
+    [%Credo.SourceFile{ast: ast, valid?: true}] = Credo.Sources.find(config)
+
+    assert ast != nil
   end
 
-  #
-  # exclude
-  #
+  test "it excludes paths that match the `excluded` patterns" do
+    config = %Credo.Config{files: %{excluded: [~r/chec/, ~r/conf/], included: ["lib/mix"]}}
 
-  test "Credo.Sources.exclude" do
-    files = ["credo.ex", "credo_test.exs", "config.exs"]
-    expected = ["credo.ex"]
-    assert expected == Credo.Sources.exclude(files, [~r/test/, ~r/\.exs$/])
+    expected = ["lib/mix/tasks/credo.ex"]
+
+    files = Credo.Sources.find(config) |> Enum.map(&(&1.filename))
+
+    assert expected == files
   end
 
-  test "Credo.Sources.exclude with directories" do
-    files = ["lib/credo.ex", "lib/test/credo_test.exs", "config/config.exs"]
-    expected = ["lib/credo.ex", "lib/test/credo_test.exs"]
-    assert expected == Credo.Sources.exclude(files, ["config/"])
+  test "it excludes paths from the `excluded` directories" do
+    config = %Credo.Config{files: %{excluded: ["lib/credo"], included: ["lib"]}}
+
+    expected = [
+      "lib/credo.ex",
+      "lib/mix/tasks/credo.ex",
+      "lib/mix/tasks/credo.gen.check.ex",
+      "lib/mix/tasks/credo.gen.config.ex"
+    ]
+
+    files = Credo.Sources.find(config) |> Enum.map(&(&1.filename))
+
+    assert expected == files
   end
 
-  test "Credo.Sources.exclude with globs" do
-    files = ["lib/credo.ex", "lib/test/credo_test.exs", "config/config.exs"]
-    expected = ["lib/test/credo_test.exs", "config/config.exs"]
-    assert expected == Credo.Sources.exclude(files, ["lib/*.ex"])
+  test "it excludes paths that match the `excluded` file globs" do
+    config = %Credo.Config{files: %{excluded: ["lib/**/*gen*.ex"], included: ["lib/mix"]}}
+
+    expected = ["lib/mix/tasks/credo.ex"]
+
+    files = Credo.Sources.find(config) |> Enum.map(&(&1.filename))
+
+    assert expected == files
+  end
+
+  test "it excludes paths that match the `excluded` directory globs" do
+    config = %Credo.Config{files: %{excluded: ["lib/**/credo/"], included: ["lib"]}}
+
+    expected = [
+      "lib/credo.ex",
+      "lib/mix/tasks/credo.ex",
+      "lib/mix/tasks/credo.gen.check.ex",
+      "lib/mix/tasks/credo.gen.config.ex"
+    ]
+
+    files = Credo.Sources.find(config) |> Enum.map(&(&1.filename))
+
+    assert expected == files
   end
 end


### PR DESCRIPTION
Currently, a minor misconfiguration in the list of source files to be checked can lead to unwanted behavior. Intersecting glob patterns will make the engine process files **multiple times**, which in turn will trigger some issues of the `Credo.Check.Design.DuplicatedCode` type.