### PR TITLE
add: list concat, list subtraction, and string concat for pipeline

### DIFF
--- a/lib/credo/check/refactor/pipe_chain_start.ex
+++ b/lib/credo/check/refactor/pipe_chain_start.ex
@@ -31,7 +31,7 @@ defmodule Credo.Check.Refactor.PipeChainStart do
   end
 
 
-  for atom <- [:%, :%{}, :.., :<<>>, :@, :__aliases__, :unquote, :{}, :&] do
+  for atom <- [:%, :%{}, :.., :<<>>, :@, :__aliases__, :unquote, :{}, :&, :<>, :++, :--] do
     defp valid_chain_start?({unquote(atom), _meta, _arguments}, _excluded_functions) do
       true
     end

--- a/test/credo/check/refactor/pipe_chain_start_test.exs
+++ b/test/credo/check/refactor/pipe_chain_start_test.exs
@@ -156,6 +156,30 @@ put_in(users["john"][:age], 28)
     |> refute_issues(@described_check, excluded_functions: ~w(String.strip table put_in))
   end
 
+  test "it should NOT report a violation for --" do
+"""
+  def test do
+    [1,2,3]
+    -- [2]
+    |> Enum.max
+  end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  test "it should NOT report a violation for string concatenation" do
+"""
+defmodule Test do
+  def test do
+    "hello"
+    <> "world"
+    |> String.captialize
+  end
+end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
   test "it should NOT report a violation for captures" do
 """
 defmodule Test do


### PR DESCRIPTION
This PR fixes and address the conversation here: https://github.com/rrrene/credo/issues/182

Added support for list concatenation, string concatenation, and list subtraction for the pipe chain start rule.

 