### PR TITLE
Add deprecation and exclusion of checks by Elixir version

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -33,6 +33,11 @@ defmodule Credo.Check do
         default || :unknown
       end
 
+      def elixir_version do
+        default = unquote(opts[:elixir_version])
+        default || ">= 0.0.1"
+      end
+
       def run_on_all? do
         unquote(run_on_all_body(opts[:run_on_all]))
       end

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -23,7 +23,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
     only_greater_than: 9_999,
   ]
 
-  use Credo.Check, base_priority: :high
+  use Credo.Check, base_priority: :high, elixir_version: ">= 1.3.2"
 
   def run(source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)

--- a/lib/credo/check/runner.ex
+++ b/lib/credo/check/runner.ex
@@ -69,12 +69,16 @@ defmodule Credo.Check.Runner do
 
   defp exclude_checks_based_on_elixir_version(config) do
     version = System.version()
+    skipped_checks = Enum.reject(config.checks, fn
+      ({check}) -> Version.match?(version, check.elixir_version)
+      ({check, _}) -> Version.match?(version, check.elixir_version)
+    end)
     checks = Enum.filter(config.checks, fn
       ({check}) -> Version.match?(version, check.elixir_version)
       ({check, _}) -> Version.match?(version, check.elixir_version)
     end)
 
-    %Config{config | checks: checks}
+    %Config{config | checks: checks, skipped_checks: skipped_checks}
   end
 
   defp run_checks_that_run_on_all(source_files, config) do

--- a/lib/credo/check/runner.ex
+++ b/lib/credo/check/runner.ex
@@ -8,6 +8,7 @@ defmodule Credo.Check.Runner do
       config
       |> set_lint_attributes(source_files)
       |> exclude_low_priority_checks(config.min_priority - 9)
+      |> exclude_checks_based_on_elixir_version
 
     {_time_run_on_all, source_files_after_run_on_all} =
       :timer.tc fn ->
@@ -62,6 +63,16 @@ defmodule Credo.Check.Runner do
           ({check}) -> check.base_priority < below_priority
           ({check, _}) -> check.base_priority < below_priority
         end)
+
+    %Config{config | checks: checks}
+  end
+
+  defp exclude_checks_based_on_elixir_version(config) do
+    version = System.version()
+    checks = Enum.filter(config.checks, fn
+      ({check}) -> Version.match?(version, check.elixir_version)
+      ({check, _}) -> Version.match?(version, check.elixir_version)
+    end)
 
     %Config{config | checks: checks}
   end

--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -34,6 +34,7 @@ defmodule Credo.CLI.Output.Summary do
     UI.puts
     UI.puts [:faint, @cry_for_help]
     UI.puts
+    print_skipped_checks(config.skipped_checks)
     UI.puts [:faint, format_time_spent(time_load, time_run)]
 
     UI.puts summary_parts(source_files, shown_issues)
@@ -42,6 +43,17 @@ defmodule Credo.CLI.Output.Summary do
     UI.puts
 
     print_priority_hint(shown_issues, config)
+  end
+
+  defp print_skipped_checks(checks) do
+    msg = """
+The following checks were skipped because they're not compatible with your
+version of Elixir (#{System.version()}). Upgrade to the newest version of Elixir to
+get the most out of Credo!
+    """
+    UI.puts(msg, :faint)
+    Enum.each(checks, fn({check, _check_info}) -> UI.puts("  - #{check}", :faint) end)
+    UI.puts
   end
 
   def print_priority_hint([], %Config{min_priority: min_priority}) when min_priority >= 0 do

--- a/lib/credo/config.ex
+++ b/lib/credo/config.ex
@@ -6,6 +6,7 @@ defmodule Credo.Config do
 
   defstruct files:              nil,
             checks:             nil,
+            skipped_checks:     nil,
             requires:           [],
             min_priority:       0,
             help:               false,


### PR DESCRIPTION
We have some checks that don't behave entirely as expected for some older
versions of Elixir, and we want to deprecate (and eventually remove) thos
checks for those versions. This is the first very quick and _very_ dirty spike
on a way to do that so we can start a discussion around how we want to handle
this process.

This is related to #229 and will hopefully give us a starting point for discussion.