### PR TITLE
Refactor to remove single pipes

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -105,12 +105,12 @@ defmodule Credo.Check do
     priority =
       case params[:priority] do
         nil -> issue_base_priority
-        val -> val |> Check.to_priority
+        val -> Check.to_priority(val)
       end
     exit_status =
       case params[:exit_status] do
-        nil -> issue_category |> Check.to_exit_status
-        val -> val |> Check.to_exit_status
+        nil -> Check.to_exit_status(issue_category)
+        val -> Check.to_exit_status(val)
       end
 
     line_no = opts[:line_no]
@@ -197,8 +197,7 @@ defmodule Credo.Check do
   @doc "Converts a given category to an exit status"
   def to_exit_status(nil), do: 0
   def to_exit_status(atom) when is_atom(atom) do
-    @base_category_exit_status_map[atom]
-    |> to_exit_status
+    to_exit_status(@base_category_exit_status_map[atom])
   end
   def to_exit_status(value), do: value
 

--- a/lib/credo/check/code_helper.ex
+++ b/lib/credo/check/code_helper.ex
@@ -70,10 +70,9 @@ defmodule Credo.Check.CodeHelper do
         value
       :notfound ->
         result =
-          lines
-          |> Enum.map(fn({line_no, _}) ->
-              Scope.name(ast, line: line_no)
-            end)
+          Enum.map(lines, fn({line_no, _}) ->
+            Scope.name(ast, line: line_no)
+          end)
         SourceFileScopes.put(filename, result)
         result
     end

--- a/lib/credo/check/consistency/exception_names.ex
+++ b/lib/credo/check/consistency/exception_names.ex
@@ -39,18 +39,16 @@ defmodule Credo.Check.Consistency.ExceptionNames do
 
   def run(source_files, params \\ []) when is_list(source_files) do
     {property_tuples, most_picked} =
-      source_files
-      |> Helper.run_code_patterns(@code_patterns, params)
+      Helper.run_code_patterns(source_files, @code_patterns, params)
 
     count =
-      property_tuples
-      |> Enum.reduce(0, fn({prop_list, _}, acc) ->
-          acc + Enum.count(prop_list)
-        end)
+      Enum.reduce(property_tuples, 0, fn({prop_list, _}, acc) ->
+        acc + Enum.count(prop_list)
+      end)
 
     if count > 2 do # we found more than one prefix and one suffix
-      {property_tuples, most_picked}
-      |> Helper.append_issues_via_issue_service(&check_for_issues/5, params)
+      info_tuple = {property_tuples, most_picked}
+      Helper.append_issues_via_issue_service(info_tuple, &check_for_issues/5, params)
     end
 
     :ok
@@ -119,18 +117,20 @@ defmodule Credo.Check.Consistency.ExceptionNames do
   end
 
   def message_for(:prefix, expected, trigger) do
-    """
+    message = """
     Exception modules should be named consistently.
     It seems your strategy is to prefix them with `#{expected}`,
     but `#{trigger}` does not follow that convention."
-    """ |> to_one_line
+    """
+    to_one_line(message)
   end
   def message_for(:suffix, expected, trigger) do
-    """
+    message = """
     Exception modules should be named consistently.
     It seems your strategy is to have `#{expected}` as a suffix,
     but `#{trigger}` does not follow that convention.
-    """ |> to_one_line
+    """
+    to_one_line(message)
   end
 
   def to_one_line(str), do: str |> String.split |> Enum.join(" ")

--- a/lib/credo/check/consistency/exception_names/prefix_and_suffix_collector.ex
+++ b/lib/credo/check/consistency/exception_names/prefix_and_suffix_collector.ex
@@ -26,13 +26,13 @@ defmodule Credo.Check.Consistency.ExceptionNames.PrefixAndSuffixCollector do
   end
 
   defp property_value_for_exception_name(name, {_, meta, _}, filename) do
-    filename = filename |> Filename.with(line_no: meta[:line])
+    filename = Filename.with(filename, line_no: meta[:line])
     name_list = name |> Name.last |> Name.split_pascal_case
-    prefix = name_list |> List.first
-    suffix = name_list |> List.last
+    prefix = List.first(name_list)
+    suffix = List.last(name_list)
     [
-      {prefix, :prefix} |> PropertyValue.for(filename),
-      {suffix, :suffix} |> PropertyValue.for(filename)
+       PropertyValue.for({prefix, :prefix}, filename),
+       PropertyValue.for({suffix, :suffix}, filename)
     ]
   end
 end

--- a/lib/credo/check/consistency/helper.ex
+++ b/lib/credo/check/consistency/helper.ex
@@ -54,8 +54,7 @@ defmodule Credo.Check.Consistency.Helper do
   """
   def most_picked_prop_value(list) when is_list(list) do
     all_property_values =
-      list
-      |> Enum.flat_map(fn({property_list, _source_file}) -> PropertyValue.get(property_list) end)
+      Enum.flat_map(list, fn({property_list, _source_file}) -> PropertyValue.get(property_list) end)
 
     result =
       all_property_values
@@ -91,8 +90,7 @@ defmodule Credo.Check.Consistency.Helper do
   Returns a tuple: {property_tuples, most_picked}
   """
   def run_code_patterns(source_files, pattern_mods, params) do
-    source_files
-    |> most_picked_prop(&create_property_tuples(&1, pattern_mods, params))
+    most_picked_prop(source_files, &create_property_tuples(&1, pattern_mods, params))
   end
 
   @doc """
@@ -102,8 +100,7 @@ defmodule Credo.Check.Consistency.Helper do
   Does call `new_issue_fun/4` when necessary to create a new issue.
   """
   def append_issues_via_issue_service({property_tuples, most_picked}, new_issue_fun, params) do
-    property_tuples
-    |> Enum.map(&append_issues_if_necessary(&1, most_picked, new_issue_fun, params))
+    Enum.map(property_tuples, &append_issues_if_necessary(&1, most_picked, new_issue_fun, params))
   end
 
   defp append_issues_if_necessary({_prop_list, _source_file}, nil, _, _) do
@@ -145,11 +142,10 @@ defmodule Credo.Check.Consistency.Helper do
   end
 
   defp collect_property_values(pattern_mods, source_file, params) do
-    pattern_mods
-    |> Enum.reduce([], fn(pattern_mod, acc) ->
-        result = pattern_mod.property_value_for(source_file, params)
-        acc ++ List.wrap(result)
-      end)
+    Enum.reduce(pattern_mods, [], fn(pattern_mod, acc) ->
+      result = pattern_mod.property_value_for(source_file, params)
+      acc ++ List.wrap(result)
+    end)
   end
 
 end

--- a/lib/credo/check/consistency/line_endings/unix.ex
+++ b/lib/credo/check/consistency/line_endings/unix.ex
@@ -4,14 +4,12 @@ defmodule Credo.Check.Consistency.LineEndings.Unix do
   def property_value, do: :unix
 
   def property_value_for(%SourceFile{lines: lines, filename: filename}, _params) do
-    lines
-    |> Enum.map(&property_value_for_line(&1, filename))
+    Enum.map(lines, &property_value_for_line(&1, filename))
   end
 
   defp property_value_for_line({line_no, line}, filename) do
     unless String.ends_with?(line, "\r") do
-      property_value()
-      |> PropertyValue.for(filename: filename, line_no: line_no)
+      PropertyValue.for(property_value(), filename: filename, line_no: line_no)
     end
   end
 end

--- a/lib/credo/check/consistency/line_endings/windows.ex
+++ b/lib/credo/check/consistency/line_endings/windows.ex
@@ -4,14 +4,12 @@ defmodule Credo.Check.Consistency.LineEndings.Windows do
   def property_value, do: :windows
 
   def property_value_for(%SourceFile{lines: lines, filename: filename}, _params) do
-    lines
-    |> Enum.map(&property_value_for_line(&1, filename))
+    Enum.map(lines, &property_value_for_line(&1, filename))
   end
 
   defp property_value_for_line({line_no, line}, filename) do
     if String.ends_with?(line, "\r") do
-      property_value()
-      |> PropertyValue.for(filename: filename, line_no: line_no)
+      PropertyValue.for(property_value(), filename: filename, line_no: line_no)
     end
   end
 end

--- a/lib/credo/check/consistency/parameter_pattern_matching/position_collector.ex
+++ b/lib/credo/check/consistency/parameter_pattern_matching/position_collector.ex
@@ -29,23 +29,19 @@ defmodule Credo.Check.Consistency.ParameterPatternMatching.PositionCollector do
   defp property_values_for_def(_, _), do: []
 
   defp property_values_for_parameter({:=, [line: line_no], [[_ | _] | _]} = _vals, filename) do
-    :after
-      |> PropertyValue.for(filename: filename, line_no: line_no)
+    PropertyValue.for(:after, filename: filename, line_no: line_no)
   end
 
   defp property_values_for_parameter({:=, [line: line_no], [{:%, _, _}, _]} = _vals, filename) do
-    :after
-      |> PropertyValue.for(filename: filename, line_no: line_no)
+    PropertyValue.for(:after, filename: filename, line_no: line_no)
   end
 
   defp property_values_for_parameter({:=, [line: line_no], [{:%{}, _, _}, _]} = _vals, filename) do
-    :after
-      |> PropertyValue.for(filename: filename, line_no: line_no)
+    PropertyValue.for(:after, filename: filename, line_no: line_no)
   end
 
   defp property_values_for_parameter({:=, [line: line_no], _} = _vals, filename) do
-    :before
-      |> PropertyValue.for(filename: filename, line_no: line_no)
+    PropertyValue.for(:before, filename: filename, line_no: line_no)
   end
 
   defp property_values_for_parameter(_, _), do: nil

--- a/lib/credo/check/consistency/space_around_operators.ex
+++ b/lib/credo/check/consistency/space_around_operators.ex
@@ -47,8 +47,8 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators do
     actual_prop = PropertyValue.get(actual_prop)
 
     line = issue_meta |> IssueMeta.source_file() |> SourceFile.line_at(line_no)
-    params = issue_meta |> IssueMeta.params()
-    ignored_triggers = params |> Params.get(:ignore, @default_params)
+    params = IssueMeta.params(issue_meta)
+    ignored_triggers = Params.get(params, :ignore, @default_params)
 
     if !Enum.member?(ignored_triggers, trigger) && create_issue?(line, column, trigger) do
       format_issue issue_meta,

--- a/lib/credo/check/consistency/space_around_operators/with_space.ex
+++ b/lib/credo/check/consistency/space_around_operators/with_space.ex
@@ -18,14 +18,13 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators.WithSpace do
   end
 
   defp to_property_values({{line_no, column, _}, trigger}, filename) do
-    property_value()
-    |> PropertyValue.for(filename: filename, line_no: line_no, column: column, trigger: trigger)
+    PropertyValue.for(property_value(), filename: filename, line_no: line_no, column: column, trigger: trigger)
   end
 
   defp check_tokens([], acc), do: acc
   defp check_tokens([prev | t], acc) do
-    current = t |> List.first
-    next = t |> Enum.at(1)
+    current = List.first(t)
+    next = Enum.at(t, 1)
 
     acc =
       if SpaceHelper.operator?(current) do

--- a/lib/credo/check/consistency/space_around_operators/without_space.ex
+++ b/lib/credo/check/consistency/space_around_operators/without_space.ex
@@ -18,14 +18,13 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators.WithoutSpace do
   end
 
   defp to_property_values({{line_no, column, _}, trigger}, filename) do
-    property_value()
-    |> PropertyValue.for(filename: filename, line_no: line_no, column: column, trigger: trigger)
+    PropertyValue.for(property_value(), filename: filename, line_no: line_no, column: column, trigger: trigger)
   end
 
   defp check_tokens([], acc), do: acc
   defp check_tokens([prev | t], acc) do
-    current = t |> List.first
-    next = t |> Enum.at(1)
+    current = List.first(t)
+    next = Enum.at(t, 1)
 
     acc =
       if SpaceHelper.operator?(current) do

--- a/lib/credo/check/consistency/space_in_parentheses/with_space.ex
+++ b/lib/credo/check/consistency/space_in_parentheses/with_space.ex
@@ -18,9 +18,8 @@ defmodule Credo.Check.Consistency.SpaceInParentheses.WithSpace do
   defp property_value_for_line({line_no, line}, filename) do
     results = Regex.run(@regex, line)
     if results do
-      trigger = results |> Enum.at(1)
-      property_value()
-      |> PropertyValue.for(filename: filename, line_no: line_no, trigger: trigger)
+      trigger = Enum.at(results, 1)
+      PropertyValue.for(property_value(), filename: filename, line_no: line_no, trigger: trigger)
     end
   end
 end

--- a/lib/credo/check/consistency/space_in_parentheses/without_space.ex
+++ b/lib/credo/check/consistency/space_in_parentheses/without_space.ex
@@ -18,9 +18,8 @@ defmodule Credo.Check.Consistency.SpaceInParentheses.WithoutSpace do
   defp property_value_for_line({line_no, line}, filename) do
     results = Regex.run(@regex, line)
     if results do
-      trigger = results |> Enum.at(1)
-      property_value()
-      |> PropertyValue.for(filename: filename, line_no: line_no, trigger: trigger)
+      trigger = Enum.at(results, 1)
+      PropertyValue.for(property_value(), filename: filename, line_no: line_no, trigger: trigger)
     end
   end
 end

--- a/lib/credo/check/consistency/tabs_or_spaces/spaces.ex
+++ b/lib/credo/check/consistency/tabs_or_spaces/spaces.ex
@@ -4,13 +4,11 @@ defmodule Credo.Check.Consistency.TabsOrSpaces.Spaces do
   def property_value, do: :spaces
 
   def property_value_for(%SourceFile{lines: lines, filename: filename}, _params) do
-    lines
-    |> Enum.map(&property_value_for_line(&1, filename))
+    Enum.map(lines, &property_value_for_line(&1, filename))
   end
 
   defp property_value_for_line({line_no, "  " <> _line}, filename) do
