### PR TITLE
Allow exclusion of file patterns per check

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ This also works for umbrella projects, where you can have individual `.credo.exs
         # Put `false` as second element:
         {Credo.Check.Design.TagFIXME, false},
 
+        # You can also excluded specific pattern for specific check
+        # Put `false` as second element:
+        {Credo.Check.Warning.IExPry, excluded: ~[^test/]},
+
         # ... several checks omitted for readability ...
       ]
     }


### PR DESCRIPTION
Not sure if this is something you are interested in. I find it useful to have different criteria for test files and the rest of the code. This comes from my usage of credo as a linter during development and not just before code commits.