### PR TITLE
Fix `prefer_implicit_try` check

### DIFF
--- a/lib/credo/check/readability/prefer_implicit_try.ex
+++ b/lib/credo/check/readability/prefer_implicit_try.ex
@@ -27,6 +27,8 @@ defmodule Credo.Check.Readability.PreferImplicitTry do
 
   @explanation [check: @moduledoc]
 
+  @def_ops [:def, :defp]
+
   use Credo.Check, base_priority: :low
 
   def run(%SourceFile{} = source_file, params \\ []) do
@@ -35,8 +37,10 @@ defmodule Credo.Check.Readability.PreferImplicitTry do
     Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
   end
 
-  defp traverse({:def, _, [{_, _, _}, [do: {:try, [line: line_no], _}]]} = ast, issues, issue_meta) do
-    {ast, issues ++ [issue_for(issue_meta, line_no)]}
+  for op <- @def_ops do
+    defp traverse({unquote(op), _, [{_, _, _}, [do: {:try, [line: line_no], _}]]} = ast, issues, issue_meta) do
+      {ast, issues ++ [issue_for(issue_meta, line_no)]}
+    end
   end
 
   defp traverse(ast, issues, _issue_meta) do

--- a/lib/credo/check/readability/prefer_implicit_try.ex
+++ b/lib/credo/check/readability/prefer_implicit_try.ex
@@ -27,7 +27,7 @@ defmodule Credo.Check.Readability.PreferImplicitTry do
 
   @explanation [check: @moduledoc]
 
-  @def_ops [:def, :defp]
+  @def_ops [:def, :defp, :defmacro]
 
   use Credo.Check, base_priority: :low
 

--- a/test/credo/check/readability/prefer_implicit_try_test.exs
+++ b/test/credo/check/readability/prefer_implicit_try_test.exs
@@ -74,4 +74,19 @@ end
     |> assert_issue(@described_check)
   end
 
+  test "it should report cases where a `try` block is the entire body of macro definition" do
+"""
+defmodule ModuleWithExplicitTry do
+  defmacro failing_function(first) do
+    try do
+      to_string(unquote(first))
+    rescue
+      _ -> :rescued
+    end
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
 end

--- a/test/credo/check/readability/prefer_implicit_try_test.exs
+++ b/test/credo/check/readability/prefer_implicit_try_test.exs
@@ -59,4 +59,19 @@ end
     |> assert_issue(@described_check)
   end
 
+  test "it should report cases where a `try` block is the entire body of a private function" do
+"""
+defmodule ModuleWithExplicitTry do
+  defp failing_function(first) do
+    try do
+      to_string(first)
+    rescue
+      _ -> :rescued
+    end
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
 end


### PR DESCRIPTION
I realized that the implementation that I had for the
`PreferImplicitTry` check was incomplete and wouldn't raise an issue
when used in private functions. That's been added here, as well as a
test to cover that additional case.