### PR TITLE
Fix config_name switch

### DIFF
--- a/lib/credo/cli/options.ex
+++ b/lib/credo/cli/options.ex
@@ -10,6 +10,7 @@ defmodule Credo.CLI.Options do
     all_priorities: :boolean,
     all: :boolean,
     checks: :string,
+    config_name: :string,
     color: :boolean,
     crash_on_error: :boolean,
     format: :string,


### PR DESCRIPTION
Some point between credo v0.5 and v0.7 the OptionParser started to use `strict` for switches (which would ignore switches that were not defined).

`-C` is an (aliased) switch that allows you to specify a ruleset that you defined on your credo file.

Eg, let's say you have the following `.credo.exs`
```elixir
%{
  configs: [
    %{
      name: "default",
      ...
    },
    %{
      name: "ci",
      ...
```

You can execute the checks of the second ruleset by running `mix credo -C ci`. The problem is that with the change from `switches` to `strict`, unfortunately this stopped working, so, before this PR, if you try to run `mix credo -C ci` you would receive the error `Unknown switch: -C`; after this PR it should work as expected