### PR TITLE
fix issue with --help

### DIFF
--- a/lib/credo/cli/command/explain.ex
+++ b/lib/credo/cli/command/explain.ex
@@ -89,5 +89,7 @@ defmodule Credo.CLI.Command.Explain do
     UI.puts(description)
     UI.puts(example)
     UI.puts(options)
+
+    :ok
   end
 end

--- a/lib/credo/cli/command/help.ex
+++ b/lib/credo/cli/command/help.ex
@@ -61,6 +61,8 @@ defmodule Credo.CLI.Command.Help do
       ]
 
     UI.puts(example)
+
+    :ok
   end
 
   def color_for("#"), do: [:faint]

--- a/lib/credo/cli/command/list.ex
+++ b/lib/credo/cli/command/list.ex
@@ -99,5 +99,7 @@ defmodule Credo.CLI.Command.List do
     UI.puts(description)
     UI.puts(example)
     UI.puts(options)
+
+    :ok
   end
 end

--- a/lib/credo/cli/command/suggest.ex
+++ b/lib/credo/cli/command/suggest.ex
@@ -100,5 +100,7 @@ defmodule Credo.CLI.Command.Suggest do
     UI.puts(description)
     UI.puts(example)
     UI.puts(options)
+
+    :ok
   end
 end


### PR DESCRIPTION
Looking quickly, this has done a fix and I looked around and saw similar approach so hopefully its the right thing to do.

This fixes the following error happening on current master (https://github.com/rrrene/credo/commit/917ea4c416577754d070b0356208d7fa7aa2c5ae)
```shell
mix credo explain --help
Usage: mix credo explain path_line_no_column [options]

Explain the given issue.

Example: $ mix credo explain lib/foo/bar.ex:13:6

General options:
  -v, --version       Show version
  -h, --help          Show this help

** (FunctionClauseError) no function clause matching in Credo.CLI.to_exit_status/1
    lib/credo/cli.ex:157: Credo.CLI.to_exit_status(nil)
    lib/credo/cli.ex:61: Credo.CLI.main/1
    (mix) lib/mix/task.ex:294: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
    (elixir) lib/code.ex:370: Code.require_file/2
```