### PR TITLE
update: summary.ex with new function head for #print_priority_hint

### DIFF
--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -44,6 +44,10 @@ defmodule Credo.CLI.Output.Summary do
     shown_issues |> print_priority_hint(config)
   end
 
+  def print_priority_hint([], %Config{min_priority: min_priority}) when min_priority >= 0 do
+    "Use `--strict` to show all issues, `--help` for options."
+    |> UI.puts(:faint)
+  end
   def print_priority_hint([], _config), do: nil
   def print_priority_hint(_, %Config{min_priority: min_priority}) when min_priority >= 0 do
     "Showing priority issues: ↑ ↗ →  (use `--strict` to show all issues, `--help` for options)."


### PR DESCRIPTION
This PR fixes: https://github.com/rrrene/credo/issues/166

Added new function head to `summary.ex` to show the user `Use --strict to show all issues, --help for options.` if credo does not produce any errors and the user does NOT input `--strict` as an argument.