### PR TITLE
change credo version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `:credo` as a dependency to your project's `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:credo, "~> 0.8", only: [:dev, :test], runtime: false}
+    {:credo, "~> 0.3", only: [:dev, :test], runtime: false}
   ]
 end
 ```


### PR DESCRIPTION
mix deps.get fails with version 0.8 right now.

`mix deps.get
Running dependency resolution...

Failed to use "credo" because
  mix.exs specifies ~> 0.8

** (Mix) Hex dependency resolution failed, relax the version requirements of your dependencies or unlock them (by using mix deps.update or mix deps.unlock). If you are unable to resolve the conflicts you can try overriding with {:dependency, "~> 1.0", override: true}`