-    property_value()
-    |> PropertyValue.for(filename: filename, line_no: line_no)
+    PropertyValue.for(property_value(), filename: filename, line_no: line_no)
   end
   defp property_value_for_line({_, _}, _), do: nil
 end

--- a/lib/credo/check/consistency/tabs_or_spaces/tabs.ex
+++ b/lib/credo/check/consistency/tabs_or_spaces/tabs.ex
@@ -4,13 +4,11 @@ defmodule Credo.Check.Consistency.TabsOrSpaces.Tabs do
   def property_value, do: :tabs
 
   def property_value_for(%SourceFile{lines: lines, filename: filename}, _params) do
-    lines
-    |> Enum.map(&property_value_for_line(&1, filename))
+    Enum.map(lines, &property_value_for_line(&1, filename))
   end
 
   defp property_value_for_line({line_no, "\t" <> _line}, filename) do
-    property_value()
-    |> PropertyValue.for(filename: filename, line_no: line_no)
+    PropertyValue.for(property_value(), filename: filename, line_no: line_no)
   end
   defp property_value_for_line({_, _}, _), do: nil
 end

--- a/lib/credo/check/design/alias_usage.ex
+++ b/lib/credo/check/design/alias_usage.ex
@@ -123,8 +123,8 @@ defmodule Credo.Check.Design.AliasUsage do
   # Returns true if mod_list and any dependent module would result in the same alias
   # since they share the same last name.
   defp conflicting_with_other_modules?(mod_list, mod_deps) do
-    last_name = mod_list |> Credo.Code.Name.last
-    full_name = mod_list |> Credo.Code.Name.full
+    last_name = Credo.Code.Name.last(mod_list)
+    full_name = Credo.Code.Name.full(mod_list)
 
     (mod_deps -- [full_name])
     |> Enum.filter(&Credo.Code.Name.parts_count(&1) > 1)

