### PR TITLE
Default value of result issues

### DIFF
--- a/lib/credo/execution.ex
+++ b/lib/credo/execution.ex
@@ -125,8 +125,8 @@ defmodule Credo.Execution do
 
   # Results
 
-  def get_result(exec, name) do
-    Map.get(exec.results, name)
+  def get_result(exec, name, default \\ nil) do
+    Map.get(exec.results, name, default)
   end
 
   def put_result(exec, name, value) do

--- a/lib/credo/execution/task/halt_execution.ex
+++ b/lib/credo/execution/task/halt_execution.ex
@@ -5,7 +5,7 @@ defmodule Credo.Execution.Task.HaltExecution do
   def call(exec, _opts) do
     exit_status =
       exec
-      |> get_result("issues")
+      |> get_result("issues", [])
       |> to_exit_status()
 
     halt_if_failed(exit_status)


### PR DESCRIPTION
Ref #376 

This is an addition to the fix in https://github.com/rrrene/credo/commit/a300b110f20df088b862c12ed85a14e51d5e98ad ;)

This fixes an error for commands that does not put anything into the
Execution result "issues" key. E.g. the version command.

Example run without this fix:

```
$ mix credo -v
0.8.0-rc3
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil
    (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir) lib/enum.ex:116: Enumerable.reduce/3
    (elixir) lib/enum.ex:1776: Enum.map/2
    lib/credo/execution/task/halt_execution.ex:20: Credo.Execution.Task.HaltExecution.to_exit_status/1
    lib/credo/execution/task/halt_execution.ex:9: Credo.Execution.Task.HaltExecution.call/2
    lib/credo/execution/task.ex:30: Credo.Execution.Task.run/3
    (mix) lib/mix/task.ex:294: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
```