### PR TITLE
Fix false positive with grouped logic in if statement

### DIFF
--- a/test/credo/check/readability/parentheses_in_condition_test.exs
+++ b/test/credo/check/readability/parentheses_in_condition_test.exs
@@ -14,17 +14,21 @@ defmodule CredoSampleModule do
     if !allowed? || (something_in_parentheses == 42) do
       something
     end
+    if (something_in_parentheses == 42) || !allowed? do
+      something
+    end
+    unless (something_in_parentheses != 42) || allowed? do
+      something
+    end
     boolean |> if(do: :ok, else: :error)
     boolean |> unless(do: :ok)
     if (thing && other_thing) || better_thing, do: something
+    if !better_thing && (thing || other_thing), do: something_else
   end
 end
 """ |> to_source_file
     |> refute_issues(@described_check)
   end
-
-
-
 
   test "it should report a violation" do
 """
@@ -39,6 +43,18 @@ defmodule Mix.Tasks.Credo do
 end
 """ |> to_source_file
     |> assert_issue(@described_check)
+  end
+
+  test "it should report violations with oneliners if used with parentheses" do
+"""
+defmodule Mix.Tasks.Credo do
+  def run(argv) do
+    if (allowed?), do: true
+    unless (!allowed?), do: true
+  end
+end
+""" |> to_source_file
+    |> assert_issues(@described_check)
   end
 
   test "it should report a violation if used with parentheses" do


### PR DESCRIPTION
Fixes #164 

I added some more tests to account for grouping on either side of the outer operation and for one lined statements.

This keeps track of the condition that had the grouped logic. 

Before 
```
echo "if (thing && other_thing), do: something" | mix credo --read-from-stdin
Checking 1 source file ...

  Code Readability                                                              
┃ 
┃ [R] ↗ The condition of `` should not be wrapped in parentheses.
┃       stdin:1 ()
```

After
```
echo "if (thing && other_thing), do: something" | mix credo --read-from-stdin
Checking 1 source file ...

  Code Readability                                                              
┃ 
┃ [R] ↗ The condition of `if` should not be wrapped in parentheses.
┃       stdin:1:1 ()
```
