### PR TITLE
Add new function head for #traverse_abc in abc_size.ex(fixes issue #171)

### DIFF
--- a/lib/credo/check/refactor/abc_size.ex
+++ b/lib/credo/check/refactor/abc_size.ex
@@ -112,6 +112,9 @@ defmodule Credo.Check.Refactor.ABCSize do
     {ast, [a: a, b: b + 1, c: c, var_names: var_names]}
   end
   for op <- @branch_ops do
+    defp traverse_abc({unquote(op), _meta, [{_, _, nil}, _] = arguments} = ast, [a: a, b: b, c: c, var_names: var_names]) when is_list(arguments) do
+      {ast, [a: a, b: b, c: c, var_names: var_names]}
+    end
     defp traverse_abc({unquote(op), _meta, arguments} = ast, [a: a, b: b, c: c, var_names: var_names]) when is_list(arguments) do
       {ast, [a: a, b: b + 1, c: c, var_names: var_names]}
     end

--- a/test/credo/check/refactor/abc_size_test.exs
+++ b/test/credo/check/refactor/abc_size_test.exs
@@ -195,4 +195,18 @@ end
     |> assert_issue(@described_check, max_size: 3)
   end
 
+  test "it should NOT count map/struct field access with dot notation for abc size" do
+    source =
+"""
+  def test do
+    %{
+      foo: foo.bar,
+      bar: bar.baz,
+      baz: bux.bus
+    }
+  end
+"""
+    assert rounded_abc_size(source) == 3
+  end
+
 end


### PR DESCRIPTION
@rrrene created a new head for `traverse_abc` in order to omit counting of Map/Struct record access using dot notation inside of a function.  Please let me know if there was an edge case I have missed and need to rework the solution or if the patch needs further explanation.

This issue fixes https://github.com/rrrene/credo/issues/171.