### PR TITLE
Exclude Credo from the application runtime list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `:credo` as a dependency to your project's `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:credo, "~> 0.8", only: [:dev, :test]}
+    {:credo, "~> 0.8", only: [:dev, :test], runtime: false}
   ]
 end
 ```


### PR DESCRIPTION
This fixes the ff. error encountered
when "credo" is added to the Mix test alias:

** (Mix) Could not start application credo: Credo.start(:normal, []) returned an error: already started