### PR TITLE
Semicolons check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -87,6 +87,7 @@
         {Credo.Check.Readability.TrailingBlankLine},
         {Credo.Check.Readability.TrailingWhiteSpace},
         {Credo.Check.Readability.VariableNames},
+        {Credo.Check.Readability.Semicolons},
 
         {Credo.Check.Refactor.DoubleBooleanNegation},
         {Credo.Check.Refactor.CondStatements},

--- a/lib/credo/check/readability/semicolons.ex
+++ b/lib/credo/check/readability/semicolons.ex
@@ -1,0 +1,40 @@
+defmodule Credo.Check.Readability.Semicolons do
+  @moduledoc """
+  Don't use ; to separate statements and expressions.
+  Statements and expressions should be separated by lines.
+
+  Like all `Readability` issues, this one is not a technical concern.
+  But you can improve the odds of others reading and liking your code by making
+  it easier to follow.
+  """
+
+  @explanation [
+    check: @moduledoc
+  ]
+
+  use Credo.Check, base_priority: :high
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    source_file.source
+    |> Credo.Code.to_tokens
+    |> collect_issues([], issue_meta)
+  end
+
+  defp collect_issues([], acc, _issue_meta), do: acc
+  defp collect_issues([{:";", {line_no, column1, _}} | rest], acc, issue_meta) do
+    acc = [issue_for(issue_meta, line_no, column1) | acc]
+    collect_issues(rest, acc, issue_meta)
+  end
+  defp collect_issues([_ | rest], acc, issue_meta), do: collect_issues(rest, acc, issue_meta)
+
+  def issue_for(issue_meta, line_no, column) do
+    format_issue issue_meta,
+      message: "Don't use ; to separate statements and expressions",
+      line_no: line_no,
+      column: column,
+      trigger: ";"
+  end
+end

--- a/test/credo/check/readability/semicolons_test.exs
+++ b/test/credo/check/readability/semicolons_test.exs
@@ -3,8 +3,6 @@ defmodule Credo.Check.Readability.SemicolonsTest do
 
   @described_check Credo.Check.Readability.Semicolons
 
-  @moduletag :to_be_implemented
-
   #
   # cases NOT raising issues
   #


### PR DESCRIPTION
Semicolons are mentioned in the style guide [here](https://github.com/rrrene/elixir-style-guide#semicolon-between-statements), but there weren't any checks.  I tried to fill in the functionality for it since there were already tests.

I'm not super familiar with credo structure, so if I made some mistakes, I'd be happy to try and fix.