### PR TITLE
fix(sources): support command line filename args when reading from stdin

### DIFF
--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -20,6 +20,11 @@ defmodule Credo.Sources do
     |> source_file_from_stdin()
     |> List.wrap
   end
+  def find(%Credo.Config{read_from_stdin: true, args: [filename]}) do
+    filename
+    |> source_file_from_stdin()
+    |> List.wrap
+  end
   def find(%Credo.Config{read_from_stdin: true}) do
     @stdin_filename
     |> source_file_from_stdin()


### PR DESCRIPTION
The behavior as described in #349 is still exactly as described before this [fix](https://github.com/rrrene/credo/commit/947efb05fdf57b352068fb0d8e7164d761eea051).

To reiterate #349, commands like:

```
mix credo --strict --format flycheck --read-from-stdin /path/to/lib/file.ex < /path/to/lib/file.ex
```

Return: 

```
stdin:20:1: R: There should be no trailing white-space at the end of a line.
```

Instead of:

```
/path/to/lib/file.ex:20:1: R: There should be no trailing white-space at the end of a line.
```

Which causes things like flycheck to be unable to parse and show the errors inline.