### PR TITLE
WIP - Fixing the low priority exclusion

### DIFF
--- a/lib/credo/check/runner.ex
+++ b/lib/credo/check/runner.ex
@@ -66,7 +66,8 @@ defmodule Credo.Check.Runner do
     checks =
       Enum.reject(config.checks, fn
         ({check}) -> check.base_priority < below_priority
-        ({check, _}) -> check.base_priority < below_priority
+        ({check, opts}) ->
+          (opts[:priority] || check.base_priority) < below_priority
       end)
 
     %Config{config | checks: checks}


### PR DESCRIPTION
Before this, the decision to execute or not the check was based only on the
`base_priority`, but we should read from the user config to decide this kind of
thing.