### PR TITLE
Set unicode option for regex at UI.wrap_at

### DIFF
--- a/lib/credo/cli/output/ui.ex
+++ b/lib/credo/cli/output/ui.ex
@@ -29,7 +29,7 @@ defmodule Credo.CLI.Output.UI do
 
   def wrap_at(text, number) do
     "(?:((?>.{1,#{number}}(?:(?<=[^\\S\\r\\n])[^\\S\\r\\n]?|(?=\\r?\\n)|$|[^\\S\\r\\n]))|.{1,#{number}})(?:\\r?\\n)?|(?:\\r?\\n|$))"
-    |> Regex.compile!
+    |> Regex.compile!("u")
     |> Regex.scan(text)
     |> Enum.map(&List.first/1)
     |> List.delete_at(-1)

--- a/test/credo/cli/output/ui_test.exs
+++ b/test/credo/cli/output/ui_test.exs
@@ -27,6 +27,16 @@ These checks take a look at your code and ensure a consistent coding style. Usin
     assert expected == lines
   end
 
+test "it should be able to break up a line including unicode characters" do
+    lines =
+       "あいうえ"
+       |> UI.wrap_at(2)
+     expected = [
+         "あい", "うえ"
+       ]
+     assert expected == lines
+   end
+
   test "truncate when max_length > ellipsis length and truncation required" do
     # Even if the ellipsis is longer than the max lenght we should not
     # truncate the ellipsis so the human reader doesn't have to figure out


### PR DESCRIPTION
The regular expression used in `UI.wrap_at` can break unicode characters into invalid binaries as unicode. Some functions using the result like IO.puts raise exception.

```
iex(1)> Credo.CLI.Output.UI.wrap_at("あ", 1)
[<<227>>, <<129>>, <<130>>]
```

This patch doesn't care about display width of unicode characters.