### PR TITLE
Fix regex matching tags and improvements.

### DIFF
--- a/lib/credo/check/design/tag_helper.ex
+++ b/lib/credo/check/design/tag_helper.ex
@@ -4,7 +4,7 @@ defmodule Credo.Check.Design.TagHelper do
   alias Credo.Check.CodeHelper
 
   def tags(source, tag_name) do
-    {:ok, regex} = Regex.compile("[^\?]?#\s*#{tag_name}:?\s*.+", "i")
+    {:ok, regex} = Regex.compile("(\A|[^\?])#\s*#{tag_name}:?\s*.+", "i")
 
     source
     |> CodeHelper.clean_strings_and_sigils

--- a/lib/credo/check/design/tag_helper.ex
+++ b/lib/credo/check/design/tag_helper.ex
@@ -4,7 +4,7 @@ defmodule Credo.Check.Design.TagHelper do
   alias Credo.Check.CodeHelper
 
   def tags(source, tag_name) do
-    {:ok, regex} = Regex.compile("[^\?]# #{tag_name}:? .+", "i")
+    {:ok, regex} = Regex.compile("#\s*#{tag_name}:?\s*.+", "i")
 
     source
     |> CodeHelper.clean_strings_and_sigils

--- a/lib/credo/check/design/tag_helper.ex
+++ b/lib/credo/check/design/tag_helper.ex
@@ -4,7 +4,7 @@ defmodule Credo.Check.Design.TagHelper do
   alias Credo.Check.CodeHelper
 
   def tags(source, tag_name) do
-    {:ok, regex} = Regex.compile("#\s*#{tag_name}:?\s*.+", "i")
+    {:ok, regex} = Regex.compile("[^\?]?#\s*#{tag_name}:?\s*.+", "i")
 
     source
     |> CodeHelper.clean_strings_and_sigils

--- a/test/credo/check/design/tag_todo_test.exs
+++ b/test/credo/check/design/tag_todo_test.exs
@@ -39,6 +39,48 @@ end
     |> assert_issue(@described_check)
   end
 
+  test "it should report an issue when not indented" do
+"""
+defmodule CredoSampleModule do
+  use ExUnit.Case # FIXME: this should not appear in the TODO test
+
+# TODO: this should appear
+
+  def some_fun do
+    assert x == x + 2
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report an issue when no spaces" do
+"""
+defmodule CredoSampleModule do
+  #TODO: this should appear
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report an issue with more spaces after #" do
+"""
+defmodule CredoSampleModule do
+  #       TODO: this should appear
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report an issue with more spaces after tag" do
+"""
+defmodule CredoSampleModule do
+  # TODO:         this should appear
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
   test "it should report an issue at the end of a line w/o space" do
 """
 defmodule CredoSampleModule do


### PR DESCRIPTION
I have found a regex bug matching tags: not indented lines were not correctly matched.
I took the opportunity to improve the same regex with more flexible patterns (spaces between # and tag, spaces between tag and the rest of the line).

Thanks.
