### PR TITLE
Fix false positives in SpacesAroundOperators

### DIFF
--- a/lib/credo/check/consistency/space_around_operators.ex
+++ b/lib/credo/check/consistency/space_around_operators.ex
@@ -115,12 +115,12 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators do
     typed_after? =
       line
       |> String.slice(column..-1) # -1 because we need to subtract the operator
-      |> String.match?(~r/^\s*(integer|native|signed|unsigned|binary|size)/)
+      |> String.match?(~r/^\s*(integer|native|signed|unsigned|binary|size|little|float)/)
 
     typed_before? =
       line
       |> String.slice(0..column - 2) # -2 because we need to subtract the operator
-      |> String.match?(~r/(integer|native|signed|unsigned|binary|size)\s*$/)
+      |> String.match?(~r/(integer|native|signed|unsigned|binary|size|little|float)\s*$/)
 
     heuristics_met_count =
       [

--- a/test/credo/check/consistency/space_around_operators_test.exs
+++ b/test/credo/check/consistency/space_around_operators_test.exs
@@ -55,6 +55,7 @@ defmodule Credo.Sample2 do
       <<102::unsigned-big-integer, rest::binary>>
       <<102::unsigned-big-integer-size(8), rest::binary>>
       <<102::unsigned-big-integer-8, rest::binary>>
+      <<102::signed-little-float-8, rest::binary>>
       <<102::8-integer-big-unsigned, rest::binary>>
       <<102, rest::binary>>
       << valsize :: 32-unsigned, rest::binary >>
@@ -180,7 +181,7 @@ end
 
   test "it should report an issue for mixed styles /1" do
     [
-      @without_spaces, @with_spaces, @with_spaces2
+      @without_spaces, @with_spaces, @with_spaces2, @with_spaces3
     ]
     |> to_source_files()
     |> assert_issue(@described_check)


### PR DESCRIPTION
From #144, I was still having issues with false positives being reported due to my use of other keywords not listed in the check.