--- a/lib/credo/check/design/alias_usage.ex
+++ b/lib/credo/check/design/alias_usage.ex
@@ -55,8 +55,8 @@ defmodule Credo.Check.Design.AliasUsage do
   @doc false
   def run(%SourceFile{ast: ast} = source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
-    excluded_namespaces = params |> Params.get(:excluded_namespaces, @default_params)
-    excluded_lastnames = params |> Params.get(:excluded_lastnames, @default_params)
+    excluded_namespaces = Params.get(params, :excluded_namespaces, @default_params)
+    excluded_lastnames = Params.get(params, :excluded_lastnames, @default_params)
 
     Credo.Code.prewalk(ast, &traverse(&1, &2, issue_meta, excluded_namespaces, excluded_lastnames))
   end
@@ -90,7 +90,7 @@ defmodule Credo.Check.Design.AliasUsage do
       conflicting_with_other_modules?(mod_list, mod_deps) ->
         {ast, issues}
       true ->
-        trigger = mod_list |> Enum.join(".")
+        trigger = Enum.join(mod_list, ".")
         {ast, issues ++ [issue_for(issue_meta, meta[:line], trigger)]}
     end
   end
@@ -99,8 +99,8 @@ defmodule Credo.Check.Design.AliasUsage do
   end
 
   defp excluded_lastname_or_namespace?(mod_list, excluded_namespaces, excluded_lastnames) do
-    first_name = mod_list |> Credo.Code.Name.first
-    last_name = mod_list |> Credo.Code.Name.last
+    first_name = Credo.Code.Name.first(mod_list)
+    last_name = Credo.Code.Name.last(mod_list)
 
     Enum.member?(excluded_namespaces, first_name) ||
     Enum.member?(excluded_lastnames, last_name)
@@ -109,13 +109,13 @@ defmodule Credo.Check.Design.AliasUsage do
   # Returns true if mod_list and alias_name would result in the same alias
   # since they share the same last name.
   defp conflicting_with_aliases?(mod_list, aliases) do
-    last_name = mod_list |> Credo.Code.Name.last
+    last_name = Credo.Code.Name.last(mod_list)
 
-    aliases |> Enum.find(&conflicting_alias?(&1, mod_list, last_name))
+    Enum.find(aliases, &conflicting_alias?(&1, mod_list, last_name))
   end
   defp conflicting_alias?(alias_name, mod_list, last_name) do
-    full_name = mod_list |> Credo.Code.Name.full
-    alias_last_name = alias_name |> Credo.Code.Name.last
+    full_name = Credo.Code.Name.full(mod_list)
+    alias_last_name = Credo.Code.Name.last(alias_name)
 
     full_name != alias_name && alias_last_name == last_name
   end

--- a/lib/credo/check/design/duplicated_code.ex
+++ b/lib/credo/check/design/duplicated_code.ex
@@ -38,8 +38,8 @@ defmodule Credo.Check.Design.DuplicatedCode do
   use Credo.Check, run_on_all: true, base_priority: :higher
 
   def run(source_files, params \\ []) when is_list(source_files) do
-    mass_threshold = params |> Params.get(:mass_threshold, @default_params)
-    nodes_threshold = params |> Params.get(:nodes_threshold, @default_params)
+    mass_threshold = Params.get(params, :mass_threshold, @default_params)
+    nodes_threshold = Params.get(params, :nodes_threshold, @default_params)
 
     source_files
     |> duplicate_nodes(mass_threshold)
@@ -50,7 +50,7 @@ defmodule Credo.Check.Design.DuplicatedCode do
 
   defp append_issues_via_issue_service(found_hashes, source_files, nodes_threshold, params) when is_map(found_hashes) do
     Enum.each(found_hashes, fn({_hash, nodes}) ->
-      filenames = nodes |> Enum.map(&(&1.filename))
+      filenames = Enum.map(nodes, &(&1.filename))
       Enum.each(source_files, fn(source_file) ->
         if Enum.member?(filenames, source_file.filename) do
           this_node = Enum.find(nodes, &(&1.filename == source_file.filename))
@@ -84,10 +84,9 @@ defmodule Credo.Check.Design.DuplicatedCode do
 
   defp add_mass_to_subnode({hash, node_items}) do
     node_items =
-      node_items
-      |> Enum.map(fn(node_item) ->
-          %{node_item | mass: mass(node_item.node)}
-         end)
+      Enum.map(node_items, fn(node_item) ->
+        %{node_item | mass: mass(node_item.node)}
+      end)
 
     {hash, node_items}
   end
@@ -213,16 +212,16 @@ defmodule Credo.Check.Design.DuplicatedCode do
   # TODO: Put in AST helper
 
   def line_no_for({:__block__, _meta, arguments}) do
-    arguments |> line_no_for()
+    line_no_for(arguments)
   end
   def line_no_for({:do, arguments}) do
-    arguments |> line_no_for()
+    line_no_for(arguments)
   end
   def line_no_for({atom, meta, _}) when is_atom(atom) do
     meta[:line]
   end
   def line_no_for(list) when is_list(list) do
-    list |> Enum.find_value(&line_no_for/1)
+    Enum.find_value(list, &line_no_for/1)
   end
   def line_no_for(nil), do: nil
   def line_no_for(block) do

--- a/lib/credo/check/design/tag_helper.ex
+++ b/lib/credo/check/design/tag_helper.ex
@@ -21,7 +21,7 @@ defmodule Credo.Check.Design.TagHelper do
       |> List.wrap
       |> Enum.map(&String.strip/1)
 
-    {index + 1, line, tag_list |> List.first}
+    {index + 1, line, List.first(tag_list)}
   end
 
   defp tags?({_line_no, _line, nil}), do: false

--- a/lib/credo/check/find_lint_attributes.ex
+++ b/lib/credo/check/find_lint_attributes.ex
@@ -11,8 +11,7 @@ defmodule Credo.Check.FindLintAttributes do
 
   @doc false
   def run(source_files, _params) when is_list(source_files) do
-    source_files
-    |> Enum.map(&find_and_set_in_source_file/1)
+    Enum.map(source_files, &find_and_set_in_source_file/1)
   end
 
   def find_and_set_in_source_file(source_file) do

--- a/lib/credo/check/lint_attribute.ex
+++ b/lib/credo/check/lint_attribute.ex
@@ -18,8 +18,7 @@ defmodule Credo.Check.LintAttribute do
   end
   def ignores_issue?(%__MODULE__{value: check_list} = lint_attribute, issue) when is_list(check_list) do
     if lint_attribute.scope == issue.scope do
-      check_list
-      |> Enum.any?(&check_tuple_ignores_issue?(&1, issue))
+      Enum.any?(check_list, &check_tuple_ignores_issue?(&1, issue))
     else
       false
     end
@@ -29,7 +28,7 @@ defmodule Credo.Check.LintAttribute do
   end
 
   defp check_tuple_ignores_issue?({check_or_regex, false}, issue) do
-    if check_or_regex |> Regex.regex? do
+    if Regex.regex?(check_or_regex) do
       issue.check |> to_string |> String.match?(check_or_regex)
     else
       issue.check == check_or_regex
@@ -41,10 +40,10 @@ defmodule Credo.Check.LintAttribute do
 
   def value_for([false]), do: false
   def value_for([list]) when is_list(list) do
-    list |> Enum.map(&value_for/1)
+    Enum.map(list, &value_for/1)
   end
   def value_for([tuple]) when is_tuple(tuple) do
-    [tuple |> value_for()]
+    [value_for(tuple)]
   end
   def value_for({{:__aliases__, _, mod_list}, params}) do
     {Module.concat(mod_list), params}

--- a/lib/credo/check/property_value.ex
+++ b/lib/credo/check/property_value.ex
@@ -2,7 +2,7 @@ defmodule Credo.Check.PropertyValue do
   def for(value, meta_info), do: {__MODULE__, value, meta_info}
 
   def get({__MODULE__, value, _}), do: value
-  def get(list) when is_list(list), do: list |> Enum.map(&get/1)
+  def get(list) when is_list(list), do: Enum.map(list, &get/1)
   def get(value), do: value
 
   def meta(tuple, key) do
@@ -10,5 +10,5 @@ defmodule Credo.Check.PropertyValue do
     m[key]
   end
   def meta({__MODULE__, _, value}), do: value
-  def meta(list) when is_list(list), do: list |> Enum.map(&meta/1)
+  def meta(list) when is_list(list), do: Enum.map(list, &meta/1)
 end

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -27,7 +27,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
 
   def run(source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
-    min_number = params |> Params.get(:only_greater_than, @default_params)
+    min_number = Params.get(params, :only_greater_than, @default_params)
 
     source_file.source
     |> Credo.Code.to_tokens
@@ -82,9 +82,9 @@ defmodule Credo.Check.Readability.LargeNumbers do
   defp number_with_underscores(number, source_fragment) when is_number(number) do
     case String.split(source_fragment, ".", parts: 2) do
       [num, decimal] ->
-        [num |> add_underscores_to_number_string(), decimal] |> Enum.join(".")
+        Enum.join([add_underscores_to_number_string(num), decimal], ".")
       [num] ->
-        num |> add_underscores_to_number_string()
+        add_underscores_to_number_string(num)
     end
   end
 
@@ -121,7 +121,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
       |> String.strip
       |> String.replace(~r/\D$/, "")
 
-    if System.version |> Version.match?("< 1.3.2-dev") do
+    if Version.match?(System.version, "< 1.3.2-dev") do
       source_fragment_pre_132(tuple, issue_meta, fragment)
     else
       fragment

--- a/lib/credo/check/readability/max_line_length.ex
+++ b/lib/credo/check/readability/max_line_length.ex
@@ -26,10 +26,10 @@ defmodule Credo.Check.Readability.MaxLineLength do
 
   def run(%SourceFile{ast: ast, lines: lines} = source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
-    max_length = params |> Params.get(:max_length, @default_params)
-    ignore_definitions = params |> Params.get(:ignore_definitions, @default_params)
-    ignore_specs = params |> Params.get(:ignore_specs, @default_params)
-    ignore_strings = params |> Params.get(:ignore_strings, @default_params)
+    max_length = Params.get(params, :max_length, @default_params)
+    ignore_definitions = Params.get(params, :ignore_definitions, @default_params)
+    ignore_specs = Params.get(params, :ignore_specs, @default_params)
+    ignore_strings = Params.get(params, :ignore_strings, @default_params)
 
     definitions = Credo.Code.prewalk(ast, &find_definitions/2)
     specs = Credo.Code.prewalk(ast, &find_specs/2)

--- a/lib/credo/check/readability/module_doc.ex
+++ b/lib/credo/check/readability/module_doc.ex
@@ -34,7 +34,7 @@ defmodule Credo.Check.Readability.ModuleDoc do
       []
     else
       issue_meta = IssueMeta.for(source_file, params)
-      ignore_names = params |> Params.get(:ignore_names, @default_params)
+      ignore_names = Params.get(params, :ignore_names, @default_params)
 
       {_continue, issues} = Credo.Code.prewalk(ast, &traverse(&1, &2, issue_meta, ignore_names), {true, []})
       issues
@@ -43,7 +43,7 @@ defmodule Credo.Check.Readability.ModuleDoc do
 
   defp traverse({:defmodule, meta, _arguments} = ast, {true, issues}, issue_meta, ignore_names) do
     mod_name = Module.name(ast)
-    if mod_name |> matches?(ignore_names) do
+    if matches?(mod_name, ignore_names) do
       {ast, {false, issues}}
     else
       exception? = Module.exception?(ast)
@@ -61,10 +61,10 @@ defmodule Credo.Check.Readability.ModuleDoc do
   end
 
   defp matches?(name, patterns) when is_list(patterns) do
-    patterns |> Enum.any?(&matches?(name, &1))
+    Enum.any?(patterns, &matches?(name, &1))
   end
   defp matches?(name, string) when is_binary(string) do
-    name |> String.contains?(string)
+    String.contains?(name, string)
   end
   defp matches?(name, regex) do
     String.match?(name, regex)

--- a/lib/credo/check/readability/module_names.ex
+++ b/lib/credo/check/readability/module_names.ex
@@ -43,7 +43,7 @@ defmodule Credo.Check.Readability.ModuleNames do
       {:__aliases__, meta, names} ->
         names |> Enum.join(".") |> issues_for_name(meta, issues, issue_meta)
       {name, meta, nil} ->
-        name |> issues_for_name(meta, issues, issue_meta)
+        issues_for_name(name, meta, issues, issue_meta)
       _ ->
         issues
     end

--- a/lib/credo/check/readability/no_parentheses_when_zero_arity.ex
+++ b/lib/credo/check/readability/no_parentheses_when_zero_arity.ex
@@ -17,7 +17,7 @@ defmodule Credo.Check.Readability.NoParenthesesWhenZeroArity do
   for op <- @def_ops do
     # catch variables named e.g. `defp`
     defp traverse({unquote(op), _, body} = ast, issues, issue_meta) do
-      function_head = body |> Enum.at(0)
+      function_head = Enum.at(body, 0)
       {ast, issues_for_definition(function_head, issues, issue_meta)}
     end
   end

--- a/lib/credo/check/readability/predicate_function_names.ex
+++ b/lib/credo/check/readability/predicate_function_names.ex
@@ -61,7 +61,7 @@ defmodule Credo.Check.Readability.PredicateFunctionNames do
   end
 
   def issues_for_name(_op, name, meta, issues, issue_meta) do
-    name = name |> to_string
+    name =  to_string(name)
     cond do
       String.starts_with?(name, "is_") && String.ends_with?(name, "?") ->
         [issue_for(issue_meta, meta[:line], name, :predicate_and_question_mark) | issues]

--- a/lib/credo/check/readability/redundant_blank_lines.ex
+++ b/lib/credo/check/readability/redundant_blank_lines.ex
@@ -18,7 +18,7 @@ defmodule Credo.Check.Readability.RedundantBlankLines do
   def run(%SourceFile{lines: lines} = source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
 
-    max_blank_lines = params |> Params.get(:max_blank_lines, @default_params)
+    max_blank_lines = Params.get(params, :max_blank_lines, @default_params)
 
     lines
     |> blank_lines

--- a/lib/credo/check/readability/variable_names.ex
+++ b/lib/credo/check/readability/variable_names.ex
@@ -50,7 +50,7 @@ defmodule Credo.Check.Readability.VariableNames do
     Enum.reduce(list, issues, &issues_for_lhs(&1, &2, issue_meta))
   end
   defp issues_for_lhs(tuple, issues, issue_meta) when is_tuple(tuple) do
-    Enum.reduce(tuple |> Tuple.to_list, issues, &issues_for_lhs(&1, &2, issue_meta))
+    Enum.reduce(Tuple.to_list(tuple), issues, &issues_for_lhs(&1, &2, issue_meta))
   end
   defp issues_for_lhs(_, issues, _issue_meta) do
     issues
@@ -60,7 +60,7 @@ defmodule Credo.Check.Readability.VariableNames do
     defp issue_for_name({unquote(name), _, nil}, _), do: nil
   end
   defp issue_for_name({name, meta, nil}, issue_meta) do
-    string_name = name |> to_string
+    string_name = to_string(name)
     unless Name.snake_case?(string_name) or Name.no_case?(string_name) do
       issue_for(issue_meta, meta[:line], name)
     end

--- a/lib/credo/check/refactor/abc_size.ex
+++ b/lib/credo/check/refactor/abc_size.ex
@@ -30,7 +30,7 @@ defmodule Credo.Check.Refactor.ABCSize do
 
   def run(%SourceFile{ast: ast} = source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
-    max_abc_size = params |> Params.get(:max_size, @default_params)
+    max_abc_size = Params.get(params, :max_size, @default_params)
 
     Credo.Code.prewalk(ast, &traverse(&1, &2, issue_meta, max_abc_size))
   end
@@ -83,7 +83,7 @@ defmodule Credo.Check.Refactor.ABCSize do
   end
 
   def get_parameters(arguments) do
-    case arguments |> Enum.at(0) do
+    case Enum.at(arguments, 0) do
       {_name, _meta, nil} -> []
       {_name, _meta, parameters} -> Enum.map(parameters, &var_name/1)
     end

--- a/lib/credo/check/refactor/cyclomatic_complexity.ex
+++ b/lib/credo/check/refactor/cyclomatic_complexity.ex
@@ -46,7 +46,7 @@ defmodule Credo.Check.Refactor.CyclomaticComplexity do
 
   def run(%SourceFile{ast: ast} = source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
-    max_complexity = params |> Params.get(:max_complexity, @default_params)
+    max_complexity = Params.get(params, :max_complexity, @default_params)
 
     Credo.Code.prewalk(ast, &traverse(&1, &2, issue_meta, max_complexity))
   end

--- a/lib/credo/check/refactor/function_arity.ex
+++ b/lib/credo/check/refactor/function_arity.ex
@@ -22,8 +22,8 @@ defmodule Credo.Check.Refactor.FunctionArity do
 
   def run(%SourceFile{ast: ast} = source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
-    max_arity = params |> Params.get(:max_arity, @default_params)
-    ignore_defp = params |> Params.get(:ignore_defp, @default_params)
+    max_arity = Params.get(params, :max_arity, @default_params)
+    ignore_defp = Params.get(params, :ignore_defp, @default_params)
 
     Credo.Code.prewalk(ast, &traverse(&1, &2, issue_meta, max_arity, ignore_defp))
   end

--- a/lib/credo/check/refactor/match_in_condition.ex
+++ b/lib/credo/check/refactor/match_in_condition.ex
@@ -50,9 +50,7 @@ defmodule Credo.Check.Refactor.MatchInCondition do
 
   for op <- @condition_ops do
     defp traverse({unquote(op), _meta, arguments} = ast, issues, issue_meta) do
-      condition_arguments =
-        arguments
-        |> Enum.reject(&Keyword.keyword?/1) # remove do/else blocks
+      condition_arguments = Enum.reject(arguments, &Keyword.keyword?/1) # remove do/else blocks
 
       new_issues =
         Credo.Code.prewalk(condition_arguments, &traverse_condition(&1, &2, unquote(op), condition_arguments, issue_meta))
@@ -68,7 +66,7 @@ defmodule Credo.Check.Refactor.MatchInCondition do
     case arguments do
       [{atom, _, nil}, _right] when is_atom(atom) ->
         # this means that the current ast is part of the `if/unless`
-        if op_arguments |> Enum.member?(ast) do
+        if Enum.member?(op_arguments, ast) do
           {ast, issues}
         else
           new_issue = issue_for(op, meta[:line], "=", issue_meta)

--- a/lib/credo/check/refactor/negated_conditions_in_unless.ex
+++ b/lib/credo/check/refactor/negated_conditions_in_unless.ex
@@ -31,7 +31,7 @@ defmodule Credo.Check.Refactor.NegatedConditionsInUnless do
 
   defp traverse({:unless, meta, arguments} = ast, issues, issue_meta) do
     new_issue =
-      issue_for_first_condition(arguments |> List.first, meta, issue_meta)
+      issue_for_first_condition(List.first(arguments), meta, issue_meta)
 
     {ast, issues ++ List.wrap(new_issue)}
   end

--- a/lib/credo/check/refactor/negated_conditions_with_else.ex
+++ b/lib/credo/check/refactor/negated_conditions_with_else.ex
@@ -65,7 +65,7 @@ defmodule Credo.Check.Refactor.NegatedConditionsWithElse do
   end
   # parentheses around the condition wrap it in a __block__
   defp negated_condition?({:__block__, _meta, arguments}) do
-    arguments |> negated_condition?()
+    negated_condition?(arguments)
   end
   defp negated_condition?(_) do
     false

--- a/lib/credo/check/refactor/nesting.ex
+++ b/lib/credo/check/refactor/nesting.ex
@@ -37,7 +37,7 @@ defmodule Credo.Check.Refactor.Nesting do
 
   def run(%SourceFile{ast: ast} = source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
-    max_nesting = params |> Params.get(:max_nesting, @default_params)
+    max_nesting = Params.get(params, :max_nesting, @default_params)
 
     Credo.Code.prewalk(ast, &traverse(&1, &2, issue_meta, max_nesting))
   end

--- a/lib/credo/check/refactor/perceived_complexity.ex
+++ b/lib/credo/check/refactor/perceived_complexity.ex
@@ -46,7 +46,7 @@ defmodule Credo.Check.Refactor.PerceivedComplexity do
 
   def run(%SourceFile{ast: ast} = source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
-    max_complexity = params |> Params.get(:max_complexity, @default_params)
+    max_complexity = Params.get(params, :max_complexity, @default_params)
 
     Credo.Code.prewalk(ast, &traverse(&1, &2, issue_meta, max_complexity))
   end

--- a/lib/credo/check/refactor/pipe_chain_start.ex
+++ b/lib/credo/check/refactor/pipe_chain_start.ex
@@ -10,7 +10,7 @@ defmodule Credo.Check.Refactor.PipeChainStart do
 
   def run(%SourceFile{ast: ast} = source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
-    excluded_functions = params |> Params.get(:excluded_functions, @default_params)
+    excluded_functions = Params.get(params, :excluded_functions, @default_params)
 
 
     Credo.Code.prewalk(ast, &traverse(&1, &2, issue_meta, excluded_functions))
@@ -43,7 +43,7 @@ defmodule Credo.Check.Refactor.PipeChainStart do
   # function_call(with, args) and sigils
   defp valid_chain_start?({atom, _, arguments} = ast, excluded_functions) when is_atom(atom) and is_list(arguments) do
     function_name = to_function_call_name(ast)
-    sigil?(atom) || excluded_functions |> Enum.member?(function_name)
+    sigil?(atom) || Enum.member?(excluded_functions, function_name)
   end
   # map[:access]
   defp valid_chain_start?({{:., _, [Access, :get]}, _, _}, _excluded_functions) do
@@ -54,7 +54,7 @@ defmodule Credo.Check.Refactor.PipeChainStart do
   # Module.function_call(with, parameters)
   defp valid_chain_start?({{:., _, _}, _, _} = ast, excluded_functions) do
     function_name = to_function_call_name(ast)
-    excluded_functions |> Enum.member?(function_name)
+    Enum.member?(excluded_functions, function_name)
   end
   defp valid_chain_start?(_, _excluded_functions), do: true
 

--- a/lib/credo/check/refactor/variable_rebind.ex
+++ b/lib/credo/check/refactor/variable_rebind.ex
@@ -26,8 +26,7 @@ defmodule Credo.Check.Refactor.VariableRebinding do
 
 
     duplicates = 
-      variables
-      |> Enum.filter(fn {key, _} ->
+      Enum.filter(variables, fn {key, _} ->
         Enum.count(variables, fn 
           {other, _} -> key == other
         end) >= 2
@@ -36,8 +35,7 @@ defmodule Credo.Check.Refactor.VariableRebinding do
       |> Enum.uniq_by(&get_variable_name/1)
 
     new_issues = 
-      duplicates
-      |> Enum.map(fn {variable_name, line} ->
+      Enum.map(duplicates, fn {variable_name, line} ->
         issue_for(issue_meta, Atom.to_string(variable_name), line)
       end)
 

--- a/lib/credo/check/runner.ex
+++ b/lib/credo/check/runner.ex
@@ -11,8 +11,7 @@ defmodule Credo.Check.Runner do
 
     {_time_run_on_all, source_files_after_run_on_all} =
       :timer.tc fn ->
-        source_files
-        |> run_checks_that_run_on_all(config)
+        run_checks_that_run_on_all(source_files, config)
       end
 
     #IO.inspect time_run_on_all
@@ -59,8 +58,7 @@ defmodule Credo.Check.Runner do
 
   defp exclude_low_priority_checks(config, below_priority) do
     checks =
-      config.checks
-      |> Enum.reject(fn
+      Enum.reject(config.checks, fn
           ({check}) -> check.base_priority < below_priority
           ({check, _}) -> check.base_priority < below_priority
         end)
@@ -77,13 +75,11 @@ defmodule Credo.Check.Runner do
       end))
     |> Enum.each(&Task.await(&1, :infinity))
 
-    source_files
-    |> SourceFileIssues.update_in_source_files
+    SourceFileIssues.update_in_source_files(source_files)
   end
 
   defp run_checks(%SourceFile{} = source_file, checks, config) when is_list(checks) do
-    checks
-    |> Enum.flat_map(&run_check(&1, source_file, config))
+    Enum.flat_map(checks, &run_check(&1, source_file, config))
   end
 
   defp run_check({_check, false}, source_files, _config) when is_list(source_files) do

--- a/lib/credo/check/warning/name_redeclaration_by_assignment.ex
+++ b/lib/credo/check/warning/name_redeclaration_by_assignment.ex
@@ -81,13 +81,12 @@ defmodule Credo.Check.Warning.NameRedeclarationByAssignment do
     find_issue(lhs, issue_meta, def_names, excluded_names)
   end
   def find_issue({:%{}, _meta2, keywords}, issue_meta, def_names, excluded_names) do
-    keywords
-    |> Enum.map(fn
+    Enum.map(keywords, fn
       {_lhs, rhs} ->
         find_issue(rhs, issue_meta, def_names, excluded_names)
       _ ->
         nil
-      end)
+    end)
   end
   def find_issue({:{}, _meta2, tuple_list}, issue_meta, def_names, excluded_names) do
     find_issue(tuple_list, issue_meta, def_names, excluded_names)
@@ -97,24 +96,23 @@ defmodule Credo.Check.Warning.NameRedeclarationByAssignment do
   end
   def find_issue({name, meta, _}, issue_meta, def_names, excluded_names) when is_atom(name) do
     line_no = meta[:line]
-    def_op = def_names |> find_def_op(name)
+    def_op = find_def_op(def_names, name)
 
     cond do
-      excluded_names |> Enum.member?(name) ->
+      Enum.member?(excluded_names, name) ->
         nil
       def_op ->
         issue_for(issue_meta, line_no, name, message_for_def(def_op))
-      @kernel_fun_names |> Enum.member?(name) ->
+      Enum.member?(@kernel_fun_names, name) ->
         issue_for(issue_meta, line_no, name, "the `Kernel.#{name}` function")
-      @kernel_macro_names |> Enum.member?(name) ->
+      Enum.member?(@kernel_macro_names, name) ->
         issue_for(issue_meta, line_no, name, "the `Kernel.#{name}` macro")
       true ->
         nil
     end
   end
   def find_issue(list, issue_meta, def_names, excluded_names) when is_list(list) do
-    list
-    |> Enum.map(&find_issue(&1, issue_meta, def_names, excluded_names))
+    Enum.map(list, &find_issue(&1, issue_meta, def_names, excluded_names))
   end
   def find_issue(tuple, issue_meta, def_names, excluded_names) when is_tuple(tuple) do
     tuple

--- a/lib/credo/check/warning/name_redeclaration_by_case.ex
+++ b/lib/credo/check/warning/name_redeclaration_by_case.ex
@@ -84,8 +84,7 @@ defmodule Credo.Check.Warning.NameRedeclarationByCase do
     find_issue(lhs, issue_meta, def_names, excluded_names)
   end
   def find_issue({:%{}, _meta2, keywords}, issue_meta, def_names, excluded_names) do
-    keywords
-    |> Enum.map(fn
+    Enum.map(keywords, fn
       {_lhs, rhs} ->
         find_issue(rhs, issue_meta, def_names, excluded_names)
       _ ->
@@ -100,10 +99,9 @@ defmodule Credo.Check.Warning.NameRedeclarationByCase do
   end
   def find_issue({name, meta, _}, issue_meta, def_names, excluded_names) when is_atom(name) do
     def_name_with_op =
-      def_names
-      |> Enum.find(fn({def_name, _op}) -> def_name == name end)
+      Enum.find(def_names, fn({def_name, _op}) -> def_name == name end)
     cond do
-      excluded_names |> Enum.member?(name) ->
+      Enum.member?(excluded_names, name) ->
         nil
       def_name_with_op ->
         what =
@@ -114,17 +112,16 @@ defmodule Credo.Check.Warning.NameRedeclarationByCase do
             _ -> "ERROR"
           end
         issue_for(issue_meta, meta[:line], name, what)
-      @kernel_fun_names |> Enum.member?(name) ->
+      Enum.member?(@kernel_fun_names, name) ->
         issue_for(issue_meta, meta[:line], name, "the `Kernel.#{name}` function")
-      @kernel_macro_names |> Enum.member?(name) ->
+      Enum.member?(@kernel_macro_names, name) ->
         issue_for(issue_meta, meta[:line], name, "the `Kernel.#{name}` macro")
       true ->
         nil
     end
   end
   def find_issue(list, issue_meta, def_names, excluded_names) when is_list(list) do
-    list
-    |> Enum.map(&find_issue(&1, issue_meta, def_names, excluded_names))
+    Enum.map(list, &find_issue(&1, issue_meta, def_names, excluded_names))
   end
   def find_issue(tuple, issue_meta, def_names, excluded_names) when is_tuple(tuple) do
     tuple

--- a/lib/credo/check/warning/name_redeclaration_by_def.ex
+++ b/lib/credo/check/warning/name_redeclaration_by_def.ex
@@ -92,13 +92,12 @@ defmodule Credo.Check.Warning.NameRedeclarationByDef do
     find_issue(lhs, issue_meta, def_names, excluded_names)
   end
   def find_issue({:%{}, _meta2, keywords}, issue_meta, def_names, excluded_names) do
-    keywords
-    |> Enum.map(fn
+    Enum.map(keywords, fn
       {_lhs, rhs} ->
         find_issue(rhs, issue_meta, def_names, excluded_names)
       _ ->
         nil
-      end)
+    end)
   end
   def find_issue({:{}, _meta2, tuple_list}, issue_meta, def_names, excluded_names) do
     find_issue(tuple_list, issue_meta, def_names, excluded_names)
@@ -107,13 +106,11 @@ defmodule Credo.Check.Warning.NameRedeclarationByDef do
     find_issue(map, issue_meta, def_names, excluded_names)
   end
   def find_issue({name, meta, _}, issue_meta, def_names, excluded_names) when is_atom(name) do
-    def_name_with_op =
-      def_names
-      |> Enum.find(fn({def_name, _op}) -> def_name == name end)
+    def_name_with_op = Enum.find(def_names, fn({def_name, _op}) -> def_name == name end)
     cond do
       name |> to_string |> String.match?(@excluded_names_regex) ->
         nil
-      excluded_names |> Enum.member?(name) ->
+      Enum.member?(excluded_names, name) ->
         nil
       def_name_with_op ->
         what =
@@ -124,17 +121,16 @@ defmodule Credo.Check.Warning.NameRedeclarationByDef do
             _ -> "ERROR"
           end
         issue_for(issue_meta, meta[:line], name, what)
-      @kernel_fun_names |> Enum.member?(name) ->
+      Enum.member?(@kernel_fun_names, name) ->
         issue_for(issue_meta, meta[:line], name, "the `Kernel.#{name}` function")
-      @kernel_macro_names |> Enum.member?(name) ->
+      Enum.member?(@kernel_macro_names, name) ->
         issue_for(issue_meta, meta[:line], name, "the `Kernel.#{name}` macro")
       true ->
         nil
     end
   end
   def find_issue(list, issue_meta, def_names, excluded_names) when is_list(list) do
-    list
-    |> Enum.map(&find_issue(&1, issue_meta, def_names, excluded_names))
+    Enum.map(list, &find_issue(&1, issue_meta, def_names, excluded_names))
   end
   def find_issue(tuple, issue_meta, def_names, excluded_names) when is_tuple(tuple) do
     tuple

--- a/lib/credo/check/warning/name_redeclaration_by_fn.ex
+++ b/lib/credo/check/warning/name_redeclaration_by_fn.ex
@@ -80,8 +80,7 @@ defmodule Credo.Check.Warning.NameRedeclarationByFn do
     find_issue(lhs, issue_meta, def_names, excluded_names)
   end
   def find_issue({:%{}, _meta2, keywords}, issue_meta, def_names, excluded_names) do
-    keywords
-    |> Enum.map(fn
+    Enum.map(keywords, fn
       {_lhs, rhs} ->
         find_issue(rhs, issue_meta, def_names, excluded_names)
       _ ->
@@ -96,10 +95,9 @@ defmodule Credo.Check.Warning.NameRedeclarationByFn do
   end
   def find_issue({name, meta, _}, issue_meta, def_names, excluded_names) when is_atom(name) do
     def_name_with_op =
-      def_names
-      |> Enum.find(fn({def_name, _op}) -> def_name == name end)
+      Enum.find(def_names, fn({def_name, _op}) -> def_name == name end)
     cond do
-      excluded_names |> Enum.member?(name) ->
+      Enum.member?(excluded_names, name) ->
         nil
       def_name_with_op ->
         what =
@@ -110,17 +108,16 @@ defmodule Credo.Check.Warning.NameRedeclarationByFn do
             _ -> "ERROR"
           end
         issue_for(issue_meta, meta[:line], name, what)
-      @kernel_fun_names |> Enum.member?(name) ->
+      Enum.member?(@kernel_fun_names, name) ->
         issue_for(issue_meta, meta[:line], name, "the `Kernel.#{name}` function")
-      @kernel_macro_names |> Enum.member?(name) ->
+      Enum.member?(@kernel_macro_names, name) ->
         issue_for(issue_meta, meta[:line], name, "the `Kernel.#{name}` macro")
       true ->
         nil
     end
   end
   def find_issue(list, issue_meta, def_names, excluded_names) when is_list(list) do
-    list
-    |> Enum.map(&find_issue(&1, issue_meta, def_names, excluded_names))
+    Enum.map(list, &find_issue(&1, issue_meta, def_names, excluded_names))
   end
   def find_issue(tuple, issue_meta, def_names, excluded_names) when is_tuple(tuple) do
     tuple

--- a/lib/credo/check/warning/unused_enum_operation.ex
+++ b/lib/credo/check/warning/unused_enum_operation.ex
@@ -50,16 +50,15 @@ defmodule Credo.Check.Warning.UnusedEnumOperation do
         source_file, params, [@checked_module], @funs_with_return_value
       )
 
-    all_unused_calls
-    |> Enum.reduce([], fn(invalid_call, issues) ->
-        {_, meta, _} = invalid_call
-        trigger =
-          invalid_call
-          |> Macro.to_string
-          |> String.split("(")
-          |> List.first
-        issues ++ [issue_for(issue_meta, meta[:line], trigger)]
-      end)
+    Enum.reduce(all_unused_calls, [], fn(invalid_call, issues) ->
+      {_, meta, _} = invalid_call
+      trigger =
+        invalid_call
+        |> Macro.to_string
+        |> String.split("(")
+        |> List.first
+      issues ++ [issue_for(issue_meta, meta[:line], trigger)]
+    end)
   end
 
   defp issue_for(issue_meta, line_no, trigger) do

--- a/lib/credo/check/warning/unused_file_operation.ex
+++ b/lib/credo/check/warning/unused_file_operation.ex
@@ -19,16 +19,15 @@ defmodule Credo.Check.Warning.UnusedFileOperation do
       UnusedFunctionReturnHelper.find_unused_calls(source_file, params,
                                               [@checked_module], @funs_with_return_value)
 
-    all_unused_calls
-    |> Enum.reduce([], fn(invalid_call, issues) ->
-        {_, meta, _} = invalid_call
-        trigger =
-          invalid_call
-          |> Macro.to_string
-          |> String.split("(")
-          |> List.first
-        issues ++ [issue_for(issue_meta, meta[:line], trigger)]
-      end)
+    Enum.reduce(all_unused_calls, [], fn(invalid_call, issues) ->
+      {_, meta, _} = invalid_call
+      trigger =
+        invalid_call
+        |> Macro.to_string
+        |> String.split("(")
+        |> List.first
+      issues ++ [issue_for(issue_meta, meta[:line], trigger)]
+    end)
   end
 
   defp issue_for(issue_meta, line_no, trigger) do

--- a/lib/credo/check/warning/unused_keyword_operation.ex
+++ b/lib/credo/check/warning/unused_keyword_operation.ex
@@ -23,16 +23,15 @@ defmodule Credo.Check.Warning.UnusedKeywordOperation do
       UnusedFunctionReturnHelper.find_unused_calls(source_file, params,
                                                     [@checked_module], nil)
 
-    all_unused_calls
-    |> Enum.reduce([], fn(invalid_call, issues) ->
-        {_, meta, _} = invalid_call
-        trigger =
-          invalid_call
-          |> Macro.to_string
-          |> String.split("(")
-          |> List.first
-        issues ++ [issue_for(issue_meta, meta[:line], trigger)]
-      end)
+    Enum.reduce(all_unused_calls, [], fn(invalid_call, issues) ->
+      {_, meta, _} = invalid_call
+      trigger =
+        invalid_call
+        |> Macro.to_string
+        |> String.split("(")
+        |> List.first
+      issues ++ [issue_for(issue_meta, meta[:line], trigger)]
+    end)
   end
 
   defp issue_for(issue_meta, line_no, trigger) do

--- a/lib/credo/check/warning/unused_list_operation.ex
+++ b/lib/credo/check/warning/unused_list_operation.ex
@@ -23,16 +23,15 @@ defmodule Credo.Check.Warning.UnusedListOperation do
       UnusedFunctionReturnHelper.find_unused_calls(source_file, params,
                                                     [@checked_module], nil)
 
-    all_unused_calls
-    |> Enum.reduce([], fn(invalid_call, issues) ->
-        {_, meta, _} = invalid_call
-        trigger =
-          invalid_call
-          |> Macro.to_string
-          |> String.split("(")
-          |> List.first
-        issues ++ [issue_for(issue_meta, meta[:line], trigger)]
-      end)
+    Enum.reduce(all_unused_calls, [], fn(invalid_call, issues) ->
+      {_, meta, _} = invalid_call
+      trigger =
+        invalid_call
+        |> Macro.to_string
+        |> String.split("(")
+        |> List.first
+      issues ++ [issue_for(issue_meta, meta[:line], trigger)]
+    end)
   end
 
   defp issue_for(issue_meta, line_no, trigger) do

--- a/lib/credo/check/warning/unused_path_operation.ex
+++ b/lib/credo/check/warning/unused_path_operation.ex
@@ -19,16 +19,15 @@ defmodule Credo.Check.Warning.UnusedPathOperation do
       UnusedFunctionReturnHelper.find_unused_calls(source_file, params,
                                               [@checked_module], @funs_with_return_value)
 
-    all_unused_calls
-    |> Enum.reduce([], fn(invalid_call, issues) ->
-        {_, meta, _} = invalid_call
-        trigger =
-          invalid_call
-          |> Macro.to_string
-          |> String.split("(")
-          |> List.first
-        issues ++ [issue_for(issue_meta, meta[:line], trigger)]
-      end)
+    Enum.reduce(all_unused_calls, [], fn(invalid_call, issues) ->
+      {_, meta, _} = invalid_call
+      trigger =
+        invalid_call
+        |> Macro.to_string
+        |> String.split("(")
+        |> List.first
+      issues ++ [issue_for(issue_meta, meta[:line], trigger)]
+    end)
   end
 
   defp issue_for(issue_meta, line_no, trigger) do

--- a/lib/credo/check/warning/unused_regex_operation.ex
+++ b/lib/credo/check/warning/unused_regex_operation.ex
@@ -19,16 +19,15 @@ defmodule Credo.Check.Warning.UnusedRegexOperation do
       UnusedFunctionReturnHelper.find_unused_calls(source_file, params,
                                               [@checked_module], @funs_with_return_value)
 
-    all_unused_calls
-    |> Enum.reduce([], fn(invalid_call, issues) ->
-        {_, meta, _} = invalid_call
-        trigger =
-          invalid_call
-          |> Macro.to_string
-          |> String.split("(")
-          |> List.first
-        issues ++ [issue_for(issue_meta, meta[:line], trigger)]
-      end)
+    Enum.reduce(all_unused_calls, [], fn(invalid_call, issues) ->
+      {_, meta, _} = invalid_call
+      trigger =
+        invalid_call
+        |> Macro.to_string
+        |> String.split("(")
+        |> List.first
+      issues ++ [issue_for(issue_meta, meta[:line], trigger)]
+    end)
   end
 
   defp issue_for(issue_meta, line_no, trigger) do

--- a/lib/credo/check/warning/unused_string_operation.ex
+++ b/lib/credo/check/warning/unused_string_operation.ex
@@ -36,16 +36,15 @@ defmodule Credo.Check.Warning.UnusedStringOperation do
       UnusedFunctionReturnHelper.find_unused_calls(source_file, params,
                                                     [@checked_module], nil)
 
-    all_unused_calls
-    |> Enum.reduce([], fn(invalid_call, issues) ->
-        {_, meta, _} = invalid_call
-        trigger =
-          invalid_call
-          |> Macro.to_string
-          |> String.split("(")
-          |> List.first
-        issues ++ [issue_for(issue_meta, meta[:line], trigger)]
-      end)
+    Enum.reduce(all_unused_calls, [], fn(invalid_call, issues) ->
+      {_, meta, _} = invalid_call
+      trigger =
+        invalid_call
+        |> Macro.to_string
+        |> String.split("(")
+        |> List.first
+      issues ++ [issue_for(issue_meta, meta[:line], trigger)]
+    end)
   end
 
   defp issue_for(issue_meta, line_no, trigger) do

--- a/lib/credo/check/warning/unused_tuple_operation.ex
+++ b/lib/credo/check/warning/unused_tuple_operation.ex
@@ -23,16 +23,15 @@ defmodule Credo.Check.Warning.UnusedTupleOperation do
       UnusedFunctionReturnHelper.find_unused_calls(source_file, params,
                                                     [@checked_module], nil)
 
-    all_unused_calls
-    |> Enum.reduce([], fn(invalid_call, issues) ->
-        {_, meta, _} = invalid_call
-        trigger =
-          invalid_call
-          |> Macro.to_string
-          |> String.split("(")
-          |> List.first
-        issues ++ [issue_for(issue_meta, meta[:line], trigger)]
-      end)
+    Enum.reduce(all_unused_calls, [], fn(invalid_call, issues) ->
+      {_, meta, _} = invalid_call
+      trigger =
+        invalid_call
+        |> Macro.to_string
+        |> String.split("(")
+        |> List.first
+      issues ++ [issue_for(issue_meta, meta[:line], trigger)]
+    end)
   end
 
   defp issue_for(issue_meta, line_no, trigger) do

--- a/lib/credo/check_for_updates.ex
+++ b/lib/credo/check_for_updates.ex
@@ -11,7 +11,7 @@ defmodule Credo.CheckForUpdates do
 
     if should_update?(all_versions, current) do
       latest = latest_version(all_versions, current)
-      [
+      warning = [
         :orange,
         :bright,
         "A new Credo version is available (#{latest})",
@@ -19,7 +19,7 @@ defmodule Credo.CheckForUpdates do
         :orange,
         ", please update with `mix deps.update credo`"
       ]
-      |> warn()
+      warn(warning)
     end
   end
 
@@ -31,8 +31,7 @@ defmodule Credo.CheckForUpdates do
   defp latest_version(all_versions, default) do
     including_pre_versions? = pre_version?(default)
     latest =
-      all_versions
-      |> highest_version(including_pre_versions?)
+      highest_version(all_versions, including_pre_versions?)
 
     latest || default
   end
@@ -41,7 +40,7 @@ defmodule Credo.CheckForUpdates do
     included_versions = if including_pre_versions? do
       versions
     else
-      versions |> Enum.reject(&pre_version?/1)
+      Enum.reject(versions, &pre_version?/1)
     end
 
     List.last(included_versions)
@@ -59,7 +58,7 @@ defmodule Credo.CheckForUpdates do
   defp fetch_all_hex_versions(package_name) do
     case fetch("https://hex.pm/api/packages/#{package_name}") do
       nil -> nil
-      package_info -> package_info |> hex_versions()
+      package_info -> hex_versions(package_info)
     end
   end
 
@@ -85,6 +84,6 @@ defmodule Credo.CheckForUpdates do
 
   defp hex_versions(nil), do: nil
   defp hex_versions(%{"releases" => releases}) do
-    releases |> Enum.map(&(&1["version"]))
+    Enum.map(releases, &(&1["version"]))
   end
 end

--- a/lib/credo/cli.ex
+++ b/lib/credo/cli.ex
@@ -91,7 +91,7 @@ defmodule Credo.CLI do
 
     if config.check_for_updates, do: Credo.CheckForUpdates.run()
 
-    config |> require_requires()
+    require_requires(config)
 
     command_mod.run(dir, config)
   end
@@ -112,12 +112,12 @@ defmodule Credo.CLI do
         nil ->
           {nil, Enum.at(args, 0), args}
         command_name ->
-          {command_name, Enum.at(args, 1), args |> Enum.slice(1..-1)}
+          {command_name, Enum.at(args, 1), Enum.slice(args, 1..-1)}
       end
 
     dir = given_directory || @default_dir
-    switches = switches_kw |> Enum.into(%{})
-    config = dir |> to_config(switches)
+    switches = Enum.into(switches_kw, %{})
+    config = to_config(dir, switches)
 
     command_name_dir_config(command_name, args, config)
   end
@@ -158,5 +158,5 @@ defmodule Credo.CLI do
   end
 
   defp halt_if_failed(0), do: nil
-  defp halt_if_failed(x), do: x |> System.halt
+  defp halt_if_failed(x), do: System.halt(x)
 end

--- a/lib/credo/cli/command/explain.ex
+++ b/lib/credo/cli/command/explain.ex
@@ -35,8 +35,7 @@ defmodule Credo.CLI.Command.Explain do
         |> Enum.partition(&(&1.valid?))
       end
 
-    invalid_source_files
-    |> Output.complain_about_invalid_source_files
+    Output.complain_about_invalid_source_files(invalid_source_files)
 
     {time_load, valid_source_files}
   end
@@ -67,27 +66,26 @@ defmodule Credo.CLI.Command.Explain do
     output = output_mod(config)
     output.print_before_info([source_file], config)
 
-    source_file
-    |> output.print_after_info(config, line_no, column)
+    output.print_after_info(source_file, config, line_no, column)
   end
 
-
   defp print_help do
-    ["Usage: ", :olive, "mix credo explain path_line_no_column [options]"]
-    |> UI.puts
-    """
+    usage = ["Usage: ", :olive, "mix credo explain path_line_no_column [options]"]
+    explain = """
 
     Explain the given issue.
     """
-    |> UI.puts
-    ["Example: ", :olive, :faint, "$ mix credo explain lib/foo/bar.ex:13:6"]
-    |> UI.puts
-    """
+    example = ["Example: ", :olive, :faint, "$ mix credo explain lib/foo/bar.ex:13:6"]
+    options = """
 
     General options:
       -v, --version       Show version
       -h, --help          Show this help
     """
-    |> UI.puts
+
+    UI.puts(usage)
+    UI.puts(explain)
+    UI.puts(example)
+    UI.puts(options)
   end
 end

--- a/lib/credo/cli/command/gen.check.ex
+++ b/lib/credo/cli/command/gen.check.ex
@@ -13,9 +13,9 @@ defmodule Credo.CLI.Command.GenCheck do
   end
 
   defp create_check_file(nil) do
-    [:red, :bright, "Please provide a filename:", "\n\n",
+    output = [:red, :bright, "Please provide a filename:", "\n\n",
       "  mix credo gen.check lib/my_first_credo_check.ex", "\n"]
-    |> Bunt.puts
+    Bunt.puts(output)
   end
   defp create_check_file(filename) do
     check_name = check_name_for(filename)

--- a/lib/credo/cli/command/help.ex
+++ b/lib/credo/cli/command/help.ex
@@ -39,7 +39,7 @@ defmodule Credo.CLI.Command.Help do
     CLI.commands
     |> Sorter.ensure(@starting_order, @ending_order)
     |> Enum.each(fn(name) ->
-      module = name |> CLI.command_for
+      module = CLI.command_for(name)
       name2 = name |> to_string |> String.ljust(@ljust)
       case List.keyfind(module.__info__(:attributes), :shortdoc, 0) do
         {:shortdoc, [shortdesc]} ->
@@ -51,11 +51,11 @@ defmodule Credo.CLI.Command.Help do
 
     UI.puts "\nUse `--help` on any command to get further information."
 
-    [
+    example = [
       "For example, `", :olive, "mix credo suggest --help",
         :reset, "` for help on the default command."
     ]
-    |> UI.puts
+    UI.puts(example)
   end
 
   def color_for("#"), do: [:faint]
@@ -65,7 +65,7 @@ defmodule Credo.CLI.Command.Help do
   def color_for(_), do: [:reset, :white]
 
   def banner do
-"""
+banner = """
 #   ____                    __
 #  /\\  _`\\                 /\\ \\
 #  \\ \\ \\/\\_\\  _ __    __   \\_\\ \\    ___
@@ -74,7 +74,8 @@ defmodule Credo.CLI.Command.Help do
 #     \\ \\____/\\ \\_\\\\ \\____\\ \\___,_\\ \\____/
 #      \\/___/  \\/_/ \\/____/\\/__,_ /\\/___/
 #
-""" |> String.strip
+"""
+    String.strip(banner)
   end
 
 end

--- a/lib/credo/cli/command/help.ex
+++ b/lib/credo/cli/command/help.ex
@@ -65,7 +65,7 @@ defmodule Credo.CLI.Command.Help do
   def color_for(_), do: [:reset, :white]
 
   def banner do
-banner = """
+output = """
 #   ____                    __
 #  /\\  _`\\                 /\\ \\
 #  \\ \\ \\/\\_\\  _ __    __   \\_\\ \\    ___
@@ -75,7 +75,7 @@ banner = """
 #      \\/___/  \\/_/ \\/____/\\/__,_ /\\/___/
 #
 """
-    String.strip(banner)
+    String.strip(output)
   end
 
 end

--- a/lib/credo/cli/command/list.ex
+++ b/lib/credo/cli/command/list.ex
@@ -31,8 +31,7 @@ defmodule Credo.CLI.Command.List do
         |> Enum.partition(&(&1.valid?))
       end
 
-    invalid_source_files
-    |> Output.complain_about_invalid_source_files
+    Output.complain_about_invalid_source_files(invalid_source_files)
 
     {time_load, valid_source_files}
   end
@@ -54,22 +53,21 @@ defmodule Credo.CLI.Command.List do
     output = output_mod(config)
     output.print_before_info(source_files, config)
 
-    source_files
-    |> output.print_after_info(config, time_load, time_run)
+    output.print_after_info(source_files, config, time_load, time_run)
   end
 
 
   defp print_help do
-    ["Usage: ", :olive, "mix credo list [paths] [options]"]
-    |> UI.puts
-    """
+    usage_output = ["Usage: ", :olive, "mix credo list [paths] [options]"]
+    UI.puts(usage_output)
+    list_output = """
 
     Lists objects that Credo thinks can be improved ordered by their priority.
     """
-    |> UI.puts
-    ["Example: ", :olive, :faint, "$ mix credo list lib/**/*.ex --format=oneline"]
-    |> UI.puts
-    """
+    UI.puts(list_output)
+    example_output = ["Example: ", :olive, :faint, "$ mix credo list lib/**/*.ex --format=oneline"]
+    UI.puts(example_output)
+    config_output = """
 
     Arrows (↑ ↗ → ↘ ↓) hint at the importance of an issue.
 
@@ -85,6 +83,6 @@ defmodule Credo.CLI.Command.List do
       -v, --version         Show version
       -h, --help            Show this help
     """
-    |> UI.puts
+    UI.puts(config_output)
   end
 end

--- a/lib/credo/cli/command/suggest.ex
+++ b/lib/credo/cli/command/suggest.ex
@@ -42,8 +42,7 @@ defmodule Credo.CLI.Command.Suggest do
         |> Enum.partition(&(&1.valid?))
       end
 
-    invalid_source_files
-    |> Output.complain_about_invalid_source_files
+    Output.complain_about_invalid_source_files(invalid_source_files)
 
     {time_load, valid_source_files}
   end
@@ -64,21 +63,17 @@ defmodule Credo.CLI.Command.Suggest do
   defp print_results_and_summary(source_files, config, time_load, time_run) do
     out = output_mod(config)
 
-    source_files
-    |> out.print_after_info(config, time_load, time_run)
+    out.print_after_info(source_files, config, time_load, time_run)
   end
 
   defp print_help do
-    ["Usage: ", :olive, "mix credo suggest [paths] [options]"]
-    |> UI.puts
-    """
+    usage = ["Usage: ", :olive, "mix credo suggest [paths] [options]"]
+    suggestions = """
 
     Suggests objects from every category that Credo thinks can be improved.
     """
-    |> UI.puts
-    ["Example: ", :olive, :faint, "$ mix credo suggest lib/**/*.ex --all -c names"]
-    |> UI.puts
-    """
+    command = ["Example: ", :olive, :faint, "$ mix credo suggest lib/**/*.ex --all -c names"]
+    arrows = """
 
     Arrows (↑ ↗ → ↘ ↓) hint at the importance of an issue.
 
@@ -94,6 +89,9 @@ defmodule Credo.CLI.Command.Suggest do
       -v, --version         Show version
       -h, --help            Show this help
     """
-    |> UI.puts
+    UI.puts(usage)
+    UI.puts(suggestions)
+    UI.puts(command)
+    UI.puts(arrows)
   end
 end

--- a/lib/credo/cli/filter.ex
+++ b/lib/credo/cli/filter.ex
@@ -4,29 +4,25 @@ defmodule Credo.CLI.Filter do
   alias Credo.Check.LintAttribute
 
   def important(list, config) when is_list(list) do
-    list
-    |> Enum.filter(&important?(&1, config))
+    Enum.filter(list, &important?(&1, config))
   end
 
   def important?(%Issue{} = issue, config) do
     issue.priority >= config.min_priority
   end
   def important?(%SourceFile{} = source_file, config) do
-    source_file.issues
-    |> Enum.any?(&important?(&1, config))
+    Enum.any?(source_file.issues, &important?(&1, config))
   end
 
 
   def valid_issues(list, config) when is_list(list) do
-    list
-    |> Enum.reject(&ignored?(&1, config))
+    Enum.reject(list, &ignored?(&1, config))
   end
 
   def ignored?(%Issue{} = issue, config) do
     case config.lint_attribute_map[issue.filename] do
       list when is_list(list) ->
-        list
-        |> Enum.any?(&(LintAttribute.ignores_issue?(&1, issue)))
+        Enum.any?(list, &(LintAttribute.ignores_issue?(&1, issue)))
       _ ->
         false
     end

--- a/lib/credo/cli/output.ex
+++ b/lib/credo/cli/output.ex
@@ -86,15 +86,15 @@ defmodule Credo.CLI.Output do
   def complain_about_invalid_source_files([]), do: nil
   def complain_about_invalid_source_files(invalid_source_files) do
     invalid_source_filenames = Enum.map(invalid_source_files, &(&1.filename))
-    [
+    output = [
       :red, "Some source files could not be parsed correctly and are excluded:\n",
     ]
-    |> UI.puts
+    UI.puts(output)
 
     invalid_source_filenames
     |> Enum.with_index
     |> Enum.flat_map(fn({filename, index}) ->
-        [:reset, "#{index+1})" |> String.rjust(5), :faint, " #{filename}\n"]
+        [:reset, String.rjust("#{index+1})", 5), :faint, " #{filename}\n"]
       end)
     |> UI.puts
   end

--- a/lib/credo/cli/output/categories.ex
+++ b/lib/credo/cli/output/categories.ex
@@ -44,22 +44,21 @@ defmodule Credo.CLI.Output.Categories do
   ]
 
   def print do
-    @order
-    |> Enum.each(&print_category/1)
+    Enum.each(@order, &print_category/1)
   end
 
   defp print_category(category) do
     term_width = Output.term_columns
     color = @category_colors[category]
     title = @category_titles[category]
+    output = [
+      :bright, String.to_atom("#{color}_background"), color, " ",
+      Output.foreground_color(color), :normal,
+      String.ljust(" #{title}", term_width - 1),
+    ]
 
     UI.puts
-    [
-      :bright, "#{color}_background" |> String.to_atom, color, " ",
-        Output.foreground_color(color), :normal,
-      " #{title}" |> String.ljust(term_width - 1),
-    ]
-    |> UI.puts
+    UI.puts(output)
 
     color
     |> UI.edge
@@ -71,8 +70,8 @@ defmodule Credo.CLI.Output.Categories do
   end
 
   defp print_line(line, color) do
-    [UI.edge(color), " ", :reset, line]
-    |> UI.puts
+    output = [UI.edge(color), " ", :reset, line]
+    UI.puts(output)
   end
 
 end

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -97,7 +97,7 @@ defmodule Credo.CLI.Output.Explain do
         inner_color,
         tag_style,
         "   ",
-        priority |> Output.priority_arrow,
+        Output.priority_arrow(priority),
         :reset, "  Priority: #{Output.priority_name(priority)} "
     ]
     UI.puts(priority_output)
@@ -115,7 +115,7 @@ defmodule Credo.CLI.Output.Explain do
 
     scope_output = [
       UI.edge(outer_color, @indent),
-        filename_color, :faint, filename |> to_string,
+        filename_color, :faint, to_string(filename),
         :default_color, :faint, pos,
         :faint, " (#{issue.scope})"
     ]
@@ -202,7 +202,7 @@ defmodule Credo.CLI.Output.Explain do
   def format_explanation(line, outer_color) do
     [
       UI.edge([outer_color, :faint], @indent),
-      :reset, line |> format_explanation_text,
+      :reset, format_explanation_text(line),
       "\n"
     ]
   end
@@ -264,7 +264,7 @@ defmodule Credo.CLI.Output.Explain do
         output = [
           UI.edge([outer_color, :faint]), :reset,
             String.duplicate(" ", @indent-2),
-            :cyan, "  #{param}:" |> String.ljust(20),
+            :cyan, String.ljust("  #{param}:", 20),
             :reset, text
         ]
         UI.puts(output)

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -49,7 +49,7 @@ defmodule Credo.CLI.Output.Explain do
     output = [
       :bright, String.to_atom("#{color}_background" ), color, " ",
         Output.foreground_color(color), :normal,
-      " #{scope_name}" |> String.ljust(term_width - 1),
+      String.ljust(" #{scope_name}", term_width - 1),
     ]
 
     UI.puts

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -47,7 +47,7 @@ defmodule Credo.CLI.Output.Explain do
     scope_name = Scope.mod_name(first_issue.scope)
     color = Output.check_color(first_issue)
     output = [
-      :bright, String.to_atom("#{color}_background" ), color, " ",
+      :bright, String.to_atom("#{color}_background"), color, " ",
         Output.foreground_color(color), :normal,
       String.ljust(" #{scope_name}", term_width - 1),
     ]

--- a/lib/credo/cli/output/issue_helper.ex
+++ b/lib/credo/cli/output/issue_helper.ex
@@ -24,8 +24,8 @@ defmodule Credo.CLI.Output.IssueHelper do
 
     output = [
       inner_color,
-      Output.check_tag(check.category), " ", priority |> Output.priority_arrow, " ",
-      :reset, filename_color, :faint, filename |> to_string,
+      Output.check_tag(check.category), " ", Output.priority_arrow(priority), " ",
+      :reset, filename_color, :faint, to_string(filename),
       :default_color, :faint, Filename.pos_suffix(issue.line_no, issue.column),
       :reset, message_color,  " ", message,
     ]
@@ -44,7 +44,7 @@ defmodule Credo.CLI.Output.IssueHelper do
 
     output = [
       UI.edge(outer_color, @indent),
-        filename_color, :faint, filename |> to_string,
+        filename_color, :faint, to_string(filename),
         :default_color, :faint, Filename.pos_suffix(issue.line_no, issue.column),
         :faint, " (#{issue.scope})"
     ]
@@ -62,7 +62,7 @@ defmodule Credo.CLI.Output.IssueHelper do
       UI.edge(outer_color),
         outer_color,
         tag_style,
-        Output.check_tag(check.category), " ", priority |> Output.priority_arrow,
+        Output.check_tag(check.category), " ", Output.priority_arrow(priority),
         :normal, message_color, " ", first_line,
     ]
     UI.puts(output)

--- a/lib/credo/cli/output/issue_helper.ex
+++ b/lib/credo/cli/output/issue_helper.ex
@@ -11,10 +11,10 @@ defmodule Credo.CLI.Output.IssueHelper do
                     %Config{format: "flycheck"} = _config, _term_width) do
     tag = Output.check_tag(issue, false)
 
-    [
-      filename |> to_string, Filename.pos_suffix(issue.line_no, issue.column), ": ", tag, ": ", message,
+    output = [
+      to_string(filename), Filename.pos_suffix(issue.line_no, issue.column), ": ", tag, ": ", message,
     ]
-    |> UI.puts
+    UI.puts(output)
   end
   def print_issue(%Issue{check: check, message: message, filename: filename, priority: priority} = issue, _source_file,
                     %Config{format: "oneline"} = _config, _term_width) do
@@ -22,14 +22,14 @@ defmodule Credo.CLI.Output.IssueHelper do
     message_color  = inner_color
     filename_color = :default_color
 
-    [
+    output = [
       inner_color,
       Output.check_tag(check.category), " ", priority |> Output.priority_arrow, " ",
       :reset, filename_color, :faint, filename |> to_string,
       :default_color, :faint, Filename.pos_suffix(issue.line_no, issue.column),
       :reset, message_color,  " ", message,
     ]
-    |> UI.puts
+    UI.puts(output)
   end
   def print_issue(%Issue{check: check, message: message, filename: filename, priority: priority} = issue, source_file, %Config{format: _} = config, term_width) do
     outer_color = Output.check_color(issue)
@@ -42,13 +42,13 @@ defmodule Credo.CLI.Output.IssueHelper do
     |> UI.wrap_at(term_width - @indent)
     |> print_issue_message(check, outer_color, message_color, tag_style, priority)
 
-    [
+    output = [
       UI.edge(outer_color, @indent),
         filename_color, :faint, filename |> to_string,
         :default_color, :faint, Filename.pos_suffix(issue.line_no, issue.column),
         :faint, " (#{issue.scope})"
     ]
-    |> UI.puts
+    UI.puts(output)
 
     if config.verbose do
       print_issue_line(issue, source_file, inner_color, outer_color, term_width)
@@ -58,28 +58,27 @@ defmodule Credo.CLI.Output.IssueHelper do
   end
 
   defp print_issue_message([first_line | other_lines], check, outer_color, message_color, tag_style, priority) do
-    [
+    output = [
       UI.edge(outer_color),
         outer_color,
         tag_style,
         Output.check_tag(check.category), " ", priority |> Output.priority_arrow,
         :normal, message_color, " ", first_line,
     ]
-    |> UI.puts
+    UI.puts(output)
 
-    other_lines
-    |> Enum.each(&print_issue_message(&1, outer_color, message_color))
+    Enum.each(other_lines, &print_issue_message(&1, outer_color, message_color))
   end
   defp print_issue_message("", _outer_color, _message_color) do
   end
   defp print_issue_message(message, outer_color, message_color) do
-    [
+    output = [
       UI.edge(outer_color),
         outer_color,
         String.duplicate(" ", @indent - 3),
         :normal, message_color, " ", message,
     ]
-    |> UI.puts
+    UI.puts(output)
   end
 
   defp print_issue_line(%Issue{line_no: nil}, _source_file, _inner_color, _outer_color, _term_width) do
@@ -87,18 +86,18 @@ defmodule Credo.CLI.Output.IssueHelper do
   end
   defp print_issue_line(%Issue{} = issue, source_file, inner_color, outer_color, term_width) do
     {_, raw_line} = Enum.at(source_file.lines, issue.line_no - 1)
-    line = raw_line |> String.strip
+    line = String.strip(raw_line)
 
     [outer_color, :faint]
     |> UI.edge
     |> UI.puts
 
-    [
+    output = [
       UI.edge([outer_color, :faint]), :cyan, :faint,
         String.duplicate(" ", @indent-2),
         UI.truncate(line, term_width - @indent)
     ]
-    |> UI.puts
+    UI.puts(output)
 
     print_issue_trigger_marker(issue, raw_line, inner_color, outer_color)
   end
@@ -115,11 +114,11 @@ defmodule Credo.CLI.Output.IssueHelper do
         atom -> atom |> to_string |> String.length
       end
 
-    [
+    output = [
       UI.edge([outer_color, :faint], @indent),
         inner_color, String.duplicate(" ", x),
         :faint, String.duplicate("^", w)
     ]
-    |> UI.puts
+    UI.puts(output)
   end
 end

--- a/lib/credo/cli/output/issues_by_scope.ex
+++ b/lib/credo/cli/output/issues_by_scope.ex
@@ -45,7 +45,7 @@ defmodule Credo.CLI.Output.IssuesByScope do
       scope_name = Scope.mod_name(first_issue.scope)
       color = Output.check_color(first_issue)
       output = [
-        :bright, String.to_atom("#{color}_background" ), color, " ",
+        :bright, String.to_atom("#{color}_background"), color, " ",
           Output.foreground_color(color), :normal,
         String.ljust(" #{scope_name}", term_width - 1),
       ]

--- a/lib/credo/cli/output/issues_grouped_by_category.ex
+++ b/lib/credo/cli/output/issues_grouped_by_category.ex
@@ -52,7 +52,7 @@ defmodule Credo.CLI.Output.IssuesGroupedByCategory do
   def print_after_info(source_files, config, time_load, time_run) do
     term_width = Output.term_columns
 
-    issues = source_files |> Enum.flat_map(&(&1.issues))
+    issues = Enum.flat_map(source_files, &(&1.issues))
     shown_issues =
       issues
       |> Filter.important(config)
@@ -66,7 +66,7 @@ defmodule Credo.CLI.Output.IssuesGroupedByCategory do
     issue_map =
       categories
       |> Enum.map(fn(category) ->
-          {category, shown_issues |> Enum.filter(&(&1.category == category))}
+          {category, Enum.filter(shown_issues, &(&1.category == category))}
         end)
       |> Enum.into(%{})
 
@@ -81,8 +81,7 @@ defmodule Credo.CLI.Output.IssuesGroupedByCategory do
         print_issues(category, issue_map[category], source_file_map, config, term_width)
       end)
 
-    source_files
-    |> Summary.print(config, time_load, time_run)
+    Summary.print(source_files, config, time_load, time_run)
   end
 
   defp print_issues(_category, nil, _source_file_map, _config, _term_width) do
@@ -100,12 +99,12 @@ defmodule Credo.CLI.Output.IssuesGroupedByCategory do
 
     UI.puts
 
-    [
-      :bright, "#{color}_background" |> String.to_atom, color, " ",
+    title_output = [
+      :bright, String.to_atom("#{color}_background"), color, " ",
         Output.foreground_color(color), :normal,
-      " #{title}" |> String.ljust(term_width - 1),
+      String.ljust(" #{title}", term_width - 1),
     ]
-    |> UI.puts
+    UI.puts(title_output)
 
     color
     |> UI.edge
@@ -116,8 +115,8 @@ defmodule Credo.CLI.Output.IssuesGroupedByCategory do
     if Enum.count(issues) > per_category(config) do
       not_shown = Enum.count(issues) - per_category(config)
 
-      [UI.edge(color), :faint, " ...  (#{not_shown} more, use `-a` to show them)"]
-      |> UI.puts
+      not_shown_output = [UI.edge(color), :faint, " ...  (#{not_shown} more, use `-a` to show them)"]
+      UI.puts(not_shown_output)
     end
   end
 
@@ -125,7 +124,7 @@ defmodule Credo.CLI.Output.IssuesGroupedByCategory do
     issues
     |> Enum.sort_by(fn(issue) -> {issue.priority, issue.severity} end)
     |> Enum.reverse
-    |> Enum.take(config |> per_category)
+    |> Enum.take(per_category(config))
     |> Enum.each(&print_issue(&1, source_file_map, config, term_width))
   end
 

--- a/lib/credo/cli/output/issues_short_list.ex
+++ b/lib/credo/cli/output/issues_short_list.ex
@@ -44,15 +44,15 @@ defmodule Credo.CLI.Output.IssuesShortList do
     message_color  = inner_color
     filename_color = :default_color
 
-    [
+    output = [
       inner_color,
       check_tag_style(outer_color, inner_color),
-      Output.check_tag(check.category), " ", priority |> Output.priority_arrow, " ",
-      :reset, filename_color, :faint, filename |> to_string,
+      Output.check_tag(check.category), " ", Output.priority_arrow(priority), " ",
+      :reset, filename_color, :faint, to_string(filename),
       :default_color, :faint, Filename.pos_suffix(issue.line_no, issue.column),
       :reset, message_color,  " ", message,
     ]
-    |> UI.puts
+    UI.puts(output)
   end
 
   defp check_tag_style(a, a), do: :faint

--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -41,17 +41,17 @@ defmodule Credo.CLI.Output.Summary do
     # print_badge(source_files, issues)
     UI.puts
 
-    shown_issues |> print_priority_hint(config)
+    print_priority_hint(shown_issues, config)
   end
 
   def print_priority_hint([], %Config{min_priority: min_priority}) when min_priority >= 0 do
-    "Use `--strict` to show all issues, `--help` for options."
-    |> UI.puts(:faint)
+    hint = "Use `--strict` to show all issues, `--help` for options."
+    UI.puts(hint, :faint)
   end
   def print_priority_hint([], _config), do: nil
   def print_priority_hint(_, %Config{min_priority: min_priority}) when min_priority >= 0 do
-    "Showing priority issues: ↑ ↗ →  (use `--strict` to show all issues, `--help` for options)."
-    |> UI.puts(:faint)
+    hint = "Showing priority issues: ↑ ↗ →  (use `--strict` to show all issues, `--help` for options)."
+    UI.puts(hint, :faint)
   end
   def print_priority_hint(_, _config), do: nil
 
@@ -59,9 +59,7 @@ defmodule Credo.CLI.Output.Summary do
   def print_badge(source_files, issues) do
     scopes = scope_count(source_files)
 
-    parts =
-      @category_wording
-      |> Enum.map(fn({category, _, _}) -> category_count(issues, category) end)
+    parts = Enum.map(@category_wording, fn({category, _, _}) -> category_count(issues, category) end)
 
     parts = [scopes] ++ parts
     sum = Enum.sum(parts)
@@ -78,19 +76,18 @@ defmodule Credo.CLI.Output.Summary do
             if index == 0 do
               :green
             else
-              {category, _, _} = @category_wording |> Enum.at(index - 1)
+              {category, _, _} = Enum.at(@category_wording, index - 1)
               Output.check_color(category)
             end
           [color, String.duplicate("=", round(quota * width))]
         end)
 
-    [bar]
-    |> UI.puts
+    UI.puts([bar])
   end
 
   defp format_time_spent(time_load, time_run) do
-    time_run  = time_run |> div(10_000)
-    time_load = time_load |> div(10_000)
+    time_run  = div(time_run, 10_000)
+    time_load = div(time_load, 10_000)
 
     formatted_total = format_in_seconds(time_run + time_load)
     total_in_seconds =
@@ -124,12 +121,10 @@ defmodule Credo.CLI.Output.Summary do
   end
 
   defp summary_parts(source_files, issues) do
-    parts =
-      @category_wording
-      |> Enum.flat_map(&summary_part(&1, issues))
+    parts = Enum.flat_map(@category_wording, &summary_part(&1, issues))
 
     parts =
-      parts |> List.update_at(Enum.count(parts) - 1, fn(last_part) ->
+      List.update_at(parts, Enum.count(parts) - 1, fn(last_part) ->
         String.replace(last_part, ", ", "")
        end)
 

--- a/lib/credo/cli/output/ui.ex
+++ b/lib/credo/cli/output/ui.ex
@@ -4,7 +4,7 @@ defmodule Credo.CLI.Output.UI do
   @ellipsis "…"
 
   def edge(color, indent \\ 2) when is_integer(indent) do
-    [:reset, color, @edge |> String.ljust(indent)]
+    [:reset, color, String.ljust(@edge, indent)]
   end
 
   defdelegate puts, to: Bunt

--- a/lib/credo/cli/sorter.ex
+++ b/lib/credo/cli/sorter.ex
@@ -6,12 +6,12 @@ defmodule Credo.CLI.Sorter do
   end
 
   def to_start(list, list_start) do
-    list_start = list_start |> Enum.filter(&(Enum.member?(list, &1)))
+    list_start = Enum.filter(list_start, &(Enum.member?(list, &1)))
     list_start ++ (list -- list_start)
   end
 
   def to_end(list, list_end) do
-    list_end = list_end |> Enum.filter(&(Enum.member?(list, &1)))
+    list_end = Enum.filter(list_end, &(Enum.member?(list, &1)))
     (list -- list_end) ++ list_end
   end
 end

--- a/lib/credo/cli/switches.ex
+++ b/lib/credo/cli/switches.ex
@@ -33,12 +33,12 @@ defmodule Credo.CLI.Switches do
     set_strict(config, %{strict: true})
   end
   defp set_strict(config, %{strict: true}) do
-    %Config{config | strict: true}
-    |> Config.set_strict()
+    new_config = %Config{config | strict: true}
+    Config.set_strict(new_config)
   end
   defp set_strict(config, %{strict: false}) do
-    %Config{config | strict: false}
-    |> Config.set_strict()
+    new_config = %Config{config | strict: false}
+    Config.set_strict(new_config)
   end
   defp set_strict(config, _), do: config
   defp set_help(config, %{help: true}) do
@@ -81,8 +81,8 @@ defmodule Credo.CLI.Switches do
     set_only(config, %{checks: only})
   end
   defp set_only(config, %{checks: check_pattern}) do
-    %Config{config | strict: true, match_checks: check_pattern |> String.split(",")}
-    |> Config.set_strict()
+    new_config = %Config{config | strict: true, match_checks: String.split(check_pattern, ",")}
+    Config.set_strict(new_config)
   end
   defp set_only(config, _), do: config
 
@@ -91,7 +91,7 @@ defmodule Credo.CLI.Switches do
     set_ignore(config, %{ignore_checks: ignore})
   end
   defp set_ignore(config, %{ignore_checks: ignore_pattern}) do
-    %Config{config | ignore_checks: ignore_pattern |> String.split(",")}
+    %Config{config | ignore_checks: String.split(ignore_pattern, ",")}
   end
   defp set_ignore(config, _), do: config
 

--- a/lib/credo/code/block.ex
+++ b/lib/credo/code/block.ex
@@ -9,10 +9,10 @@ defmodule Credo.Code.Block do
   """
   def all_blocks_for!(ast) do
     [
-      ast |> do_block_for!,
-      ast |> else_block_for!,
-      ast |> rescue_block_for!,
-      ast |> after_block_for!,
+      do_block_for!(ast),
+      else_block_for!(ast),
+      rescue_block_for!(ast),
+      after_block_for!(ast),
     ]
   end
 
@@ -46,8 +46,7 @@ defmodule Credo.Code.Block do
     {:ok, block}
   end
   def do_block_for(arguments) when is_list(arguments) do
-    arguments
-    |> Enum.find_value(&find_keyword(&1, :do))
+    Enum.find_value(arguments, &find_keyword(&1, :do))
   end
   def do_block_for(_) do
     nil
@@ -85,8 +84,7 @@ defmodule Credo.Code.Block do
     {:ok, else_block}
   end
   def else_block_for(arguments) when is_list(arguments) do
-    arguments
-    |> Enum.find_value(&find_keyword(&1, :else))
+    Enum.find_value(arguments, &find_keyword(&1, :else))
   end
   def else_block_for(_) do
     nil
@@ -125,8 +123,7 @@ defmodule Credo.Code.Block do
     {:ok, rescue_block}
   end
   def rescue_block_for(arguments) when is_list(arguments) do
-    arguments
-    |> Enum.find_value(&find_keyword(&1, :rescue))
+    Enum.find_value(arguments, &find_keyword(&1, :rescue))
   end
   def rescue_block_for(_) do
     nil
@@ -165,8 +162,7 @@ defmodule Credo.Code.Block do
     {:ok, after_block}
   end
   def after_block_for(arguments) when is_list(arguments) do
-    arguments
-    |> Enum.find_value(&find_keyword(&1, :after))
+    Enum.find_value(arguments, &find_keyword(&1, :after))
   end
   def after_block_for(_) do
     nil

--- a/lib/credo/code/module.ex
+++ b/lib/credo/code/module.ex
@@ -27,8 +27,7 @@ defmodule Credo.Code.Module do
 
   def defs(nil), do: []
   def defs({:defmodule, _, _arguments} = ast) do
-    ast
-    |> Code.postwalk(&traverse_mod/2)
+    Code.postwalk(ast, &traverse_mod/2)
   end
 
   @doc "Returns the arity of the given function definition `ast`"
@@ -57,11 +56,11 @@ defmodule Credo.Code.Module do
   @doc "Returns the {fun_name, op} tuple of the function/macro defined in the given `ast`"
   for op <- @def_ops do
     def def_name_with_op({unquote(op) = op, _, _} = ast) do
-      {ast |> def_name, op}
+      {def_name(ast), op}
     end
     def def_name_with_op({unquote(op) = op, _, _} = ast, arity) do
-      if ast |> def_arity() == arity do
-        {ast |> def_name, op}
+      if def_arity(ast) == arity do
+        {def_name(ast), op}
       else
         nil
       end
@@ -123,10 +122,9 @@ defmodule Credo.Code.Module do
   # Multi alias
   defp find_aliases({:alias, _, [{{:., _, [{:__aliases__, _, mod_list}, :{}]}, _, multi_mod_list}]} = ast, aliases) do
     module_names =
-      multi_mod_list
-      |> Enum.map(fn(tuple) ->
-          [Credo.Code.Name.full(mod_list), Credo.Code.Name.full(tuple)] |> Credo.Code.Name.full
-        end)
+      Enum.map(multi_mod_list, fn(tuple) ->
+        [Credo.Code.Name.full(mod_list), Credo.Code.Name.full(tuple)] |> Credo.Code.Name.full
+      end)
 
     {ast, aliases ++ module_names}
   end
@@ -135,7 +133,7 @@ defmodule Credo.Code.Module do
   end
 
   defp find_attribute({:@, _meta, arguments} = ast, tuple, attribute_name) do
-    case arguments |> List.first do
+    case List.first(arguments) do
       {^attribute_name, _meta, [value]} -> {:ok, value}
       _ -> {ast, tuple}
     end
@@ -157,10 +155,9 @@ defmodule Credo.Code.Module do
   # multi alias
   defp find_dependent_modules({:alias, _, [{{:., _, [{:__aliases__, _, mod_list}, :{}]}, _, multi_mod_list}]} = ast, modules) do
     module_names =
-      multi_mod_list
-      |> Enum.flat_map(fn(tuple) ->
-          [Credo.Code.Name.full(mod_list), Credo.Code.Name.full(tuple)]
-        end)
+      Enum.flat_map(multi_mod_list, fn(tuple) ->
+        [Credo.Code.Name.full(mod_list), Credo.Code.Name.full(tuple)]
+      end)
 
     {ast, modules -- module_names}
   end

--- a/lib/credo/code/module.ex
+++ b/lib/credo/code/module.ex
@@ -123,7 +123,7 @@ defmodule Credo.Code.Module do
   defp find_aliases({:alias, _, [{{:., _, [{:__aliases__, _, mod_list}, :{}]}, _, multi_mod_list}]} = ast, aliases) do
     module_names =
       Enum.map(multi_mod_list, fn(tuple) ->
-        [Credo.Code.Name.full(mod_list), Credo.Code.Name.full(tuple)] |> Credo.Code.Name.full
+        Credo.Code.Name.full([Credo.Code.Name.full(mod_list), Credo.Code.Name.full(tuple)])
       end)
 
     {ast, aliases ++ module_names}

--- a/lib/credo/code/name.ex
+++ b/lib/credo/code/name.ex
@@ -27,7 +27,7 @@ defmodule Credo.Code.Name do
   end
 
   def full({:__aliases__, _, mod_list}) do
-    mod_list |> full
+    full(mod_list)
   end
   def full(mod_list) when is_list(mod_list) do
     mod_list
@@ -35,7 +35,7 @@ defmodule Credo.Code.Name do
     |> Enum.join(".")
   end
   def full({name, _, nil}) when is_atom(name) do
-    name |> full
+    full(name)
   end
   def full(name) when is_atom(name) do
     name
@@ -54,7 +54,7 @@ defmodule Credo.Code.Name do
   end
 
   def pascal_case?(name) do
-    name |> String.match?(~r/^[A-Z][a-zA-Z0-9]*$/)
+    String.match?(name, ~r/^[A-Z][a-zA-Z0-9]*$/)
   end
 
   def split_pascal_case(name) do
@@ -62,11 +62,11 @@ defmodule Credo.Code.Name do
   end
 
   def snake_case?(name) do
-    name |> String.match?(~r/^[a-z0-9\_\?\!]+$/)
+    String.match?(name, ~r/^[a-z0-9\_\?\!]+$/)
   end
 
   def no_case?(name) do
-    name |> String.match?(~r/^[^a-zA-Z0-9]+$/)
+    String.match?(name, ~r/^[^a-zA-Z0-9]+$/)
   end
 
   defp name_from_splitted_parts(splitted_parts) when length(splitted_parts) > 1 do
@@ -75,7 +75,6 @@ defmodule Credo.Code.Name do
     |> Enum.join(".")
   end
   defp name_from_splitted_parts(splitted_parts) do
-    splitted_parts
-    |> Enum.join(".")
+    Enum.join(splitted_parts, ".")
   end
 end

--- a/lib/credo/code/parameters.ex
+++ b/lib/credo/code/parameters.ex
@@ -10,9 +10,9 @@ defmodule Credo.Code.Parameters do
   def count(nil), do: 0
   for op <- @def_ops do
     def count({unquote(op), _, arguments}) when is_list(arguments) do
-      case arguments |> List.first do
+      case List.first(arguments) do
         {_atom, _meta, nil} -> 0
-        {_atom, _meta, list} -> list |> Enum.count
+        {_atom, _meta, list} -> Enum.count(list)
         _ -> 0
       end
     end
@@ -38,7 +38,7 @@ defmodule Credo.Code.Parameters do
   end
 
   defp get_param_name({:::, _, [var, _type]}) do
-    var |> get_param_name
+    get_param_name(var)
   end
   defp get_param_name({:<<>>, _, arguments}) do
     arguments
@@ -51,16 +51,13 @@ defmodule Credo.Code.Parameters do
     |> Enum.reject(&is_nil/1)
   end
   defp get_param_name({:%, _, [{:__aliases__, _meta, _mod_list}, {:%{}, _meta2, arguments}]}) do
-    arguments
-    |> get_param_name
+    get_param_name(arguments)
   end
   defp get_param_name({:%{}, _, arguments}) do
-    arguments
-    |> get_param_name
+    get_param_name(arguments)
   end
   defp get_param_name({:\\, _, arguments}) do
-    arguments
-    |> Enum.find_value(&get_param_name/1)
+    Enum.find_value(arguments, &get_param_name/1)
   end
   defp get_param_name(list) when is_list(list) do
     list

--- a/lib/credo/code/scope.ex
+++ b/lib/credo/code/scope.ex
@@ -12,7 +12,7 @@ defmodule Credo.Code.Scope do
 
   def mod_name(nil), do: nil
   def mod_name(scope_name) do
-    names = scope_name |> String.split(".")
+    names = String.split(scope_name, ".")
     if names |> List.last |> String.match?(~r/^[a-z]/) do
       names |> Enum.slice(0..length(names) - 2) |> Enum.join(".")
     else
@@ -51,8 +51,7 @@ defmodule Credo.Code.Scope do
     find_scope(arguments, line, name_list, last_op)
   end
   defp find_scope(list, line, name_list, last_op) when is_list(list) do
-    list
-    |> Enum.find_value(&find_scope(&1, line, name_list, last_op))
+    Enum.find_value(list, &find_scope(&1, line, name_list, last_op))
   end
   defp find_scope({:defmodule, meta, [{:__aliases__, _, module_name}, arguments]}, line, name_list, _last_op) do
     name_list = name_list ++ module_name

--- a/lib/credo/code/sigils.ex
+++ b/lib/credo/code/sigils.ex
@@ -1,19 +1,19 @@
 defmodule Credo.Code.Sigils do
   @moduledoc """
-  This module let's you strip sigils from source code.
+  This module lets you strip sigils from source code.
   """
 
   @sigil_delimiters [{"(", ")"}, {"[", "]"}, {"{", "}"}, {"<", ">"},
                       {"|", "|"}, {"/", "/"}, {"\"\"\"", "\"\"\""}, {"\"", "\""}, {"'", "'"}]
-  @all_sigil_chars  ~w(a b c d e f g h i j k l m n o p q r s t u v w x y z)
-                    |> Enum.flat_map(fn a -> [a, a |> String.upcase] end)
-  @all_sigil_starts @all_sigil_chars |> Enum.map(fn c -> "~#{c}" end)
-  @removable_sigils @sigil_delimiters
-                    |> Enum.flat_map(fn({b, e}) ->
-                        Enum.flat_map(@all_sigil_starts, fn(start) ->
-                          [{"#{start}#{b}", e}, {"#{start}#{b}", e}]
-                        end)
+  @all_sigil_chars Enum.flat_map(~w(a b c d e f g h i j k l m n o p q r s t u v w x y z), fn a ->
+                     [a, String.upcase(a)]
+                   end)
+  @all_sigil_starts Enum.map(@all_sigil_chars, fn c -> "~#{c}" end)
+  @removable_sigils Enum.flat_map(@sigil_delimiters, fn({b, e}) ->
+                      Enum.flat_map(@all_sigil_starts, fn(start) ->
+                        [{"#{start}#{b}", e}, {"#{start}#{b}", e}]
                       end)
+                    end)
 
   @doc """
   Replaces all characters inside all sigils with the equivalent amount of
@@ -47,7 +47,7 @@ defmodule Credo.Code.Sigils do
     parse_code(t, acc <> <<h :: utf8>>, replacement)
   end
   defp parse_code(str, acc, replacement) when is_binary(str) do
-    {h, t} = str |> String.next_codepoint
+    {h, t} = String.next_codepoint(str)
     parse_code(t, acc <> h, replacement)
   end
 
@@ -67,7 +67,7 @@ defmodule Credo.Code.Sigils do
     parse_string_literal(t, acc <> "\n", replacement)
   end
   defp parse_string_literal(str, acc, replacement) when is_binary(str) do
-    {h, t} = str |> String.next_codepoint
+    {h, t} = String.next_codepoint(str)
     parse_string_literal(t, acc <> h, replacement)
   end
 
@@ -108,7 +108,7 @@ defmodule Credo.Code.Sigils do
     parse_heredoc(t, acc <> "\n", replacement)
   end
   defp parse_heredoc(str, acc, replacement) when is_binary(str) do
-    {h, t} = str |> String.next_codepoint
+    {h, t} = String.next_codepoint(str)
     parse_heredoc(t, acc <> h, replacement)
   end
 end

--- a/lib/credo/code/strings.ex
+++ b/lib/credo/code/strings.ex
@@ -5,7 +5,7 @@ defmodule Credo.Code.Strings do
 
   @sigil_delimiters [{"(", ")"}, {"[", "]"}, {"{", "}"}, {"<", ">"},
                       {"|", "|"}, {"\"", "\""}, {"'", "'"}]
-  @all_string_sigils @sigil_delimiters |> Enum.flat_map(fn({b, e}) -> [{"~s#{b}", e}, {"~S#{b}", e}] end)
+  @all_string_sigils Enum.flat_map(@sigil_delimiters, fn({b, e}) -> [{"~s#{b}", e}, {"~S#{b}", e}] end)
 
   @doc """
   Replaces all characters inside string literals and string sigils
@@ -39,7 +39,7 @@ defmodule Credo.Code.Strings do
     parse_code(t, acc <> <<h :: utf8>>, replacement)
   end
   defp parse_code(str, acc, replacement) when is_binary(str) do
-    {h, t} = str |> String.next_codepoint
+    {h, t} = String.next_codepoint(str)
     parse_code(t, acc <> h, replacement)
   end
 

--- a/lib/credo/config.ex
+++ b/lib/credo/config.ex
@@ -52,16 +52,14 @@ defmodule Credo.Config do
       |> List.first
       |> to_string
 
-    regexes
-    |> Enum.any?(&Regex.run(&1, check_name))
+    Enum.any?(regexes, &Regex.run(&1, check_name))
   end
 
   defp to_match_regexes(list) do
-    list
-    |> Enum.map(fn(match_check) ->
-        {:ok, match_pattern} = Regex.compile(match_check, "i")
-        match_pattern
-      end)
+    Enum.map(list, fn(match_check) ->
+      {:ok, match_pattern} = Regex.compile(match_check, "i")
+      match_pattern
+    end)
   end
 
   @doc """
@@ -176,8 +174,8 @@ defmodule Credo.Config do
   The `checks:` field is merged.
   """
   def merge(list) when is_list(list) do
-    base = list |> List.first
-    tail = list |> List.delete_at(0)
+    base = List.first(list)
+    tail = List.delete_at(list, 0)
     merge(tail, base)
   end
   def merge([], config), do: config
@@ -208,8 +206,7 @@ defmodule Credo.Config do
 
   defp normalize_check_tuples(nil), do: []
   defp normalize_check_tuples(list) when is_list(list) do
-    list
-    |> Enum.map(&normalize_check_tuple/1)
+    Enum.map(list, &normalize_check_tuple/1)
   end
 
   defp normalize_check_tuple({name}), do: {name, []}

--- a/lib/credo/exs_loader.ex
+++ b/lib/credo/exs_loader.ex
@@ -29,14 +29,12 @@ defmodule Credo.ExsLoader do
   end
 
   defp process_exs({:sigil_w, _, [{:<<>>, _, [list_as_string]}, []]}) do
-    list_as_string
-    |> String.split(~r/\s+/)
+    String.split(list_as_string, ~r/\s+/)
   end
 
   # TODO: support regex modifiers
   defp process_exs({:sigil_r, _, [{:<<>>, _, [regex_as_string]}, []]}) do
-    regex_as_string
-    |> Regex.compile!
+    Regex.compile!(regex_as_string)
   end
 
   defp process_exs({:%{}, _meta, body}) do

--- a/lib/credo/priority.ex
+++ b/lib/credo/priority.ex
@@ -14,24 +14,20 @@ defmodule Credo.Priority do
 
   def scope_priorities(%SourceFile{} = source_file) do
     empty_priorities =
-      1..length(source_file.lines)
-      |> Enum.map(fn(_) -> [] end)
+      Enum.map(1..length(source_file.lines), fn(_) -> [] end)
 
     priority_list =
-      source_file
-      |> Credo.Code.prewalk(&traverse/2, empty_priorities)
+      Credo.Code.prewalk(source_file, &traverse/2, empty_priorities)
 
     base_map =
-      priority_list
-      |> make_base_map(source_file)
+      make_base_map(priority_list, source_file)
 
     lookup =
-      base_map
-      |> Enum.into(%{})
+      Enum.into(base_map, %{})
 
     base_map
     |> Enum.map(fn({scope_name, prio}) ->
-        names = scope_name |> String.split(".")
+        names = String.split(scope_name, ".")
         if names |> List.last |> String.match?(~r/^[a-z]/) do
           mod_name = names |> Enum.slice(0..length(names) - 2) |> Enum.join(".")
           mod_prio = lookup[mod_name]

--- a/lib/credo/service/source_file_issues.ex
+++ b/lib/credo/service/source_file_issues.ex
@@ -32,14 +32,14 @@ defmodule Credo.Service.SourceFileIssues do
   end
 
   def handle_call({:append, filename, issue}, _from, current_state) do
-    issues = current_state[filename] |> List.wrap
+    issues = List.wrap(current_state[filename])
     new_issue_list = [issue] ++ issues
-    new_current_state = current_state |> Map.put(filename, new_issue_list)
+    new_current_state = Map.put(current_state, filename, new_issue_list)
 
     {:reply, new_issue_list, new_current_state}
   end
 
   def handle_call({:get, filename}, _from, current_state) do
-    {:reply, current_state[filename] |> List.wrap, current_state}
+    {:reply, List.wrap(current_state[filename]), current_state}
   end
 end

--- a/lib/credo/source_file.ex
+++ b/lib/credo/source_file.ex
@@ -10,11 +10,12 @@ defmodule Credo.SourceFile do
   @type t :: module
 
   def parse(source, filename) do
-    %Credo.SourceFile{
-      filename: filename |> Path.relative_to_cwd(),
+    source_file = %Credo.SourceFile{
+      filename: Path.relative_to_cwd(filename),
       source:   source,
-      lines:    source |> Credo.Code.to_lines,
-    } |> with_ast
+      lines:    Credo.Code.to_lines(source),
+    }
+    with_ast(source_file)
   end
 
   @doc """
@@ -50,7 +51,7 @@ defmodule Credo.SourceFile do
     case Regex.run(~r/\b#{regexed}\b/, line, return: :index) do
       nil -> nil
       result ->
-        {col, _} = result |> List.first
+        {col, _} = List.first(result)
         col + 1
     end
   end

--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -29,11 +29,10 @@ defmodule Credo.Sources do
     |> Enum.map(&to_source_file/1)
   end
   def find(paths) when is_list(paths) do
-    paths
-    |> Enum.flat_map(&find/1)
+    Enum.flat_map(paths, &find/1)
   end
   def find(path) when is_binary(path) do
-    path |> recurse_path()
+    recurse_path(path)
   end
 
   defp include(files, []), do: files
@@ -79,7 +78,7 @@ defmodule Credo.Sources do
           |> Enum.flat_map(&recurse_path/1)
       end
 
-    paths |> Enum.map(&Path.expand/1)
+    Enum.map(paths, &Path.expand/1)
   end
 
   defp to_source_file(filename) do
@@ -89,8 +88,7 @@ defmodule Credo.Sources do
   end
 
   defp source_file_from_stdin(filename) do
-    read_from_stdin!()
-    |> SourceFile.parse(filename)
+    SourceFile.parse(read_from_stdin(), filename)
   end
 
   defp read_from_stdin! do


### PR DESCRIPTION
I wanted to do a little refactoring to see how much of a difference the new
single pipe rule would make, and it turns out that a) we were using that
_everywhere_, and b) it actually makes the code a lot easier to reason about.
I think it's a great rule!

This commit doesn't remove _all_ of the single pipe instances since I figured
doing that in one huge PR might be overwhelming, but it's a step in the right
direction. If it would be helpful to have all of them removed in one PR then
I'm happy to do that!