### PR TITLE
BugFix: Crashes on zero arity function in macro

### DIFF
--- a/lib/credo/check/readability/parentheses_on_zero_arity_defs.ex
+++ b/lib/credo/check/readability/parentheses_on_zero_arity_defs.ex
@@ -42,6 +42,10 @@ defmodule Credo.Check.Readability.ParenthesesOnZeroArityDefs do
     {ast, issues}
   end
 
+  # skip the false positive for a metaprogrammed definition
+  defp issues_for_definition({{:unquote, _, _}, _, _}, issues, _) do
+    issues
+  end
   defp issues_for_definition({_, _, args}, issues, _) when length(args) > 0 do
     issues
   end

--- a/test/credo/check/readability/parentheses_on_zero_arity_defs_test.exs
+++ b/test/credo/check/readability/parentheses_on_zero_arity_defs_test.exs
@@ -36,4 +36,17 @@ end
 """ |> to_source_file
     |> assert_issue(@described_check)
   end
+
+  test "it should not crash on macros creating zero arity functions" do
+"""
+defmodule Credo.Sample.Module do
+  defmacro dynamic_methoder(attribute, value) do
+    quote do
+      def unquote(attribute)(), do: unquote(value)
+    end
+  end
+end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+  end
 end


### PR DESCRIPTION
PR related to https://github.com/rrrene/credo/issues/337 

Credo.Check.Readability.ParenthesesOnZeroArityDefs crashes if a macro defines a zero-arity function. 

- [x] Add a test to demonstrate the issue.
- [x] Fix the issue.

Credo.Check.Readability.ParenthesesOnZeroArityDefs checks zero arity methods and flags if they have parenthesis.  When generating a zero arity method in a macro we are required to add the parens.  This causes an issue because issues_for_definition/3 sees that args are == 0 but there is no name defined for the method yet (we just have something like ({:unquote, [line: 4], [{:attribute, [line: 4], nil}]}`)... so we blow up.

In theory this check needs to be skipped in this case - as the parens are required to generate the method.  As such I just skip the issue anytime this comes up.