### PR TITLE
Add doctests for Credo.CLI.Filename

### DIFF
--- a/lib/credo/cli/filename.ex
+++ b/lib/credo/cli/filename.ex
@@ -4,13 +4,13 @@ defmodule Credo.CLI.Filename do
   @doc """
   Returns `true` if a given `filename` contains a pos_suffix.
 
-      iex> contains_line_no?("lib/credo/sources.ex:39:8")
+      iex> Credo.CLI.Filename.contains_line_no?("lib/credo/sources.ex:39:8")
       true
 
-      iex> contains_line_no?("lib/credo/sources.ex:39")
+      iex> Credo.CLI.Filename.contains_line_no?("lib/credo/sources.ex:39")
       true
 
-      iex> contains_line_no?("lib/credo/sources.ex")
+      iex> Credo.CLI.Filename.contains_line_no?("lib/credo/sources.ex")
       false
   """
   def contains_line_no?(filename) do
@@ -25,10 +25,10 @@ defmodule Credo.CLI.Filename do
   @doc """
   Returns a suffix for a filename, which contains a line and column value.
 
-      iex> pos_suffix(39, 8)
+      iex> Credo.CLI.Filename.pos_suffix(39, 8)
       ":39:8"
 
-      iex> pos_suffix(39, nil)
+      iex> Credo.CLI.Filename.pos_suffix(39, nil)
       ":39"
 
   These are used in this way: lib/credo/sources.ex:39:8
@@ -40,7 +40,7 @@ defmodule Credo.CLI.Filename do
   @doc """
   Removes the pos_suffix for a filename.
 
-      iex> remove_line_no_and_column("lib/credo/sources.ex:39:8")
+      iex> Credo.CLI.Filename.remove_line_no_and_column("lib/credo/sources.ex:39:8")
       "lib/credo/sources.ex"
   """
   def remove_line_no_and_column(filename) do
@@ -52,6 +52,9 @@ defmodule Credo.CLI.Filename do
 
   @doc """
   Adds a pos_suffix to a filename.
+
+      iex> Credo.CLI.Filename.with("test/file.exs", %{:line_no => 1, :column => 2})
+      "test/file.exs:1:2"
   """
   def with(filename, params) do
     filename <> pos_suffix(params[:line_no], params[:column])

--- a/test/credo/cli/filename_test.exs
+++ b/test/credo/cli/filename_test.exs
@@ -1,0 +1,4 @@
+defmodule Credo.CLI.FilenameTest do
+  use ExUnit.Case
+  doctest Credo.CLI.Filename
+end


### PR DESCRIPTION
I noticed a while back that there are some functions that were untested
in the CLI part of the app, and I wanted to double back to add some
tests there. I noticed that some doctests had already been written for
`Credo.CLI.Filename`, so I decided to just run with that and turn the
doctests on for that module as part of the test suite.