### PR TITLE
Checks no parentheses exists on zero arity functions

### DIFF
--- a/lib/credo/check/readability/no_parentheses_when_zero_arity.ex
+++ b/lib/credo/check/readability/no_parentheses_when_zero_arity.ex
@@ -1,0 +1,51 @@
+defmodule Credo.Check.Readability.NoParenthesesWhenZeroArity do
+  @moduledoc """
+  Do not write parentheses when function receives no arguments
+  """
+
+  @explanation [check: @moduledoc]
+  @def_ops [:def, :defp, :defmacro, :defmacrop]
+
+  use Credo.Check, base_priority: :low
+
+  def run(%SourceFile{} = source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  for op <- @def_ops do
+    # catch variables named e.g. `defp`
+    defp traverse({unquote(op), _, body} = ast, issues, issue_meta) do
+      function_head = body |> Enum.at(0)
+      {ast, issues_for_definition(function_head, issues, issue_meta)}
+    end
+  end
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issues_for_definition({_, _, args}, issues, _) when length(args) > 0 do
+    issues
+  end
+  defp issues_for_definition({name, meta, _}, issues, issue_meta) do
+    line_no = meta[:line]
+    source_file = IssueMeta.source_file(issue_meta)
+    line = SourceFile.line_at(source_file, line_no)
+    name_size = name |> to_string |> String.length
+    skip = SourceFile.column(source_file, line_no, name) + name_size - 1
+    rest = String.slice(line, skip..-1)
+
+    if Regex.match?(~r/^\((\w*)\)(.)*/, rest) do
+      issues ++ [issue_for(issue_meta, line_no)]
+    else
+      issues
+    end
+  end
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue issue_meta,
+      message: "Do not write parentheses when function receives no arguments.",
+      line_no: line_no
+  end
+end

--- a/test/credo/check/readability/no_parentheses_when_zero_arity_test.exs
+++ b/test/credo/check/readability/no_parentheses_when_zero_arity_test.exs
@@ -1,0 +1,31 @@
+defmodule Credo.Check.Readability.NoParenthesesWhenZeroArityTest do
+  use Credo.TestHelper
+
+  @described_check Credo.Check.Readability.NoParenthesesWhenZeroArity
+
+  test "it should NOT report expected code" do
+"""
+defmodule CredoSampleModule do
+  def some_function(parameter1, parameter2) do
+    parameter1 + parameter2
+  end
+
+  def some_other_function do
+    18
+  end
+end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  test "it should report a violation" do
+"""
+defmodule Mix.Tasks.Credo do
+  def run() do
+    21
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+end


### PR DESCRIPTION
This will trigger a warning on function heads that have no arguments, but do have parentheses.

Interesting to have that in credo? 😊