### PR TITLE
Update README installation instructions to v0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add as a dependency in your mix.exs file:
 ```elixir
 defp deps do
   [
-    {:credo, "~> 0.4", only: [:dev, :test]}
+    {:credo, "~> 0.5", only: [:dev, :test]}
   ]
 end
 ```


### PR DESCRIPTION
Since 0.4 does not work properly with the Hex v0.14.0. See #210.

_Update:_
I did see that v0.4.14 addresses this issue for v0.4, but still seems like a good idea to have new projects use 0.5.