### PR TITLE
Fix the typespec check when guards are present.

### DIFF
--- a/lib/credo/check/readability/specs.ex
+++ b/lib/credo/check/readability/specs.ex
@@ -39,6 +39,9 @@ defmodule Credo.Check.Readability.Specs do
     {ast, issues}
   end
 
+  defp traverse({:def, meta, [{:when, _, def_ast} |_ ]}, issues, specs, issue_meta) do
+    traverse({:def, meta, def_ast}, issues, specs, issue_meta)
+  end
   defp traverse({:def, meta, [{name, _, args} | _]} = ast, issues, specs, issue_meta) when is_list(args) do
     if {name, length(args)} in specs do
       {ast, issues}

--- a/lib/credo/check/runner.ex
+++ b/lib/credo/check/runner.ex
@@ -66,6 +66,7 @@ defmodule Credo.Check.Runner do
     checks =
       Enum.reject(config.checks, fn
         ({check}) -> check.base_priority < below_priority
+        ({check, false}) -> true
         ({check, opts}) ->
           (opts[:priority] || check.base_priority) < below_priority
       end)


### PR DESCRIPTION
The current implementation of the type spec check will not properly detect if a typespec is defined against a function which has a guard clause.

Example:

```elixir
def get_foo(bar) when is_map(bar) do
  bar[:foo]
end
```

This PR fixes that.