### PR TITLE
Add missing type specification check for functions

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -73,6 +73,7 @@
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
+        {Credo.Check.Readability.MissingTypespecs, priority: :low},
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc},
         {Credo.Check.Readability.ModuleNames},

--- a/lib/credo/check/readability/missing_typespecs.ex
+++ b/lib/credo/check/readability/missing_typespecs.ex
@@ -1,0 +1,58 @@
+defmodule Credo.Check.Readability.MissingTypespecs do
+  @moduledoc """
+  Functions, callbacks and macros need typespecs.
+
+  Adding typespecs allows tools like dialyzer to perform success typing on
+  functions. Without a spec functions and macros are ignored by the type
+  checker.
+
+      @spec add(integer, integer) :: integer
+      def add(a, b), do: a + b
+
+  Functions with multiple arities need to have a spec defined for each arity:
+
+      @spec foo(integer) :: boolean
+      @spec foo(integer, integer) :: boolean
+      def foo(a), do: a > 0
+      def foo(a, b), do: a > b
+
+  The check only considers whether the specification is present, it doesn't
+  perform any actual type checking.
+  """
+
+  @explanation [check: @moduledoc]
+
+  use Credo.Check
+
+  def run(%SourceFile{} = source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+    spec_names = Credo.Code.prewalk(source_file, &find_specs(&1, &2))
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, spec_names, issue_meta))
+  end
+
+  defp find_specs({:spec, _, [{_, _, [{name, _, args} | _]}]} = ast, specs) do
+    {ast, [{name, length(args)} | specs]}
+  end
+  defp find_specs(ast, issues) do
+    {ast, issues}
+  end
+
+  defp traverse({:def, meta, [{name, _, args} | _]} = ast, issues, specs, issue_meta) do
+    if {name, length(args)} in specs do
+      {ast, issues}
+    else
+      {ast, [issue_for(issue_meta, meta[:line], name) | issues]}
+    end
+  end
+  defp traverse(ast, issues, _specs, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue issue_meta,
+      message: "Functions should have a @spec type specification",
+      trigger: trigger,
+      line_no: line_no
+  end
+end

--- a/test/credo/check/readability/missing_typespecs_test.exs
+++ b/test/credo/check/readability/missing_typespecs_test.exs
@@ -1,0 +1,44 @@
+defmodule Credo.Check.Readability.MissingTypespecsTest do
+  use Credo.TestHelper
+
+  @described_check Credo.Check.Readability.MissingTypespecs
+
+  test "it should NOT report functions with specs" do
+    """
+    defmodule CredoTypespecTest do
+      @spec foo(integer, integer) :: integer
+      def foo(a, b), do: a + b
+    end
+    """ |> to_source_file()
+        |> refute_issues(@described_check)
+  end
+
+  test "it should NOT report private functions" do
+    """
+    defmodule CredoTypespecTest do
+      defp foo(a, b), do: a + b
+    end
+    """ |> to_source_file()
+        |> refute_issues(@described_check)
+  end
+
+  test "it should report functions without specs" do
+    """
+    defmodule CredoTypespecTest do
+      def foo(a, b), do: a + b
+    end
+    """ |> to_source_file()
+        |> assert_issue(@described_check)
+  end
+
+  test "it should report specs with mismatched arity" do
+    """
+    defmodule CredoTypespecTest do
+      @spec foo(integer) :: integer
+      def foo(a), do: a
+      def foo(a, b), do: a + b
+    end
+    """ |> to_source_file()
+        |> assert_issue(@described_check)
+  end
+end


### PR DESCRIPTION
The `MissingTypespecs` readability check compares specs against definitions using the name and the arity. This implementation only checks for specs on `def` and ignores `defp`. Based on a brief survey of core elixir projects it seems rather common to skip typespecs for `defp`, though it could be configurable very easily.

Due to the presence of the function name right in the spec this was _vastly_ easier to work with than `@doc` tags.

This addresses #205 