### PR TITLE
Add ability to use `--no-strict` command line flag

### DIFF
--- a/lib/credo/cli.ex
+++ b/lib/credo/cli.ex
@@ -172,6 +172,10 @@ defmodule Credo.CLI do
     %Config{config | strict: true}
     |> Config.set_strict()
   end
+  defp set_strict(config, %{strict: false}) do
+    %Config{config | strict: false}
+    |> Config.set_strict()
+  end
   defp set_strict(config, _), do: config
 
   defp set_help(config, %{help: true}) do

--- a/lib/credo/config.ex
+++ b/lib/credo/config.ex
@@ -254,5 +254,8 @@ defmodule Credo.Config do
   def set_strict(%__MODULE__{strict: true} = config) do
     %__MODULE__{config | all: true, min_priority: -99}
   end
+  def set_strict(%__MODULE__{strict: false} = config) do
+    %__MODULE__{config | all: false, min_priority: 0}
+  end
   def set_strict(config), do: config
 end


### PR DESCRIPTION
We implemented the ability to set a `strict: true` config in the `.credo.exs`
file for a project, but when we did that we didn't implement any way to
override that with a command line flag. In this commit we're adding that
ability to override that setting with a `--no-strict` flag so you don't need to
edit that file to turn off `strict` mode for just a single run.

Closes #214 