### PR TITLE
Fix explain on last line issue raises a match error

### DIFF
--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -138,9 +138,9 @@ defmodule Credo.CLI.Output.Explain do
       UI.puts_edge([outer_color, :faint])
 
       code_color = :faint
-      print_source_line(source_file.lines, issue.line_no - 2, term_width, code_color, outer_color)
-      print_source_line(source_file.lines, issue.line_no - 1, term_width, code_color, outer_color)
-      print_source_line(source_file.lines, issue.line_no, term_width, [:cyan, :bright], outer_color)
+      print_source_line(source_file, issue.line_no - 2, term_width, code_color, outer_color)
+      print_source_line(source_file, issue.line_no - 1, term_width, code_color, outer_color)
+      print_source_line(source_file, issue.line_no, term_width, [:cyan, :bright], outer_color)
 
       if issue.column do
         offset = 0
@@ -158,8 +158,8 @@ defmodule Credo.CLI.Output.Explain do
         ]
         |> UI.puts
       end
-      print_source_line(source_file.lines, issue.line_no + 1, term_width, code_color, outer_color)
-      print_source_line(source_file.lines, issue.line_no + 2, term_width, code_color, outer_color)
+      print_source_line(source_file, issue.line_no + 1, term_width, code_color, outer_color)
+      print_source_line(source_file, issue.line_no + 2, term_width, code_color, outer_color)
     end
 
     UI.puts_edge([outer_color, :faint], @indent)
@@ -187,11 +187,11 @@ defmodule Credo.CLI.Output.Explain do
     UI.puts_edge([outer_color, :faint])
   end
 
-  defp print_source_line(source_file_lines, line_no, _, _, _) when line_no < 1 or line_no > length(source_file_lines) do
+  defp print_source_line(%SourceFile{lines: lines}, line_no, _, _, _) when line_no < 1 or line_no > length(lines) do
     nil
   end
-  defp print_source_line(source_file_lines, line_no, term_width, color, outer_color) do
-    {_, line} = Enum.at(source_file_lines, line_no - 1)
+  defp print_source_line(%SourceFile{lines: lines}, line_no, term_width, color, outer_color) do
+    {_, line} = Enum.at(lines, line_no - 1)
 
     line_no_str =
       "#{line_no} "

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -138,9 +138,9 @@ defmodule Credo.CLI.Output.Explain do
       UI.puts_edge([outer_color, :faint])
 
       code_color = :faint
-      print_source_line(source_file, issue.line_no - 2, term_width, code_color, outer_color)
-      print_source_line(source_file, issue.line_no - 1, term_width, code_color, outer_color)
-      print_source_line(source_file, issue.line_no, term_width, [:cyan, :bright], outer_color)
+      print_source_line(source_file.lines, issue.line_no - 2, term_width, code_color, outer_color)
+      print_source_line(source_file.lines, issue.line_no - 1, term_width, code_color, outer_color)
+      print_source_line(source_file.lines, issue.line_no, term_width, [:cyan, :bright], outer_color)
 
       if issue.column do
         offset = 0
@@ -158,8 +158,8 @@ defmodule Credo.CLI.Output.Explain do
         ]
         |> UI.puts
       end
-      print_source_line(source_file, issue.line_no + 1, term_width, code_color, outer_color)
-      print_source_line(source_file, issue.line_no + 2, term_width, code_color, outer_color)
+      print_source_line(source_file.lines, issue.line_no + 1, term_width, code_color, outer_color)
+      print_source_line(source_file.lines, issue.line_no + 2, term_width, code_color, outer_color)
     end
 
     UI.puts_edge([outer_color, :faint], @indent)
@@ -187,11 +187,11 @@ defmodule Credo.CLI.Output.Explain do
     UI.puts_edge([outer_color, :faint])
   end
 
-  defp print_source_line(_, line_no, _, _, _) when line_no < 1 do
+  defp print_source_line(source_file_lines, line_no, _, _, _) when line_no < 1 or line_no > length(source_file_lines) do
     nil
   end
-  defp print_source_line(source_file, line_no, term_width, color, outer_color) do
-    {_, line} = Enum.at(source_file.lines, line_no - 1)
+  defp print_source_line(source_file_lines, line_no, term_width, color, outer_color) do
+    {_, line} = Enum.at(source_file_lines, line_no - 1)
 
     line_no_str =
       "#{line_no} "


### PR DESCRIPTION
Currently if you have an issue on the last line (or second to last) of your code and you do an explain, it will raise a match error. For example:

```
$  mix credo lib/cards.ex:22
[..]
 __ CODE IN QUESTION
┃ 
┃    20   end
┃    21 end
┃    22 IO.inspect(2)
┃       ^^^^^^^^^^
┃    23 
** (MatchError) no match of right hand side value: nil
    lib/credo/cli/output/explain.ex:197: Credo.CLI.Output.Explain.print_source_line/5
    lib/credo/cli/output/explain.ex:162: Credo.CLI.Output.Explain.print_issue/3
    (elixir) lib/enum.ex:651: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir) lib/enum.ex:651: Enum.each/2
    lib/credo/cli/command/explain.ex:23: Credo.CLI.Command.Explain.run/2
    lib/credo/cli.ex:58: Credo.CLI.main/1
    (mix) lib/mix/task.ex:296: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
```

This PR prevents this error by adding a new guard clause to `print_source_line/5` so it doesn't try to access a line that doesn't exist on the file (on line 194 `{_, line} = Enum.at(source_file_lines, line_no - 1)` it is trying to match `{_, line} = nil`).

Also a little refactor to pass directly`source_file.lines` instead of `source_file` to the `print_source_line/5`, since that is the only thing needed in that function – also it is necessary for the guard clause.