### PR TITLE
Stop moduledoc check for child nodes in ignored modules

### DIFF
--- a/test/credo/check/readability/module_doc_test.exs
+++ b/test/credo/check/readability/module_doc_test.exs
@@ -12,6 +12,16 @@ end
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report test submodules" do
+"""
+defmodule ModuleTest do
+  defmodule SubModule do
+  end
+end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
   test "it should not report exception modules" do
 """
 defmodule CredoSampleModule do


### PR DESCRIPTION
Adding accumulator to keep track if we should continue the ast prewalk when an ignored module is found.
fix #165