### PR TITLE
Implemented check for variable rebinding

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -89,6 +89,7 @@
         {Credo.Check.Refactor.NegatedConditionsWithElse},
         {Credo.Check.Refactor.Nesting},
         {Credo.Check.Refactor.UnlessWithElse},
+        {Credo.Check.Refactor.VariableRebinding},
 
         {Credo.Check.Warning.IExPry},
         {Credo.Check.Warning.IoInspect},

--- a/lib/credo/check/refactor/variable_rebind.ex
+++ b/lib/credo/check/refactor/variable_rebind.ex
@@ -27,8 +27,7 @@ defmodule Credo.Check.Refactor.VariableRebinding do
       variables
       |> Enum.filter(fn {key, _} ->
         Enum.count(variables, fn 
-          {^key, _} -> true
-          _ -> false
+          {other, _} -> key == other
         end) >= 2
       end)
       |> Enum.uniq_by(fn 

--- a/lib/credo/check/refactor/variable_rebind.ex
+++ b/lib/credo/check/refactor/variable_rebind.ex
@@ -30,6 +30,7 @@ defmodule Credo.Check.Refactor.VariableRebinding do
           {other, _} -> key == other
         end) >= 2
       end)
+      |> Enum.reverse
       |> Enum.uniq_by(fn 
         {v, _} -> v
       end)

