### PR TITLE
turns out in Elixir windows uses '/' instead of '\'

### DIFF
--- a/lib/credo/cli/filename.ex
+++ b/lib/credo/cli/filename.ex
@@ -62,7 +62,7 @@ defmodule Credo.CLI.Filename do
   end
 
   defp windows_path?(path) do
-    String.contains?(path, ":\\")
+    String.contains?(path, ":\/")
   end
 
   @doc """

--- a/test/credo/cli/filename_test.exs
+++ b/test/credo/cli/filename_test.exs
@@ -3,12 +3,12 @@ defmodule Credo.CLI.FilenameTest do
   doctest Credo.CLI.Filename
 
   test "the truth" do
-    assert "C:\\Credo\\sources.ex" == Credo.CLI.Filename.remove_line_no_and_column("C:\\Credo\\sources.ex:39:8")
+    assert "C:/Credo/sources.ex" == Credo.CLI.Filename.remove_line_no_and_column("C:/Credo/sources.ex:39:8")
   end
 
   test "contains line no" do
-    assert true == Credo.CLI.Filename.contains_line_no?("C:\\Credo\\sources.ex:39:8")
-    assert true == Credo.CLI.Filename.contains_line_no?("C:\\Credo\\sources.ex:39")
-    assert false == Credo.CLI.Filename.contains_line_no?("C:\\Credo\\sources.ex")
+    assert true == Credo.CLI.Filename.contains_line_no?("C:/Credo/sources.ex:39:8")
+    assert true == Credo.CLI.Filename.contains_line_no?("C:/Credo/sources.ex:39")
+    assert false == Credo.CLI.Filename.contains_line_no?("C:/Credo/sources.ex")
   end
 end


### PR DESCRIPTION
Pretty sure this solves #347 .  After making the change, fired up `iex` and ran `Credo.CLI.main([])`. It found 141 source files, and this being windows, I feel like that's an improvement.

I also used this branch as the resolver for another Elixir project on my box, and ran that one with `mix credo` and it found the files.....