### PR TITLE
Always print where check runner errors happened to help with debugging

### DIFF
--- a/lib/credo/check/runner.ex
+++ b/lib/credo/check/runner.ex
@@ -95,16 +95,17 @@ defmodule Credo.Check.Runner do
   defp run_check({check}, source_file, config) do
     run_check({check, []}, source_file, config)
   end
-  defp run_check({check, params}, source_file, %Config{crash_on_error: true}) do
-    check.run(source_file, params)
-  end
-  defp run_check({check, params}, source_file, _config) do
+  defp run_check({check, params}, source_file, config) do
     try do
       check.run(source_file, params)
     rescue
-      _ ->
+      error ->
         IO.puts(:stderr, "Error while running #{check} on #{source_file.filename}")
-        []
+        if config.crash_on_error do
+          reraise error, System.stacktrace()
+        else
+          []
+        end
     end
   end
 


### PR DESCRIPTION
I made a large change to my codebase and credo's runner started crashing on me. While the debug stack told me where in credo I was crashing, I wasn't able to figure out what code of mine was causing the issue.

With this change, I was able to track down the file that was breaking things for me.

Obviously, I could have gotten the same debug line by turning off the "crash_on_error" setting, but I didn't know about it and don't really want to have to flip config settings to debug.

---------------
Sorry for the second PR. For some reason, force pushing my branch disabled my ability to reopen the original PR