--- a/lib/credo/check/refactor/variable_rebind.ex
+++ b/lib/credo/check/refactor/variable_rebind.ex
@@ -1,0 +1,67 @@
+defmodule Credo.Check.Refactor.VariableRebinding do
+  @explanation [
+    check: @moduledoc
+  ]
+
+  @def_ops [:def, :defp, :defmacro]
+  @nest_ops [:if, :unless, :case, :cond, :fn]
+
+  alias Credo.Check.CodeHelper
+
+  use Credo.Check
+
+  def run(%SourceFile{ast: ast} = source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(ast, &traverse(&1, &2, issue_meta))
+  end
+
+  def traverse([do: {:__block__, _, ast}], issues, issue_meta) do
+    variables = 
+      ast
+      |> Enum.map(&find_assignments/1)
+      |> Enum.filter(&(&1 != nil))
+
+
+    duplicates = 
+      variables
+      |> Enum.filter(fn {key, _} ->
+        Enum.count(variables, fn 
+          {^key, _} -> true
+          _ -> false
+        end) >= 2
+      end)
+      |> Enum.uniq_by(fn 
+        {v, _} -> v
+      end)
+
+    new_issues = 
+      duplicates
+      |> Enum.map(fn {variable_name, line} ->
+        issue_for(issue_meta, Atom.to_string(variable_name), line)
+      end)
+
+    if length(new_issues) > 0 do
+      {ast, issues ++ new_issues}
+    else
+      {ast, issues}
+    end
+  end
+  
+  def traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp find_assignments({:=, meta, [{variable_name, _, _}, _]}) do
+    {variable_name, meta[:line]}
+  end
+  
+  defp find_assignments(_), do: nil
+
+  defp issue_for(issue_meta, trigger, line) do
+    format_issue issue_meta,
+      message: "Variable was declared more than once.",
+      trigger: trigger,
+      line_no: line
+  end
+end

--- a/lib/credo/check/refactor/variable_rebind.ex
+++ b/lib/credo/check/refactor/variable_rebind.ex
@@ -58,7 +58,7 @@ defmodule Credo.Check.Refactor.VariableRebinding do
 
   defp find_assignments(_), do: nil
 
-  defp find_variables({:=, _, args} = ast) do
+  defp find_variables({:=, _, args}) do
     Enum.map(args, &find_variables/1)
   end
 
@@ -74,6 +74,15 @@ defmodule Credo.Check.Refactor.VariableRebinding do
 
   defp find_variables(list) when is_list(list) do
     list
+    |> Enum.map(&find_variables/1)
+    |> List.flatten
+    |> Enum.uniq_by(&get_variable_name/1)
+  end
+
+  defp find_variables(map) when is_map(map) do
+    map
+    |> Enum.into([])
+    |> Enum.map(fn {_, value} -> value end)
     |> Enum.map(&find_variables/1)
     |> List.flatten
     |> Enum.uniq_by(&get_variable_name/1)

--- a/lib/credo/check/refactor/variable_rebind.ex
+++ b/lib/credo/check/refactor/variable_rebind.ex
@@ -58,6 +58,10 @@ defmodule Credo.Check.Refactor.VariableRebinding do
 
   defp find_assignments(_), do: nil
 
+  defp find_variables({:=, _, args} = ast) do
+    Enum.map(args, &find_variables/1)
+  end
+
   defp find_variables({variable_name, meta, nil}) when is_list(meta) do
     {variable_name, meta[:line]}
   end

--- a/lib/credo/check/refactor/variable_rebind.ex
+++ b/lib/credo/check/refactor/variable_rebind.ex
@@ -69,6 +69,11 @@ defmodule Credo.Check.Refactor.VariableRebinding do
   defp find_variables(tuple) when is_tuple(tuple) do
     tuple
     |> Tuple.to_list
+    |> find_variables
+  end
+
+  defp find_variables(list) when is_list(list) do
+    list
     |> Enum.map(&find_variables/1)
     |> List.flatten
     |> Enum.uniq_by(&get_variable_name/1)

--- a/test/credo/check/refactor/variable_rebind_test.exs
+++ b/test/credo/check/refactor/variable_rebind_test.exs
@@ -78,4 +78,16 @@ end
 """ |> to_source_file
     |> assert_issue(@described_check)
   end
+
+  test "it should report violations when using destructuring maps" do
+"""
+defmodule CredoSampleModule do
+  def some_function(opts) do
+    %{a: foo, b: bar} = opts
+    bar = 3
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
 end

--- a/test/credo/check/refactor/variable_rebind_test.exs
+++ b/test/credo/check/refactor/variable_rebind_test.exs
@@ -42,7 +42,7 @@ end
     |> assert_issues(@described_check, nil, &(length(&1) == 2))
   end
 
-  test "it should report violations when using destructuring" do
+  test "it should report violations when using destructuring tuples" do
 """
 defmodule CredoSampleModule do
   def some_function() do
@@ -60,6 +60,18 @@ end
 defmodule CredoSampleModule do
   def some_function() do
     {a = b, a = b} = {1, 2}
+    b = 2
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report violations when using destructuring lists" do
+"""
+defmodule CredoSampleModule do
+  def some_function() do
+    [a, b] = [1, 2]
     b = 2
   end
 end

--- a/test/credo/check/refactor/variable_rebind_test.exs
+++ b/test/credo/check/refactor/variable_rebind_test.exs
@@ -54,4 +54,16 @@ end
 """ |> to_source_file
     |> assert_issue(@described_check)
   end
+
+  test "it should report violations when using destructuring with nested assignments" do
+"""
+defmodule CredoSampleModule do
+  def some_function() do
+    {a = b, a = b} = {1, 2}
+    b = 2
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
 end

--- a/test/credo/check/refactor/variable_rebind_test.exs
+++ b/test/credo/check/refactor/variable_rebind_test.exs
@@ -41,4 +41,17 @@ end
 """ |> to_source_file
     |> assert_issues(@described_check, nil, &(length(&1) == 2))
   end
+
+  test "it should report violations when using destructuring" do
+"""
+defmodule CredoSampleModule do
+  def some_function() do
+    something = "ABABAB"
+    {:ok, something} = Base.decode16(something)
+    {a, a} = {2, 2} # this should _not_ trigger it
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
 end

--- a/test/credo/check/refactor/variable_rebind_test.exs
+++ b/test/credo/check/refactor/variable_rebind_test.exs
@@ -32,7 +32,7 @@ end
 defmodule CredoSampleModule do
   def some_function() do
     var_1 = 1 + 3
-    var_b = var1 + 7
+    var_b = var_1 + 7
     var_1 = 34
     var_c = 2456
     var_b = 2

--- a/test/credo/check/refactor/variable_rebind_test.exs
+++ b/test/credo/check/refactor/variable_rebind_test.exs
@@ -1,0 +1,44 @@
+defmodule Credo.Check.Refactor.VariableRebindingTest do
+  use Credo.TestHelper
+
+  @described_check Credo.Check.Refactor.VariableRebinding
+
+  test "it should NOT report expected code" do
+"""
+defmodule CredoSampleModule do
+  def some_function(parameter1, parameter2) do
+    a = 1
+    b = 2
+  end
+end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  test "it should report a violation" do
+"""
+defmodule CredoSampleModule do
+  def some_function(parameter1, parameter2) do
+    a = 1
+    a = 2
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report two violations" do
+"""
+defmodule CredoSampleModule do
+  def some_function() do
+    var_1 = 1 + 3
+    var_b = var1 + 7
+    var_1 = 34
+    var_c = 2456
+    var_b = 2
+  end
+end
+""" |> to_source_file
+    |> assert_issues(@described_check, nil, &(length(&1) == 2))
+  end
+end


### PR DESCRIPTION
This will check for multiple declaration of the same variable within a do block. 

For example,

```elixir
defmodule CredoSampleModule do
  def some_function() do
    a = 1
    a = 2
  end
end
```

would trigger a warning because `a` is declared twice.