### PR TITLE
Add check for prefering implicit `try`

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -77,6 +77,7 @@
         {Credo.Check.Readability.TrailingBlankLine},
         {Credo.Check.Readability.TrailingWhiteSpace},
         {Credo.Check.Readability.VariableNames},
+        {Credo.Check.Readability.PreferImplictTry},
         {Credo.Check.Refactor.DoubleBooleanNegation},
 
         {Credo.Check.Refactor.ABCSize},

--- a/lib/credo/check/readability/prefer_implicit_try.ex
+++ b/lib/credo/check/readability/prefer_implicit_try.ex
@@ -1,0 +1,50 @@
+defmodule Credo.Check.Readability.PreferImplicitTry do
+  @moduledoc """
+We don't need to explicity use `try` in function definitions. For example, this:
+
+defmodule ModuleWithRescue do
+  def failing_function(first) do
+    try do
+      to_string(first)
+    rescue
+      _ -> :rescued
+    end
+  end
+end
+
+Could be rewritten without `try` as below:
+
+defmodule ModuleWithRescue do
+  def failing_function(first) do
+    to_string(first)
+  rescue
+    _ -> :rescued
+  end
+end
+"""
+
+  @explanation [check: @moduledoc]
+
+  use Credo.Check, base_priority: :low
+
+  def run(%SourceFile{} = source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse({:try, [line: line_no], _} = ast, issues, issue_meta) do
+    {ast, issues ++ [issue_for(issue_meta, line_no)]}
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue issue_meta,
+      message: "Prefer using an implicit `try` rather than explicit `try`",
+      trigger: "implicit_try",
+      line_no: line_no
+  end
+end

--- a/lib/credo/check/readability/prefer_implicit_try.ex
+++ b/lib/credo/check/readability/prefer_implicit_try.ex
@@ -37,30 +37,8 @@ end
     {ast, issues ++ [issue_for(issue_meta, line_no)]}
   end
 
-  defp traverse({:def, _, [{_, _, _}, [do: {:__block__, _, function_body}]]} = ast, issues, issue_meta) do
-    process_function_body(function_body, ast, issues, issue_meta)
-  end
-
-  defp traverse({:def, _, [{_, _, _}, function_body]} = ast, issues, issue_meta) do
-    process_function_body(function_body, ast, issues, issue_meta)
-  end
-
   defp traverse(ast, issues, _issue_meta) do
     {ast, issues}
-  end
-
-  defp process_function_body(function_body, ast, issues, issue_meta) do
-    found = Enum.find(function_body, fn
-      ({:try, _, _}) -> true
-      (_) -> false
-    end)
-
-    if is_nil(found) do
-      {ast, issues }
-    else
-      {:try, [line: line_no], _} = found
-      {ast, issues ++ [issue_for(issue_meta, line_no)]}
-    end
   end
 
   defp issue_for(issue_meta, line_no) do

--- a/test/credo/check/readability/prefer_implicit_try_test.exs
+++ b/test/credo/check/readability/prefer_implicit_try_test.exs
@@ -1,0 +1,33 @@
+defmodule Credo.Check.Readability.PreferImplicitTryTest do
+  use Credo.TestHelper
+
+  @described_check Credo.Check.Readability.PreferImplicitTry
+
+  test "it should NOT report expected code" do
+"""
+defmodule ModuleWithImplicitTry do
+  def failing_function(first) do
+    to_string(first)
+  rescue
+    _ -> :rescued
+  end
+end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  test "it should report a violation" do
+"""
+defmodule ModuleWithExplicitTry do
+   def failing_function(first) do
+     try do
+       to_string(first)
+      rescue
+        _ -> :rescued
+     end
+   end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+end

--- a/test/credo/check/readability/prefer_implicit_try_test.exs
+++ b/test/credo/check/readability/prefer_implicit_try_test.exs
@@ -30,4 +30,43 @@ end
 """ |> to_source_file
     |> assert_issue(@described_check)
   end
+
+  test "it should report a violation where try isn't first" do
+"""
+defmodule ModuleWithExplicitTry do
+   def failing_function(first) do
+     a = to_atom(first)
+
+     try do
+       to_string(first)
+      rescue
+        _ -> :rescued
+     end
+
+     [a, first]
+   end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should NOT report a violation in cases where we need `try`" do
+"""
+defmodule ModuleWithExplicitTry do
+   def failing_function(first) do
+     other_function()
+
+     str = try do
+       to_string(first)
+      rescue
+        _ -> "rescued" 
+     end
+
+     to_atom(string)
+   end
+end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
 end

--- a/test/credo/check/readability/prefer_implicit_try_test.exs
+++ b/test/credo/check/readability/prefer_implicit_try_test.exs
@@ -3,7 +3,22 @@ defmodule Credo.Check.Readability.PreferImplicitTryTest do
 
   @described_check Credo.Check.Readability.PreferImplicitTry
 
-  test "it should NOT report expected code" do
+  test "it should report cases where a `try` block is the entire body of the function" do
+"""
+defmodule ModuleWithExplicitTry do
+   def failing_function(first) do
+     try do
+       to_string(first)
+     rescue
+        _ -> :rescued
+     end
+   end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should NOT report implicit use of `try`" do
 """
 defmodule ModuleWithImplicitTry do
   def failing_function(first) do
@@ -16,51 +31,18 @@ end
     |> refute_issues(@described_check)
   end
 
-  test "it should report a violation" do
-"""
-defmodule ModuleWithExplicitTry do
-   def failing_function(first) do
-     try do
-       to_string(first)
-      rescue
-        _ -> :rescued
-     end
-   end
-end
-""" |> to_source_file
-    |> assert_issue(@described_check)
-  end
-
-  test "it should report a violation where try isn't first" do
-"""
-defmodule ModuleWithExplicitTry do
-   def failing_function(first) do
-     a = to_atom(first)
-
-     try do
-       to_string(first)
-      rescue
-        _ -> :rescued
-     end
-
-     [a, first]
-   end
-end
-""" |> to_source_file
-    |> assert_issue(@described_check)
-  end
-
   test "it should NOT report a violation in cases where we need `try`" do
 """
 defmodule ModuleWithExplicitTry do
    def failing_function(first) do
      other_function()
 
-     str = try do
-       to_string(first)
-      rescue
-        _ -> "rescued" 
-     end
+     str =
+       try do
+         to_string(first)
+       rescue
+           _ -> "rescued" 
+       end
 
      to_atom(string)
    end


### PR DESCRIPTION
We don't need to explicitly use `try` inside function definitions, and this
check will raise low priority issues when `try` is explicitly used.

Closes #224 