### PR TITLE
Ensure set_lint_attributes warning only shows when necessary

### DIFF
--- a/lib/credo/check/runner.ex
+++ b/lib/credo/check/runner.ex
@@ -55,7 +55,7 @@ defmodule Credo.Check.Runner do
           Map.put(memo, source_file.filename, source_file.lint_attributes)
         end)
 
-    if Map.size(lint_attribute_map) > 0 do
+    if lint_attribute_map |> Enum.filter(fn({_, value}) -> value != [] end) != [] do
       Credo.CLI.Output.UI.warn ""
       Credo.CLI.Output.UI.warn [:orange,
         "@lint attributes will be deprecated in the Credo v0.8 because they trigger\n",


### PR DESCRIPTION
## Background

### Environment

* Credo 0.7.1
* Erlang/OTP 19 [erts-8.1] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false]
* Elixir 1.3.4
* OS/X 10.12.3

### What were you trying to do?
Run credo in CI - warnings prevent my project from passing.

### Expected outcome

If a project uses @lint we now expect to get a warning:

```
@lint attributes will be deprecated in the Credo v0.8 because they trigger
compiler warnings on Elixir v1.4.

Please consider reporting the cases where you needed @lint attributes
to help us devise a new solution: https://github.com/rrrene/credo/issues/new
```

Our project has no @lint attributes - so I expected not to get the warning.

### Actual outcome

I get the warning no matter what.

## Discussion

The conditional to display this warning looks for a count on lint_attribute_map - however this map will have keys for every file checked... what we really want here are the number of non-empty values  for those keys to determine whether any files actually use the @link tag.

## What changed

Filter the keys to get those with values that are empty lists and show the warning if the resulting list is not empty.

## QA
There are no tests for this to update - spin up a project. Add credo. Assert the warning does not appear.  Add a module with a `@lint false` tag (or whatever).  Assert the warning does appear.