### PR TITLE
cleanup type-guards

### DIFF
--- a/lib/credo/check/code_helper.ex
+++ b/lib/credo/check/code_helper.ex
@@ -170,8 +170,6 @@ defmodule Credo.Check.CodeHelper do
   end
   defp clean_node(v) when is_atom(v)
                       or is_binary(v)
-                      or is_boolean(v)
                       or is_float(v)
-                      or is_integer(v)
-                      or is_nil(v), do: v
+                      or is_integer(v), do: v
 end

--- a/lib/credo/code/block.ex
+++ b/lib/credo/code/block.ex
@@ -202,9 +202,7 @@ defmodule Credo.Code.Block do
   defp instructions_for(v) when is_atom(v)
                       or is_tuple(v)
                       or is_binary(v)
-                      or is_boolean(v)
                       or is_float(v)
-                      or is_integer(v)
-                      or is_nil(v), do: List.wrap(v)
+                      or is_integer(v), do: List.wrap(v)
   defp instructions_for(v) when is_list(v), do: [v]
 end

--- a/lib/credo/exs_loader.ex
+++ b/lib/credo/exs_loader.ex
@@ -22,10 +22,8 @@ defmodule Credo.ExsLoader do
 
   defp process_exs(v) when is_atom(v)
                         or is_binary(v)
-                        or is_boolean(v)
                         or is_float(v)
-                        or is_integer(v)
-                        or is_nil(v), do: v
+                        or is_integer(v), do: v
   defp process_exs(list) when is_list(list) do
     Enum.map(list, &process_exs/1)
   end


### PR DESCRIPTION
Some of the typeguards would be never run, or return false, since they
were testing for a subset of the previously called `is_atom/1`

In fact `true` and `false` as well as `nil` are just atoms.