### PR TITLE
Added more documentation for readability checks

### DIFF
--- a/lib/credo/check/readability/trailing_blank_line.ex
+++ b/lib/credo/check/readability/trailing_blank_line.ex
@@ -1,7 +1,18 @@
 defmodule Credo.Check.Readability.TrailingBlankLine do
   @moduledoc """
+  For readability and Historical reason every text file should end with a \n,
+  or newline. This act as eol, or the end of the line character.
+  POSIX http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206
+
   Files should end in a trailing blank line. Many editors ensure this
   "final newline" automatically.
+
+  - For Vim users, you’re all set out of the box! Just don’t change your eol setting.
+  - For Emacs users, add (setq require-final-newline t) to your .emacs or .emacs.d/init.el file.
+  - For TextMate users, you can install the Avian Missing Bundle and
+  add TM_STRIP_WHITESPACE_ON_SAVE = true to your .tm_properties file.
+  - For Sublime users, set the ensure_newline_at_eof_on_save option to true.
+  - For RubyMine, set “Ensure line feed at file end on Save” under “Editor.”
   """
 
   @explanation [check: @moduledoc]

--- a/lib/credo/check/readability/trailing_white_space.ex
+++ b/lib/credo/check/readability/trailing_white_space.ex
@@ -1,6 +1,14 @@
 defmodule Credo.Check.Readability.TrailingWhiteSpace do
   @moduledoc """
   There should be no white-space (i.e. tabs, spaces) at the end of a line.
+
+  One of the reason for avoiding trailing white space is they cuould produce
+  bugs difficult to find.
+
+  Some editor include seeting for removing it automatically.
+
+  - For Sublime users, set the trim_trailing_white_space_on_save option to true.
+  - For Atom you could install the whitespace package
   """
 
   @explanation [check: @moduledoc]


### PR DESCRIPTION
Improve @moduledoc for some readability checks. #257

Since there are no elixir examples that could improve the documentation I decided to and some helping direction to avoid trailing white space or to add new lines at the end of the file