### PR TITLE
Add ability to specify `strict` in `.credo.exs` config file

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -31,6 +31,10 @@
       # You can disable this behaviour below:
       check_for_updates: true,
       #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to true below:
+      strict: false,
+      #
       # You can customize the parameters of any check by adding a second element
       # to the tuple.
       #

--- a/lib/credo/cli.ex
+++ b/lib/credo/cli.ex
@@ -171,7 +171,13 @@ defmodule Credo.CLI do
   defp set_strict(config, %{strict: true}) do
     %Config{config | all: true, min_priority: -99}
   end
-  defp set_strict(config, _), do: config
+  defp set_strict(config, _) do
+    if config.strict do
+      set_strict(config, %{strict: true})
+    else
+      config
+    end
+  end
 
   defp set_help(config, %{help: true}) do
     %Config{config | help: true}

--- a/lib/credo/config.ex
+++ b/lib/credo/config.ex
@@ -11,6 +11,7 @@ defmodule Credo.Config do
             help:               false,
             version:            false,
             verbose:            false,
+            strict:             false,
             all:                false,
             format:             nil,
             match_checks:       nil,
@@ -133,7 +134,8 @@ defmodule Credo.Config do
       check_for_updates: data[:check_for_updates] || false,
       requires: data[:requires] || [],
       files: files_from_data(data, dir),
-      checks: checks_from_data(data)
+      checks: checks_from_data(data),
+      strict: data[:strict] || false
     }
   end
 
@@ -186,6 +188,7 @@ defmodule Credo.Config do
       requires: base.requires ++ other.requires,
       files: merge_files(base, other),
       checks: merge_checks(base, other),
+      strict: other.strict,
     }
   end
   def merge_checks(%__MODULE__{checks: checks_base}, %__MODULE__{checks: checks_other}) do


### PR DESCRIPTION
It was requested to be able to set `--strict` in the config file, so I've added
that ability here. I have also updated the documentation to make it apparent
that this is a setting that is available to the user.

I had a hard time finding tests for similar functionality, so I haven't added
any tests for this feature. I'd love to do that, though, if someone can point me
in the right direction as to how this should be tested.

I've tried this on my local machine and seen that it works, but I'm also fairly
certain that the implementation that I have isn't consistent with the rest of
the application. If folks have any other guidance on how I can make my
implementation better, I'd be happy to hear it!

Resolves #168
