### PR TITLE
issue/20: add new check CallbacksArity

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -100,6 +100,7 @@
         {Credo.Check.Warning.UnusedStringOperation},
         {Credo.Check.Warning.UnusedTupleOperation},
         {Credo.Check.Warning.OperationWithConstantResult},
+        {Credo.Check.Warning.CallbacksArity}
 
         # Custom checks can be created using `mix credo.gen.check`.
         #

--- a/lib/credo/check/warning/callbacks_arity.ex
+++ b/lib/credo/check/warning/callbacks_arity.ex
@@ -1,0 +1,67 @@
+defmodule Credo.Check.Warning.CallbacksArity do
+  @moduledoc """
+  The arities of the callback functions should correspond respectively
+  to the arities of the functions from behaviour module
+
+  Example:
+
+  defmodule Example
+    use GenServer
+
+    def handle_call(:x, state) do
+      # Notice the missing "from" parameter
+      {:reply, :y, state}
+    end
+  end
+
+  Should warn on Example.handle_call/2 being similar to Example.handle_call/3
+  since the @behaviour added via use GenServer has a @callback handle_call/3.
+  """
+
+  @explanation [check: @moduledoc]
+
+  use Credo.Check, base_priority: :normal
+
+  def run(%SourceFile{ast: ast} = source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+    behaviours = Credo.Code.Module.behaviours(ast)
+
+    callbacks =
+      behaviours
+      |> Enum.reduce([], fn(behaviour, acc) ->
+        [Credo.Code.Module.callbacks(behaviour) | acc]
+      end)
+      |> List.flatten
+      |> Enum.uniq
+
+    Credo.Code.prewalk(ast, &find_issues(&1, &2, issue_meta, callbacks))
+  end
+
+  defp find_issues({:def, meta, arguments} = ast, issues, issue_meta, callbacks) when is_list(arguments) do
+    name = ast |> Credo.Code.Module.def_name
+    arity = ast |> Credo.Code.Module.def_arity
+
+    if conflicts_with_callbacks?(name, arity, callbacks) do
+      {ast, issues ++ [issue_for(issue_meta, meta[:line], name)]}
+    else
+      {ast, issues}
+    end
+  end
+  defp find_issues(ast, issues, _, _) do
+    {ast, issues}
+  end
+
+  defp conflicts_with_callbacks?(name, arity, callbacks) do
+    callbacks
+    |> Enum.filter(&(elem(&1, 0) == name))
+    |> Keyword.values
+    |> Enum.any?(&(&1 != arity))
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue issue_meta,
+      message: "The arities of the callback functions should correspond respectively to the arities of the functions from behaviour module",
+      trigger: trigger,
+      line_no: line_no
+  end
+end

--- a/lib/credo/cli/command/explain.ex
+++ b/lib/credo/cli/command/explain.ex
@@ -7,7 +7,6 @@ defmodule Credo.CLI.Command.Explain do
   alias Credo.Config
   alias Credo.CLI.Output.Explain
   alias Credo.CLI.Output.UI
-  alias Credo.CLI.Output
   alias Credo.Sources
 
   # TODO: explain used config options
@@ -15,7 +14,7 @@ defmodule Credo.CLI.Command.Explain do
   def run(_args, %Config{help: true}), do: print_help()
   def run([], _), do: print_help()
   def run([file | _], config) do
-    {_, source_files} = load_and_validate_source_files(config)
+    {_, source_files} = Sources.load_and_validate_source_files(config)
     {_, {source_files, config}}  = run_checks(source_files, config)
 
     file
@@ -25,20 +24,6 @@ defmodule Credo.CLI.Command.Explain do
     # TODO: return :error if there are issues so the CLI can exit with a status
     #       code other than zero
     :ok
-  end
-
-  defp load_and_validate_source_files(config) do
-    {time_load, {valid_source_files, invalid_source_files}} =
-      :timer.tc fn ->
-        config
-        |> Sources.find
-        |> Enum.partition(&(&1.valid?))
-      end
-
-    invalid_source_files
-    |> Output.complain_about_invalid_source_files
-
-    {time_load, valid_source_files}
   end
 
   defp run_checks(source_files, config) do

--- a/lib/credo/cli/command/list.ex
+++ b/lib/credo/cli/command/list.ex
@@ -8,12 +8,11 @@ defmodule Credo.CLI.Command.List do
   alias Credo.CLI.Output.IssuesByScope
   alias Credo.CLI.Output.IssuesShortList
   alias Credo.CLI.Output.UI
-  alias Credo.CLI.Output
   alias Credo.Sources
 
   def run(_args, %Config{help: true}), do: print_help()
   def run(_args, config) do
-    {time_load, source_files} = load_and_validate_source_files(config)
+    {time_load, source_files} = Sources.load_and_validate_source_files(config)
     {time_run, {source_files, config}}  = run_checks(source_files, config)
 
     print_results_and_summary(source_files, config, time_load, time_run)
@@ -21,20 +20,6 @@ defmodule Credo.CLI.Command.List do
     # TODO: return :error if there are issues so the CLI can exit with a status
     #       code other than zero
     :ok
-  end
-
-  def load_and_validate_source_files(config) do
-    {time_load, {valid_source_files, invalid_source_files}} =
-      :timer.tc fn ->
-        config
-        |> Sources.find
-        |> Enum.partition(&(&1.valid?))
-      end
-
-    invalid_source_files
-    |> Output.complain_about_invalid_source_files
-
-    {time_load, valid_source_files}
   end
 
   def run_checks(source_files, config) do

--- a/lib/credo/cli/command/suggest.ex
+++ b/lib/credo/cli/command/suggest.ex
@@ -8,12 +8,11 @@ defmodule Credo.CLI.Command.Suggest do
   alias Credo.CLI.Filter
   alias Credo.CLI.Output.IssuesGroupedByCategory
   alias Credo.CLI.Output.UI
-  alias Credo.CLI.Output
   alias Credo.Sources
 
   def run(_args, %Config{help: true}), do: print_help()
   def run(_args, config) do
-    {time_load, source_files} = load_and_validate_source_files(config)
+    {time_load, source_files} = Sources.load_and_validate_source_files(config)
 
     out = output_mod(config)
     out.print_before_info(source_files, config)
@@ -32,20 +31,6 @@ defmodule Credo.CLI.Command.Suggest do
       [] -> :ok
       issues -> {:error, issues}
     end
-  end
-
-  def load_and_validate_source_files(config) do
-    {time_load, {valid_source_files, invalid_source_files}} =
-      :timer.tc fn ->
-        config
-        |> Sources.find
-        |> Enum.partition(&(&1.valid?))
-      end
-
-    invalid_source_files
-    |> Output.complain_about_invalid_source_files
-
-    {time_load, valid_source_files}
   end
 
   def run_checks(source_files, config) do

--- a/lib/credo/code/module.ex
+++ b/lib/credo/code/module.ex
@@ -119,7 +119,7 @@ defmodule Credo.Code.Module do
       []
     end
   end
-  def behaviour(_), do: []
+  def behaviours(_), do: []
 
   @doc "Returns the keyword list of callbacks defined in a given module"
   def callbacks(behaviour) when is_atom(behaviour) do

--- a/lib/credo/code/module.ex
+++ b/lib/credo/code/module.ex
@@ -123,15 +123,10 @@ defmodule Credo.Code.Module do
 
   @doc "Returns the keyword list of callbacks defined in a given module"
   def callbacks(behaviour) when is_atom(behaviour) do
-
-    if Code.ensure_loaded?(behaviour) do
       [callbacks_from_module_attributes(behaviour) |
        callbacks_from_source_file(behaviour)]
       |> List.flatten
       |> Enum.uniq
-    else
-      []
-    end
   end
   def callbacks(_), do: []
 
@@ -140,13 +135,19 @@ defmodule Credo.Code.Module do
   #
 
   defp callbacks_from_module_attributes(behaviour) do
-    behaviour.module_info[:attributes]
-    |> Keyword.get_values(:callback)
-    |> List.flatten
-    |> Enum.map(&(elem(&1, 0)))
+    if Code.ensure_loaded?(behaviour) do
+      behaviour.module_info[:attributes]
+      |> Keyword.get_values(:callback)
+      |> List.flatten
+      |> Enum.map(&(elem(&1, 0)))
+    else
+      []
+    end
   end
 
   defp callbacks_from_source_file(behaviour) do
+    Code.ensure_compiled(behaviour)
+
     source_file = behaviour |> Credo.Sources.find
     ast = source_file.ast
 

--- a/lib/credo/code/module.ex
+++ b/lib/credo/code/module.ex
@@ -123,6 +123,7 @@ defmodule Credo.Code.Module do
 
   @doc "Returns the keyword list of callbacks defined in a given module"
   def callbacks(behaviour) when is_atom(behaviour) do
+
     if Code.ensure_loaded?(behaviour) do
       [callbacks_from_module_attributes(behaviour) |
        callbacks_from_source_file(behaviour)]
@@ -157,7 +158,7 @@ defmodule Credo.Code.Module do
 
     if Credo.Code.Name.snake_case?(behaviour_name) do
       behaviour_name
-      |> Macro.camelize
+      |> Mix.Utils.camelize
       |> Credo.Code.Name.with_prefix
       |> String.to_atom
     else
@@ -236,6 +237,9 @@ defmodule Credo.Code.Module do
   end
 
 
+  def find_callbacks({:callback, meta, [{:when, _, [{:::, _, [{callback_name, _, args}, _return_type]} = ast, _]}]}, callbacks) when is_list(args) do
+    find_callbacks({:callback, meta, [ast]}, callbacks)
+  end
   def find_callbacks({:callback, _, [{:::, _, [{callback_name, _, args}, _return_type]}]} = ast, callbacks) when is_list(args) do
     callback_arity = args |> Enum.count
 

--- a/lib/credo/code/module.ex
+++ b/lib/credo/code/module.ex
@@ -4,7 +4,6 @@ defmodule Credo.Code.Module do
   funcions or module attributes.
   """
 
-  alias Credo.Code
   alias Credo.Code.Block
 
   @def_ops [:def, :defp, :defmacro]
@@ -21,7 +20,7 @@ defmodule Credo.Code.Module do
   def def_count(nil), do: 0
   def def_count({:defmodule, _, _arguments} = ast) do
     ast
-    |> Code.postwalk(&traverse_mod/2)
+    |> Credo.Code.postwalk(&traverse_mod/2)
     |> Enum.count
   end
 
@@ -67,7 +66,7 @@ defmodule Credo.Code.Module do
   def def_names(nil), do: []
   def def_names({:defmodule, _, _arguments} = ast) do
     ast
-    |> Code.postwalk(&traverse_mod/2)
+    |> Credo.Code.postwalk(&traverse_mod/2)
     |> Enum.map(&def_name/1)
     |> Enum.uniq
   end
@@ -76,7 +75,7 @@ defmodule Credo.Code.Module do
   def def_names_with_op(nil), do: []
   def def_names_with_op({:defmodule, _, _arguments} = ast) do
     ast
-    |> Code.postwalk(&traverse_mod/2)
+    |> Credo.Code.postwalk(&traverse_mod/2)
     |> Enum.map(&def_name_with_op/1)
     |> Enum.uniq
   end
@@ -85,7 +84,7 @@ defmodule Credo.Code.Module do
   def def_names_with_op(nil, _arity), do: []
   def def_names_with_op({:defmodule, _, _arguments} = ast, arity) do
     ast
-    |> Code.postwalk(&traverse_mod/2)
+    |> Credo.Code.postwalk(&traverse_mod/2)
     |> Enum.map(&def_name_with_op(&1, arity))
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq
@@ -94,20 +93,78 @@ defmodule Credo.Code.Module do
   @doc "Returns the list of modules used in a given module source code (dependent modules)"
   def modules({:defmodule, _, _arguments} = ast) do
     ast
-    |> Code.postwalk(&find_dependent_modules/2)
+    |> Credo.Code.postwalk(&find_dependent_modules/2)
     |> Enum.uniq
   end
 
-  @doc "Returns the list of aliases defined in a given module source code"
+  @doc "Returns the list of aliases defined in a given module ast"
   def aliases({:defmodule, _, _arguments} = ast) do
     ast
     |> Credo.Code.postwalk(&find_aliases/2)
     |> Enum.uniq
   end
 
+  @doc "Returns the list of behaviours defined in a given module ast"
+  # We need to camelize_behaviour, because there are different return values
+  # from module_info[:attributes][:behaviour] depending on elixir version
+  def behaviours({:defmodule, _, [{:__aliases__, _, mod_list}, _do_block]}) do
+    module = mod_list |> Credo.Code.Name.to_module
+
+    if Code.ensure_loaded?(module) do
+      module.module_info[:attributes]
+      |> Keyword.get_values(:behaviour)
+      |> List.flatten
+      |> Enum.map(&camelize_behaviour/1)
+    else
+      []
+    end
+  end
+  def behaviour(_), do: []
+
+  @doc "Returns the keyword list of callbacks defined in a given module"
+  def callbacks(behaviour) when is_atom(behaviour) do
+    if Code.ensure_loaded?(behaviour) do
+      [callbacks_from_module_attributes(behaviour) |
+       callbacks_from_source_file(behaviour)]
+      |> List.flatten
+      |> Enum.uniq
+    else
+      []
+    end
+  end
+  def callbacks(_), do: []
+
   #
   # PRIVATE STUFF
   #
+
+  defp callbacks_from_module_attributes(behaviour) do
+    behaviour.module_info[:attributes]
+    |> Keyword.get_values(:callback)
+    |> List.flatten
+    |> Enum.map(&(elem(&1, 0)))
+  end
+
+  defp callbacks_from_source_file(behaviour) do
+    source_file = behaviour |> Credo.Sources.find
+    ast = source_file.ast
+
+    Credo.Code.postwalk(ast, &find_callbacks/2)
+  end
+
+  defp camelize_behaviour(behaviour) do
+    behaviour_name = behaviour |> to_string
+
+    if Credo.Code.Name.snake_case?(behaviour_name) do
+      behaviour_name
+      |> Macro.camelize
+      |> Credo.Code.Name.with_prefix
+      |> String.to_atom
+    else
+      behaviour
+    end
+  end
+
 
   # Single alias
   defp find_aliases({:alias, _, [{:__aliases__, _, mod_list}]} = ast, aliases) do
@@ -176,6 +233,16 @@ defmodule Credo.Code.Module do
   end
   defp traverse_mod(ast, defs) do
     {ast, defs}
+  end
+
+
+  def find_callbacks({:callback, _, [{:::, _, [{callback_name, _, args}, _return_type]}]} = ast, callbacks) when is_list(args) do
+    callback_arity = args |> Enum.count
+
+    {ast, [{callback_name, callback_arity} | callbacks]}
+  end
+  def find_callbacks(ast, callbacks) do
+    {ast, callbacks}
   end
 
   # TODO: write unit test

--- a/lib/credo/code/module.ex
+++ b/lib/credo/code/module.ex
@@ -146,12 +146,15 @@ defmodule Credo.Code.Module do
   end
 
   defp callbacks_from_source_file(behaviour) do
-    Code.ensure_compiled(behaviour)
-
     source_file = behaviour |> Credo.Sources.find
-    ast = source_file.ast
 
-    Credo.Code.postwalk(ast, &find_callbacks/2)
+    if source_file do
+      ast = source_file.ast
+
+      Credo.Code.postwalk(ast, &find_callbacks/2)
+    else
+      []
+    end
   end
 
   defp camelize_behaviour(behaviour) do

--- a/lib/credo/code/name.ex
+++ b/lib/credo/code/name.ex
@@ -47,6 +47,17 @@ defmodule Credo.Code.Name do
     name
   end
 
+  def to_module(mod_list) when is_list(mod_list) do
+    mod_list
+    |> full
+    |> with_prefix
+    |> String.to_atom
+  end
+
+  def with_prefix(name) do
+    "Elixir.#{name}"
+  end
+
   def parts_count(module_name) do
     module_name
     |> String.split(".")

--- a/test/credo/check/warning/callbacks_arity_test.exs
+++ b/test/credo/check/warning/callbacks_arity_test.exs
@@ -1,0 +1,116 @@
+defmodule Credo.Check.Warning.CallbacksArityTest do
+  use Credo.TestHelper
+
+  @described_check Credo.Check.Warning.CallbacksArity
+
+  test "it should report expected code" do
+"""
+defmodule WithWarnings do
+  use GenServer
+
+  def handle_call(:x, state) do
+    # Notice the missing "from" parameter
+    {:reply, :y, state}
+  end
+end
+""" |> to_source_file
+    |> ensure_loaded_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report expected code (custom behaviour)" do
+"""
+defmodule WithWarnings2 do
+  @behaviour TestBehaviour
+
+  # this is fine
+  def parse(str) when is_binary(str), do: str
+
+  # this will emit an issue
+  def parse(str, str2), do: {str, str2}
+end
+""" |> to_source_file
+    |> ensure_loaded_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report expected code (OTP behaviour with custom behaviour)" do
+"""
+defmodule WithWarnings3 do
+  use GenServer
+  @behaviour TestBehaviour
+
+  # this is fine
+  def parse(str) when is_binary(str), do: str 
+
+  # this will emit an issue
+  def parse(str, str2), do: {str, str2} 
+
+  # this will emit an issue
+  def handle_call(:x, state) do
+    # Notice the missing "from" parameter
+    {:reply, :y, state}
+  end
+end
+""" |> to_source_file
+    |> ensure_loaded_source_file
+    |> assert_issues(@described_check)
+  end
+
+  test "it should report expected code (custom callback with guard clause)" do
+"""
+defmodule WithWarnings4 do
+  @behaviour TestBehaviour
+
+  def parse(str) when is_binary(str), do: str
+  def parse(str, str2) when is_binary(str), do: {str, str2}
+end
+""" |> to_source_file
+    |> ensure_loaded_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should NOT report expected code" do
+"""
+defmodule WithoutWarnings do
+  use GenServer
+
+  def handle_call(:x, from, state) do
+    # Notice the missing "from" parameter
+    {:reply, from, state}
+  end
+end
+""" |> to_source_file
+    |> ensure_loaded_source_file
+    |> refute_issues(@described_check)
+  end
+
+  test "it should NOT report expected code (behaviour requirements are fulfilled)" do
+"""
+defmodule WithoutWarnings2 do
+  @behaviour TestBehaviour
+
+  def parse(str), do: str
+end
+""" |> to_source_file
+    |> ensure_loaded_source_file
+    |> refute_issues(@described_check)
+  end
+
+  test "it should NOT report expected code (empty not evaluated module)" do
+"""
+defmodule WithoutWarnings3 do
+end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  test "it should NOT report expected code (empty evaluated module)" do
+"""
+defmodule WithoutWarnings4 do
+end
+""" |> to_source_file
+    |> ensure_loaded_source_file
+    |> refute_issues(@described_check)
+  end
+end

--- a/test/credo/code/module_test.exs
+++ b/test/credo/code/module_test.exs
@@ -319,5 +319,59 @@ end
     expected = ["Exzmq.Socket", "Exzmq.Tcp", "Some.Very.Long.Name"]
     assert expected == Module.aliases(ast)
   end
+
+  #
+  # behaviours
+  #
+
+
+  test "it returns behaviours list from implementing OTP behaviour" do
+    {:ok, ast} = """
+    defmodule ModuleWithOTPBehaviour do
+      use GenServer
+    end
+    """ |> Code.string_to_quoted
+        |> ensure_loaded
+
+    expected = [GenServer]
+
+    assert expected == Module.behaviours(ast)
+  end
+
+  test "it returns behaviours list from module with @behaviour module attribute" do
+    {:ok, ast} = """
+    defmodule ModuleWithBehaviour do
+      @behaviour TestBehaviour
+
+      def parse(str), do: str
+    end
+    """ |> Code.string_to_quoted
+        |> ensure_loaded
+
+    expected = [TestBehaviour]
+
+    assert expected == Module.behaviours(ast)
+  end
+
+  #
+  # callbacks
+  #
+
+  test "returns the list of callbacks used in a OTP behaviour modules" do
+    behaviour = GenServer
+    expected = GenServer.module_info[:attributes]
+               |> Keyword.get_values(:callback)
+               |> List.flatten
+               |> Enum.map(&(elem(&1, 0)))
+
+    assert expected == Module.callbacks(behaviour)
+  end
+
+  test "returns the list of callbacks used in a custom behaviour modules" do
+    behaviour = TestBehaviour
+    expected = [parse: 1]
+
+    assert expected == Module.callbacks(behaviour)
+  end
 end
 

--- a/test/credo/code/module_test.exs
+++ b/test/credo/code/module_test.exs
@@ -359,12 +359,9 @@ end
 
   test "returns the list of callbacks used in a OTP behaviour modules" do
     behaviour = GenServer
-    expected = GenServer.module_info[:attributes]
-               |> Keyword.get_values(:callback)
-               |> List.flatten
-               |> Enum.map(&(elem(&1, 0)))
+    expected_key = :handle_call
 
-    assert expected == Module.callbacks(behaviour)
+    assert Keyword.has_key?(Module.callbacks(behaviour), expected_key)
   end
 
   test "returns the list of callbacks used in a custom behaviour modules" do

--- a/test/credo/sources_test.exs
+++ b/test/credo/sources_test.exs
@@ -32,6 +32,12 @@ defmodule Credo.SourcesTest do
     assert expected == Credo.Sources.find(path)
   end
 
+  test "Credo.Sources.find returns source_file by module name" do
+    module = GenServer
+
+    assert %Credo.SourceFile{} = Credo.Sources.find(module)
+  end
+
   #
   # exclude
   #

--- a/test/support/callbacks/test_behaviour.exs
+++ b/test/support/callbacks/test_behaviour.exs
@@ -1,0 +1,3 @@
+defmodule TestBehaviour do
+  @callback parse(String.t) :: any
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 Code.require_file("support/test_application.exs", __DIR__)
+Code.require_file("support/callbacks/test_behaviour.exs", __DIR__)
 
 Credo.Test.Application.start([], [])
 
@@ -119,5 +120,15 @@ defmodule CredoCheckCase do
     |> Inspect.Algebra.to_doc(%Inspect.Opts{})
     |> Inspect.Algebra.format(50)
     |> Enum.join("")
+  end
+
+  def ensure_loaded(ast) do
+    Code.compile_quoted(ast)
+    ast
+  end
+
+  def ensure_loaded_source_file(%Credo.SourceFile{ast: ast} = source_file) do
+    ensure_loaded(ast)
+    source_file
   end
 end


### PR DESCRIPTION
Hello, René!

This is a PR related to the issue #20 about checking arities of the callback functions.

A brief changelog:
- new check called `Credo.Check.Warning.CallbacksArity` implemented (with some initial tests)
- new functions `behaviours` and `callbacks` created in `module.ex` to fetch behaviours/callbacks for a given ast/module
- a few new `test_helper.ex` functions provided

There are some issues to discuss i think. Probably someone knows a better way of getting required callbacks or behaviours from ast/module. Please don't hesitate to correct my grammar, semantics or logical mistakes, I would be happy to fix it. 

Also please find my code-related comments attached. 

Thanks in advance for your time!