### PR TITLE
Fixed a pattern match that was preventing flycheck from being formatted correctly

### DIFF
--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -15,7 +15,7 @@ defmodule Credo.Sources do
 
   iex> Sources.find(%Credo.Config{files: %{excluded: [/messy/], included: ["lib/mix", "root.ex"]}})
   """
-  def find(%Credo.Config{files: %{read_from_stdin: true, included: [filename]}}) do
+  def find(%Credo.Config{read_from_stdin: true, files: %{included: [filename]}}) do
     filename
     |> source_file_from_stdin()
     |> List.wrap


### PR DESCRIPTION
This should fix issue #349 