### PR TITLE
Make sure credo does not crash on non-utf8 files

### DIFF
--- a/lib/credo/code.ex
+++ b/lib/credo/code.ex
@@ -59,9 +59,14 @@ defmodule Credo.Code do
     ast(source, filename)
   end
   def ast(source, filename \\ "nofilename") do
-    case Code.string_to_quoted(source, line: 1) do
-      {:ok, value} -> {:ok, value}
-      {:error, error} -> {:error, [issue_for(error, filename)]}
+    try do
+      case Code.string_to_quoted(source, line: 1) do
+        {:ok, value} -> {:ok, value}
+        {:error, error} -> {:error, [issue_for(error, filename)]}
+      end
+    rescue
+      e in UnicodeConversionError ->
+        {:error, [issue_for({1, e.message, nil}, filename)]}
     end
   end
 

--- a/test/credo/code_test.exs
+++ b/test/credo/code_test.exs
@@ -31,4 +31,13 @@ end
 """ |> Credo.Code.ast
     refute is_nil(ast)
   end
+
+  test "it issues a parser error when reading non-utf8 files" do
+    # This is `"René"` encoded as ISO-8859-1, which causes a `UnicodeConversionError`.
+    source_file = <<34, 82, 101, 110, 233, 34>>
+    {:error, [error]} = Credo.Code.ast(source_file)
+    %Credo.Issue{message: message, line_no: 1} = error
+
+    assert "invalid encoding starting at <<233, 34>>" == message
+  end
 end


### PR DESCRIPTION
When one of the files processed by credo is encoded in anything other than utf-8, credo will crash:

```
$ mix credo
** (UnicodeConversionError) invalid encoding starting at <<233, 34, 10>>
    (elixir) lib/string.ex:1748: String.to_charlist/1
    (elixir) lib/code.ex:266: Code.string_to_quoted/2
    lib/credo/code.ex:62: Credo.Code.ast/2
    lib/credo/source_file.ex:59: Credo.SourceFile.with_ast/1
    (elixir) lib/enum.ex:1184: Enum."-map/2-lists^map/1-0-"/2
    (elixir) lib/enum.ex:1184: Enum."-map/2-lists^map/1-0-"/2
    lib/credo/cli/command/suggest.ex:41: anonymous fn/1 in Credo.CLI.Command.Suggest.load_and_validate_source_files/1
    (stdlib) timer.erl:166: :timer.tc/1
```

With these changes, credo will now gracefully skip over those files:

```
$ mix credo
Some source files could not be parsed correctly and are excluded:

   1) lib/misencoded_file.exs

Checking 25 source files ...
```