### PR TITLE
Fix bug on ParameterPatternMatchingTest on private funs and funs with no binding

### DIFF
--- a/lib/credo/check/consistency/parameter_pattern_matching/position_collector.ex
+++ b/lib/credo/check/consistency/parameter_pattern_matching/position_collector.ex
@@ -25,7 +25,7 @@ defmodule Credo.Check.Consistency.ParameterPatternMatching.PositionCollector do
       |> Enum.map(&(property_values_for_parameter(&1, filename)))
       |> Enum.reject(&is_nil/1)
   end
-  defp property_values_for_def(_, _), do: nil
+  defp property_values_for_def(_, _), do: []
 
   defp property_values_for_parameter({:=, [line: line_no], [[_ | _] | _]} = _vals, filename) do
     :after

--- a/test/credo/check/consistency/parameter_pattern_matching_test.exs
+++ b/test/credo/check/consistency/parameter_pattern_matching_test.exs
@@ -89,4 +89,21 @@ end
     |> to_source_files
     |> refute_issues(@described_check)
   end
+
+  test "it should NOT break when input has a function without bindings or private funs" do
+    module_with_fun_without_bindings = """
+    defmodule SurviveThisIfYouCan do
+      def start do
+        GenServer.start(__MODULE__, [])
+      end
+
+      defp foo(bar) do
+        bar + 1
+      end
+    end
+    """
+    [module_with_fun_without_bindings]
+    |> to_source_files
+    |> refute_issues(@described_check)
+  end
 end


### PR DESCRIPTION
`position_collector.ex` checked the parameter definitions of the files and flat_mapped this. But when the input ast node was either a `def` without bindings or a `defp` or `defmacro`, it would return `nil` .

Example of input file that would have triggered an error:
```elixir
defmodule Foo do
  def bar do
    :bar
  end
  defp baz(foo) do
    foo
  end
end
```