### PR TITLE
Don't care about excluded files when reading stdin

### DIFF
--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -16,7 +16,7 @@ defmodule Credo.Sources do
   iex> Sources.find(%Credo.Config{files: %{excluded: [/messy/], included: ["lib/mix", "root.ex"]}})
 
   """
-  def find(%Credo.Config{files: %{excluded: [], included: [filename]}, read_from_stdin: true}) do
+  def find(%Credo.Config{files: %{included: [filename]}, read_from_stdin: true}) do
     filename |> source_file_from_stdin() |> List.wrap
   end
   def find(%Credo.Config{read_from_stdin: true}) do


### PR DESCRIPTION
"stdin" annotation can't be overridden since 0.3.13 with default config.

Today I spent quite some time trying to figure out why flycheck-credo doesn't work.
As it turned out this https://github.com/rrrene/credo/blob/master/.credo.exs#L23 doesn't work with this https://github.com/rrrene/credo/blob/master/lib/credo/sources.ex#L19