### PR TITLE
Feature: Warn on unsafe `Map.get/2` calls inside pipes

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -106,6 +106,7 @@
         {Credo.Check.Warning.BoolOperationOnSameValues},
         {Credo.Check.Warning.IExPry},
         {Credo.Check.Warning.IoInspect},
+        {Credo.Check.Warning.MapGetUnsafePass},
         {Credo.Check.Warning.NameRedeclarationByAssignment},
         {Credo.Check.Warning.NameRedeclarationByCase},
         {Credo.Check.Warning.NameRedeclarationByDef},

--- a/lib/credo/check/warning/map_get_unsafe_pass.ex
+++ b/lib/credo/check/warning/map_get_unsafe_pass.ex
@@ -1,0 +1,81 @@
+defmodule Credo.Check.Warning.MapGetUnsafePass do
+  @moduledoc """
+  `Map.get/2` can lead into runtime errors if the result is passed into a pipe without a proper default value.
+  This happens when the next function in the pipe cannot handle `nil` values correctly.
+
+  Example:
+
+        %{foo: [1, 2 ,3], bar: [4, 5, 6]}
+        |> Map.get(:baz)
+        |> Enum.each(&IO.puts/1)
+
+
+  This will cause a `Protocol.UndefinedError`, since `nil` isn't `Enumerable`. Often times while
+  iterating over enumerables zero iterations is preferrable to being forced to deal with an exception.
+  Had there been a `[]` default parameter this could have been averted.
+
+  Encourage use of `Map.get/3` instead to provide safer default values.
+  """
+
+  @explanation [check: @moduledoc]
+  @call_string "Map.get/2"
+
+  use Credo.Check, base_priority: :high
+
+  @doc false
+  def run(%SourceFile{} = source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse({:|>, meta , [left | right]} = ast, [] = issues, issue_meta) do
+    order = pipewalk(left) ++ pipewalk(List.first(right))
+
+    {ast, case is_unsafe?(order) do
+            true -> issues_for_call(meta, issues, issue_meta)
+            false -> issues
+          end}
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp pipewalk({:|>, _meta, [left | right]} = _ast) do
+    pipewalk(left) ++ pipewalk(List.first(right))
+  end
+
+  defp pipewalk({{:., _, [{:__aliases__, _, [namespace]}, callable]}, _, args}) do
+    [{"#{namespace}.#{callable}", args}]
+  end
+
+  defp pipewalk({value, _meta, args} = _ast) when is_atom(value),  do: [{value, args}]
+  defp pipewalk({value, _meta, []} = _ast),  do: [{value}]
+  defp pipewalk({value, _meta, nil} = _ast), do: [{value}]
+
+  defp is_unsafe?(expression) do
+    len = Enum.count(expression) - 1
+    {_, expression} = List.pop_at(expression, len)
+
+    true in Enum.map(expression, fn x ->
+                                   case x do
+                                     {"Map.get", [head | _]} when is_atom(head) -> true
+                                     {"Map.get", [head | tail]} when is_tuple(head) -> Enum.count(tail) < 2
+                                     {"Map.get", [_]} -> true
+                                     _ -> false
+                                   end
+                                 end)
+  end
+
+  def issues_for_call(meta, issues, issue_meta) do
+    [issue_for(issue_meta, meta[:line], @call_string) | issues]
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue issue_meta,
+      message: "Map.get/2 is unsafe in pipes, use Map.get/3",
+      trigger: trigger,
+      line_no: line_no
+  end
+end

--- a/lib/credo/check/warning/map_get_unsafe_pass.ex
+++ b/lib/credo/check/warning/map_get_unsafe_pass.ex
@@ -20,7 +20,7 @@ defmodule Credo.Check.Warning.MapGetUnsafePass do
   @explanation [check: @moduledoc]
   @call_string "Map.get/2"
 
-  use Credo.Check, base_priority: :high
+  use Credo.Check, base_priority: :normal
 
   @doc false
   def run(%SourceFile{} = source_file, params \\ []) do

--- a/lib/credo/check/warning/map_get_unsafe_pass.ex
+++ b/lib/credo/check/warning/map_get_unsafe_pass.ex
@@ -46,8 +46,8 @@ defmodule Credo.Check.Warning.MapGetUnsafePass do
     pipewalk(left) ++ pipewalk(List.first(right))
   end
 
-  defp pipewalk({{:., _, [{:__aliases__, _, [namespace]}, callable]}, _, args}) do
-    [{"#{namespace}.#{callable}", args}]
+  defp pipewalk({{:., _, [{:__aliases__, _, [namespace]}, callable]} = ast, _, args}) do
+    [{to_function_call_name(ast), args}]
   end
 
   defp pipewalk({value, _meta, args} = _ast) when is_atom(value),  do: [{value, args}]
@@ -56,20 +56,28 @@ defmodule Credo.Check.Warning.MapGetUnsafePass do
 
   defp is_unsafe?(expression) do
     len = Enum.count(expression) - 1
-    {_, expression} = List.pop_at(expression, len)
+    {_, [{head, head_arguments} | expression]} = List.pop_at(expression, len)
 
-    true in Enum.map(expression, fn x ->
-                                   case x do
-                                     {"Map.get", [head | _]} when is_atom(head) -> true
-                                     {"Map.get", [head | tail]} when is_tuple(head) -> Enum.count(tail) < 2
-                                     {"Map.get", [_]} -> true
-                                     _ -> false
-                                   end
-                                 end)
+    unsafe_head = (head == "Map.get" and length(head_arguments) != 3)
+
+    check = fn x ->
+              case x do
+               {"Map.get", [_]} -> true
+               _ -> false
+              end
+            end
+
+    true in Enum.map(expression, check) or unsafe_head
   end
 
   def issues_for_call(meta, issues, issue_meta) do
     [issue_for(issue_meta, meta[:line], @call_string) | issues]
+  end
+
+  defp to_function_call_name({_, _, _} = ast) do
+    {ast, [], []}
+    |> Macro.to_string()
+    |> String.replace(~r/\.?\(.*\)$/s, "")
   end
 
   defp issue_for(issue_meta, line_no, trigger) do

--- a/lib/credo/check/warning/map_get_unsafe_pass.ex
+++ b/lib/credo/check/warning/map_get_unsafe_pass.ex
@@ -1,7 +1,8 @@
 defmodule Credo.Check.Warning.MapGetUnsafePass do
   @moduledoc """
-  `Map.get/2` can lead into runtime errors if the result is passed into a pipe without a proper default value.
-  This happens when the next function in the pipe cannot handle `nil` values correctly.
+  `Map.get/2` can lead into runtime errors if the result is passed into a pipe
+  without a proper default value. This happens when the next function in the
+  pipe cannot handle `nil` values correctly.
 
   Example:
 
@@ -9,16 +10,16 @@ defmodule Credo.Check.Warning.MapGetUnsafePass do
         |> Map.get(:baz)
         |> Enum.each(&IO.puts/1)
 
-
-  This will cause a `Protocol.UndefinedError`, since `nil` isn't `Enumerable`. Often times while
-  iterating over enumerables zero iterations is preferrable to being forced to deal with an exception.
-  Had there been a `[]` default parameter this could have been averted.
+  This will cause a `Protocol.UndefinedError`, since `nil` isn't `Enumerable`.
+  Often times while iterating over enumerables zero iterations is preferrable
+  to being forced to deal with an exception. Had there been a `[]` default
+  parameter this could have been averted.
 
   Encourage use of `Map.get/3` instead to provide safer default values.
   """
 
   @explanation [check: @moduledoc]
-  @call_string "Map.get/2"
+  @call_string "Map.get"
 
   use Credo.Check, base_priority: :normal
 
@@ -29,14 +30,17 @@ defmodule Credo.Check.Warning.MapGetUnsafePass do
     Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
   end
 
-  defp traverse({:|>, meta , [left | right]} = ast, [] = issues, issue_meta) do
-    order = pipewalk(left) ++ pipewalk(List.first(right))
-
-    pipe_issues = order
-                  |> unsafe_lines
-                  |> Enum.map(fn x -> issues_for_call([line: x || meta[:line]], issues, issue_meta) end)
-                  |> List.flatten
-
+  defp traverse({:|>, _meta , _args} = ast, issues, issue_meta) do
+    pipe_issues =
+      ast
+      |> Macro.unpipe
+      |> Enum.drop(-1) # The last expression doesn't really matter
+      |> Enum.with_index
+      |> Enum.filter_map(&unsafe_expr?/1,
+                         fn ({expr, _}) ->
+                           {{{_, meta, _}, _, _}, _} = expr
+                           issue_for(issue_meta, meta[:line], @call_string)
+                         end)
     {ast, issues ++ pipe_issues}
   end
 
@@ -44,52 +48,25 @@ defmodule Credo.Check.Warning.MapGetUnsafePass do
     {ast, issues}
   end
 
-  defp pipewalk({:|>, _meta, [left | right]} = _ast) do
-    pipewalk(left) ++ pipewalk(List.first(right))
-  end
+  defp unsafe_expr?({expr, idx}) do
+    required_length =
+      case idx do
+        0 -> 3
+        _ -> 2
+      end
 
-  defp pipewalk({{:., meta, [{:__aliases__, _, [_namespace]}, _callable]} = ast, _, args}) do
-    [{to_function_call_name(ast), args, meta[:line]}]
-  end
-
-  defp pipewalk({value, meta, args} = _ast) when is_atom(value),  do: [{value, args, meta[:line]}]
-  defp pipewalk({value, meta, []} = _ast),  do: [{value, [], meta[:line]}]
-  defp pipewalk({value, meta, nil} = _ast), do: [{value, [], meta[:line]}]
-  defp pipewalk(any_literal),               do: [{any_literal, [], nil}]
-
-  defp unsafe_lines(expression) do
-    # The last expression inside the pipe doesn't really matter
-    [head | pipe] = Enum.drop(expression, -1)
-
-    unsafe_head = case head do
-                    {"Map.get", args, line} when length(args) != 3 -> [line]
-                    _ -> []
-                  end
-
-    tail_mapper = fn x, acc ->
-                    acc ++ case x do
-                      {"Map.get", [_], line} -> [line]
-                      _ -> []
-                    end
-                  end
-
-    unsafe_tail = Enum.reduce(pipe, [], tail_mapper)
-    unsafe_head ++ unsafe_tail
-  end
-
-  def issues_for_call(meta, issues, issue_meta) do
-    [issue_for(issue_meta, meta[:line], @call_string) | issues]
-  end
-
-  defp to_function_call_name({_, _, _} = ast) do
-    {ast, [], []}
-    |> Macro.to_string()
-    |> String.replace(~r/\.?\(.*\)$/s, "")
+    case expr do
+      {{{:., _, [{_, _, [:Map]}, :get]}, _, args}, _} ->
+        length(args) != required_length
+      _ ->
+        false
+    end
   end
 
   defp issue_for(issue_meta, line_no, trigger) do
     format_issue issue_meta,
-      message: "Map.get/2 is unsafe in pipes, use Map.get/3",
+      message: "Map.get with no default return value is potentially unsafe
+                in pipes, use Map.get/3 instead",
       trigger: trigger,
       line_no: line_no
   end

--- a/lib/credo/check/warning/map_get_unsafe_pass.ex
+++ b/lib/credo/check/warning/map_get_unsafe_pass.ex
@@ -53,8 +53,8 @@ defmodule Credo.Check.Warning.MapGetUnsafePass do
   end
 
   defp pipewalk({value, meta, args} = _ast) when is_atom(value),  do: [{value, args, meta[:line]}]
-  defp pipewalk({value, meta, []} = _ast),  do: [{value, meta[:line]}]
-  defp pipewalk({value, meta, nil} = _ast), do: [{value, meta[:line]}]
+  defp pipewalk({value, meta, []} = _ast),  do: [{value, [], meta[:line]}]
+  defp pipewalk({value, meta, nil} = _ast), do: [{value, [], meta[:line]}]
   defp pipewalk(any_literal),               do: [{any_literal, [], nil}]
 
   defp unsafe_lines(expression) do

--- a/lib/credo/check/warning/map_get_unsafe_pass.ex
+++ b/lib/credo/check/warning/map_get_unsafe_pass.ex
@@ -20,7 +20,7 @@ defmodule Credo.Check.Warning.MapGetUnsafePass do
 
   @explanation [check: @moduledoc]
   @call_string "Map.get"
-  @unsafe_modules [:Enum, :String]
+  @unsafe_modules [:Enum]
 
   use Credo.Check, base_priority: :normal
 

--- a/lib/credo/check/warning/map_get_unsafe_pass.ex
+++ b/lib/credo/check/warning/map_get_unsafe_pass.ex
@@ -46,7 +46,7 @@ defmodule Credo.Check.Warning.MapGetUnsafePass do
     pipewalk(left) ++ pipewalk(List.first(right))
   end
 
-  defp pipewalk({{:., _, [{:__aliases__, _, [namespace]}, callable]} = ast, _, args}) do
+  defp pipewalk({{:., _, [{:__aliases__, _, [_namespace]}, _callable]} = ast, _, args}) do
     [{to_function_call_name(ast), args}]
   end
 

--- a/test/credo/check/warning/map_get_unsafe_pass_test.exs
+++ b/test/credo/check/warning/map_get_unsafe_pass_test.exs
@@ -97,7 +97,7 @@ defmodule CredoSampleModule do
     |> Enum.map(fn x ->
                   x
                   |> Map.get(b)
-                  |> String.to_int
+                  |> Enum.reduce([], &some_fun/1)
                 end)
     |> some_other_function(c)
 

--- a/test/credo/check/warning/map_get_unsafe_pass_test.exs
+++ b/test/credo/check/warning/map_get_unsafe_pass_test.exs
@@ -25,14 +25,28 @@ end
   test "it should NOT report expected code 2" do
 """
 defmodule CredoSampleModule do
-def some_function(parameter1, parameter2) do
-  IO.inspect parameter1 + parameter2
+  def some_function(parameter1, parameter2) do
+    IO.inspect parameter1 + parameter2
 
     %{}
     |> Map.get(:foo, [])
     |> Enum.each(&IO.puts/1)
 
+  end
 end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+    end
+
+  test "it should NOT report expected code 3" do
+"""
+defmodule CredoSampleModule do
+  def some_function(parameter1) do
+
+      %{}
+      |> Map.get(:foo)
+      |> some_arbitrary_function
+  end
 end
 """ |> to_source_file
     |> refute_issues(@described_check)

--- a/test/credo/check/warning/map_get_unsafe_pass_test.exs
+++ b/test/credo/check/warning/map_get_unsafe_pass_test.exs
@@ -6,7 +6,7 @@ defmodule Credo.Check.Warning.MapGetUnsafePassTest do
   #
   # cases NOT raising issues
   #
-  @tag :to_be_implemented
+
   test "it should NOT report expected code" do
 """
 defmodule CredoSampleModule do
@@ -25,7 +25,7 @@ end
   #
   # cases raising issues
   #
-  @tag :to_be_implemented
+
   test "it should report a violation" do
 """
 defmodule CredoSampleModule do
@@ -42,7 +42,7 @@ end
     |> assert_issue(@described_check)
   end
 
-  @tag :to_be_implemented
+
   test "it should report a violation /2" do
 """
 defmodule CredoSampleModule do
@@ -58,7 +58,7 @@ end
     |> assert_issue(@described_check)
   end
 
-  @tag :to_be_implemented
+
   test "it should report a violation /3" do
 """
 defmodule CredoSampleModule do

--- a/test/credo/check/warning/map_get_unsafe_pass_test.exs
+++ b/test/credo/check/warning/map_get_unsafe_pass_test.exs
@@ -49,8 +49,7 @@ defmodule CredoSampleModule do
 
     %{}
     |> Map.get(:foo)
-    |> Map.put(:bar, "123")
-    |> Enum.each(&IO.puts/1)
+    |> Enum.sum
 
   end
 end

--- a/test/credo/check/warning/map_get_unsafe_pass_test.exs
+++ b/test/credo/check/warning/map_get_unsafe_pass_test.exs
@@ -1,0 +1,80 @@
+defmodule Credo.Check.Warning.MapGetUnsafePassTest do
+  use Credo.TestHelper
+
+  @described_check Credo.Check.Warning.MapGetUnsafePass
+
+  #
+  # cases NOT raising issues
+  #
+  @tag :to_be_implemented
+  test "it should NOT report expected code" do
+"""
+defmodule CredoSampleModule do
+  def some_function(parameter1, parameter2) do
+    IO.inspect parameter1 + parameter2
+
+    Map.get(%{}, :foo, [])
+    |> Enum.map(&(&1))
+
+  end
+end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  #
+  # cases raising issues
+  #
+  @tag :to_be_implemented
+  test "it should report a violation" do
+"""
+defmodule CredoSampleModule do
+  def some_function() do
+
+    %{}
+    |> Map.get(:foo)
+    |> Map.put(:bar, "123")
+    |> Enum.each(&IO.puts/1)
+
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  @tag :to_be_implemented
+  test "it should report a violation /2" do
+"""
+defmodule CredoSampleModule do
+  def some_function(parameter1, parameter2) do
+    some_map = %{}
+
+    Map.get(some_map, :items)
+    |> Enum.map(fn x -> x["id"] end)
+
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  @tag :to_be_implemented
+  test "it should report a violation /3" do
+"""
+defmodule CredoSampleModule do
+  def some_function(a, b, c) do
+
+    a
+    |> Enum.map(fn x ->
+                  x
+                  |> Map.get(b)
+                  |> String.to_int
+                end)
+    |> some_other_function(c)
+
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+end

--- a/test/credo/check/warning/map_get_unsafe_pass_test.exs
+++ b/test/credo/check/warning/map_get_unsafe_pass_test.exs
@@ -22,6 +22,22 @@ end
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report expected code 2" do
+"""
+defmodule CredoSampleModule do
+def some_function(parameter1, parameter2) do
+  IO.inspect parameter1 + parameter2
+
+    %{}
+    |> Map.get(:foo, [])
+    |> Enum.each(&IO.puts/1)
+
+end
+end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+    end
+
   #
   # cases raising issues
   #


### PR DESCRIPTION
Coming from Python this happens every now and then, especially when deserializing. You rarely know (or think!) whether the following function is able to handle `nil` values, and in most cases you run into a runtime at error forcing at minimum a recompile in dev and potentially dumb errors in production.

Mostly the first and consequent `n-1` pipe functions matter, nested expressions are also caught.