### PR TITLE
Add ampersand support to atom list in pipe_chain_start

### DIFF
--- a/lib/credo/check/refactor/pipe_chain_start.ex
+++ b/lib/credo/check/refactor/pipe_chain_start.ex
@@ -31,7 +31,7 @@ defmodule Credo.Check.Refactor.PipeChainStart do
   end
 
 
-  for atom <- [:%, :%{}, :.., :<<>>, :@, :__aliases__, :unquote, :{}] do
+  for atom <- [:%, :%{}, :.., :<<>>, :@, :__aliases__, :unquote, :{}, :&] do
     defp valid_chain_start?({unquote(atom), _meta, _arguments}, _excluded_functions) do
       true
     end


### PR DESCRIPTION
This fixes https://github.com/rrrene/credo/issues/182.

This PR adds `:&` to the list of atoms in order to support variable capture at the start of the pipe chain .