### PR TITLE
Fix RedundantBlankLines raising when file doesn't have blank lines

### DIFF
--- a/lib/credo/check/readability/redundant_blank_lines.ex
+++ b/lib/credo/check/readability/redundant_blank_lines.ex
@@ -38,7 +38,7 @@ defmodule Credo.Check.Readability.RedundantBlankLines do
     |> Enum.map(fn {pos, _} -> pos end)
   end
 
-  defp consecutive_lines([], _), do: false
+  defp consecutive_lines([], _), do: []
 
   defp consecutive_lines([first_line|other_lines], max_blank_lines) do
     reducer = consecutive_lines_reducer(max_blank_lines)

--- a/test/credo/check/readability/redundant_blank_lines_test.exs
+++ b/test/credo/check/readability/redundant_blank_lines_test.exs
@@ -57,4 +57,14 @@ end
     file
     |> assert_issue(@described_check, max_blank_lines: 3)
   end
+
+  test "it should not fail when file doesn't have empty lines" do
+"defmodule ModuleWithoutEmptyLines do
+  def foo do
+    :bar
+  end
+end"
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
 end


### PR DESCRIPTION
If you had a file without ANY blank line, RedundantBlankLines would raise because `consecutive_lines([], _)` was returning `:false` and that value was being piped into an `Enum.map/2`

An example of file that would trigger the error behaviour without this patch:
```elixir
defmodule MyApp do
end
````