### PR TITLE
Replace deprecated functions for Elixir 1.5

### DIFF
--- a/lib/credo/check/design/alias_usage.ex
+++ b/lib/credo/check/design/alias_usage.ex
@@ -159,13 +159,12 @@ defmodule Credo.Check.Design.AliasUsage do
 
         Map.put(memo, issue.trigger, [issue | list])
       end)
-    |> Enum.filter_map(
-      fn({_, value}) ->
+    |> Enum.filter(fn({_, value}) ->
         length(value) > count
-      end,
-      fn({_, value}) ->
-        value
       end)
+    |> Enum.map(fn({_, value}) ->
+      value
+    end)
     |> List.flatten
   end
 

--- a/lib/credo/check/design/tag_helper.ex
+++ b/lib/credo/check/design/tag_helper.ex
@@ -2,6 +2,8 @@ defmodule Credo.Check.Design.TagHelper do
   alias Credo.Check.CodeHelper
   alias Credo.SourceFile
 
+  use Backports
+
   @doc_attribute_names [:doc, :moduledoc, :shortdoc]
 
   def tags(source_file, tag_name, include_doc?) do

--- a/lib/credo/check/design/tag_helper.ex
+++ b/lib/credo/check/design/tag_helper.ex
@@ -49,7 +49,7 @@ defmodule Credo.Check.Design.TagHelper do
       regex
       |> Regex.run(line)
       |> List.wrap
-      |> Enum.map(&String.strip/1)
+      |> Enum.map(&String.trim/1)
 
     {index + 1, line, List.first(tag_list)}
   end

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -23,6 +23,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
     only_greater_than: 9_999,
   ]
 
+  use Backports
   use Credo.Check, base_priority: :high, elixir_version: ">= 1.3.2"
 
   @doc false

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -117,7 +117,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
       |> IssueMeta.source_file
       |> SourceFile.line_at(line_no)
       |> String.slice((column1 - 1)..(column2 - 1))
-      |> String.strip
+      |> String.trim
       |> String.replace(~r/\D$/, "")
 
     if Version.match?(System.version, "< 1.3.2-dev") do
@@ -141,7 +141,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
       |> IssueMeta.source_file
       |> SourceFile.line_at(line_no)
       |> String.slice((column1 - 1)..(column2 - 2 + underscores))
-      |> String.strip
+      |> String.trim
       |> String.replace(~r/\D$/, "")
     else
       first_fragment

--- a/lib/credo/check/readability/trailing_blank_line.ex
+++ b/lib/credo/check/readability/trailing_blank_line.ex
@@ -23,7 +23,7 @@ defmodule Credo.Check.Readability.TrailingBlankLine do
       |> SourceFile.lines
       |> List.last
 
-    if String.strip(last_line) == "" do
+    if String.trim(last_line) == "" do
       []
     else
       [issue_for(issue_meta, line_no)]

--- a/lib/credo/check/readability/trailing_blank_line.ex
+++ b/lib/credo/check/readability/trailing_blank_line.ex
@@ -10,6 +10,8 @@ defmodule Credo.Check.Readability.TrailingBlankLine do
   Most text editors ensure this "final newline" automatically.
   """
 
+  use Backports
+
   @explanation [check: @moduledoc]
 
   use Credo.Check, base_priority: :low

--- a/lib/credo/check_for_updates.ex
+++ b/lib/credo/check_for_updates.ex
@@ -2,6 +2,8 @@ defmodule Credo.CheckForUpdates do
   alias Credo.CLI.Output.UI
   alias Credo.Execution
 
+  use Backports
+
   @doc false
   def run(%Execution{check_for_updates: true} = exec) do
     run()

--- a/lib/credo/check_for_updates.ex
+++ b/lib/credo/check_for_updates.ex
@@ -75,7 +75,7 @@ defmodule Credo.CheckForUpdates do
   defp fetch(url) do
     :inets.start()
     :ssl.start()
-    response = :httpc.request(:get, {String.to_char_list(url),
+    response = :httpc.request(:get, {String.to_charlist(url),
                                     [{'User-Agent', user_agent()},
                                      {'Accept', 'application/vnd.hex+erlang'}]
                                     }, [], [])

--- a/lib/credo/cli/command/help.ex
+++ b/lib/credo/cli/command/help.ex
@@ -78,7 +78,7 @@ output = """
 #      \\/___/  \\/_/ \\/____/\\/__,_ /\\/___/
 #
 """
-    String.strip(output)
+    String.trim(output)
   end
 
 end

--- a/lib/credo/cli/command/help.ex
+++ b/lib/credo/cli/command/help.ex
@@ -40,7 +40,7 @@ defmodule Credo.CLI.Command.Help do
         name2 =
           name
           |> to_string
-          |> String.ljust(@ljust)
+          |> String.pad_trailing(@ljust)
 
         case List.keyfind(module.__info__(:attributes), :shortdoc, 0) do
           {:shortdoc, [shortdesc]} ->

--- a/lib/credo/cli/command/help.ex
+++ b/lib/credo/cli/command/help.ex
@@ -1,6 +1,6 @@
 defmodule Credo.CLI.Command.Help do
+  use Backports
   use Credo.CLI.Command
-
 
   @shortdoc "Show this help message"
   @ljust 12
@@ -10,6 +10,8 @@ defmodule Credo.CLI.Command.Help do
   alias Credo.CLI
   alias Credo.CLI.Output.UI
   alias Credo.CLI.Sorter
+
+  use Backports
 
   @doc false
   def run(exec) do

--- a/lib/credo/cli/output.ex
+++ b/lib/credo/cli/output.ex
@@ -1,4 +1,6 @@
 defmodule Credo.CLI.Output do
+  use Backports
+
   alias Credo.CLI.Output.UI
   alias Credo.Execution
 

--- a/lib/credo/cli/output.ex
+++ b/lib/credo/cli/output.ex
@@ -140,7 +140,7 @@ defmodule Credo.CLI.Output do
     list
     |> Enum.with_index
     |> Enum.flat_map(fn({string, index}) ->
-        [:reset, String.rjust("#{index+1})", 5), :faint, " #{string}\n"]
+        [:reset, String.pad_leading("#{index+1})", 5), :faint, " #{string}\n"]
       end)
     |> UI.puts
   end

--- a/lib/credo/cli/output/categories.ex
+++ b/lib/credo/cli/output/categories.ex
@@ -1,4 +1,6 @@
 defmodule Credo.CLI.Output.Categories do
+  use Backports
+
   alias Credo.CLI.Output
   alias Credo.CLI.Output.UI
 

--- a/lib/credo/cli/output/categories.ex
+++ b/lib/credo/cli/output/categories.ex
@@ -57,7 +57,7 @@ defmodule Credo.CLI.Output.Categories do
     [
       :bright, "#{color}_background" |> String.to_atom, color, " ",
         Output.foreground_color(color), :normal,
-      " #{title}" |> String.ljust(term_width - 1),
+      " #{title}" |> String.pad_trailing(term_width - 1),
     ]
     |> UI.puts
 

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -1,4 +1,6 @@
 defmodule Credo.CLI.Output.Explain do
+  use Backports
+
   alias Credo.Code.Scope
   alias Credo.CLI.Filter
   alias Credo.CLI.Output

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -178,7 +178,7 @@ defmodule Credo.CLI.Output.Explain do
     UI.puts_edge([outer_color, :faint])
 
     (issue.check.explanation || "TODO: Insert explanation")
-    |> String.strip
+    |> String.trim
     |> String.split("\n")
     |> Enum.flat_map(&format_explanation(&1, outer_color))
     |> Enum.slice(0..-2)

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -57,7 +57,7 @@ defmodule Credo.CLI.Output.Explain do
     [
       :bright, "#{color}_background" |> String.to_atom, color, " ",
         Output.foreground_color(color), :normal,
-      " #{scope_name}" |> String.ljust(term_width - 1),
+      " #{scope_name}" |> String.pad_trailing(term_width - 1),
     ]
     |> UI.puts
 
@@ -305,7 +305,7 @@ defmodule Credo.CLI.Output.Explain do
         [
           UI.edge([outer_color, :faint]), :reset,
             String.duplicate(" ", @indent-2),
-            :cyan, "  #{param}:" |> String.ljust(params_indent+3),
+            :cyan, "  #{param}:" |> String.pad_trailing(params_indent+3),
             :reset, text
         ]
         |> UI.puts
@@ -317,7 +317,7 @@ defmodule Credo.CLI.Output.Explain do
           [
             UI.edge([outer_color, :faint]), :reset,
               String.duplicate(" ", @indent-2),
-              :cyan, " " |> String.ljust(params_indent+3),
+              :cyan, " " |> String.pad_trailing(params_indent+3),
               :reset, :faint, default_text
           ]
           |> UI.puts

--- a/lib/credo/cli/output/explain.ex
+++ b/lib/credo/cli/output/explain.ex
@@ -200,7 +200,7 @@ defmodule Credo.CLI.Output.Explain do
 
     line_no_str =
       "#{line_no} "
-      |> String.rjust(@indent - 2)
+      |> String.pad_leading(@indent - 2)
 
     [
       UI.edge([outer_color, :faint]), :reset,

--- a/lib/credo/cli/output/issue_helper.ex
+++ b/lib/credo/cli/output/issue_helper.ex
@@ -6,6 +6,8 @@ defmodule Credo.CLI.Output.IssueHelper do
   alias Credo.Issue
   alias Credo.SourceFile
 
+  use Backports
+
   @indent 8
 
   def print_issues(issues, source_file_map, %Execution{format: _} = exec, term_width) do

--- a/lib/credo/cli/output/issue_helper.ex
+++ b/lib/credo/cli/output/issue_helper.ex
@@ -96,7 +96,7 @@ defmodule Credo.CLI.Output.IssueHelper do
   end
   defp print_issue_line(%Issue{} = issue, source_file, inner_color, outer_color, term_width) do
     raw_line = SourceFile.line_at(source_file, issue.line_no)
-    line = String.strip(raw_line)
+    line = String.trim(raw_line)
 
     [outer_color, :faint]
     |> UI.edge
@@ -116,7 +116,7 @@ defmodule Credo.CLI.Output.IssueHelper do
     nil
   end
   defp print_issue_trigger_marker(%Issue{} = issue, line, inner_color, outer_color) do
-    offset = String.length(line) - String.length(String.strip(line))
+    offset = String.length(line) - String.length(String.trim(line))
     x = max(issue.column - offset - 1, 0) # column is one-based
     w =
       case issue.trigger do

--- a/lib/credo/cli/output/issues_by_scope.ex
+++ b/lib/credo/cli/output/issues_by_scope.ex
@@ -1,4 +1,6 @@
 defmodule Credo.CLI.Output.IssuesByScope do
+  use Backports
+
   alias Credo.Code.Scope
   alias Credo.CLI.Filename
   alias Credo.CLI.Filter
@@ -7,6 +9,7 @@ defmodule Credo.CLI.Output.IssuesByScope do
   alias Credo.CLI.Output.Summary
   alias Credo.SourceFile
   alias Credo.Issue
+
 
   @indent 8
 

--- a/lib/credo/cli/output/issues_by_scope.ex
+++ b/lib/credo/cli/output/issues_by_scope.ex
@@ -105,7 +105,7 @@ defmodule Credo.CLI.Output.IssuesByScope do
       |> UI.puts
 
       if issue.column do
-        offset = String.length(line) - String.length(String.strip(line))
+        offset = String.length(line) - String.length(String.trim(line))
         x = max(issue.column - offset - 1, 0) # column is one-based
         w =
           case issue.trigger do

--- a/lib/credo/cli/output/issues_by_scope.ex
+++ b/lib/credo/cli/output/issues_by_scope.ex
@@ -54,7 +54,7 @@ defmodule Credo.CLI.Output.IssuesByScope do
       [
         :bright, "#{color}_background" |> String.to_atom, color, " ",
           Output.foreground_color(color), :normal,
-        " #{scope_name}" |> String.ljust(term_width - 1),
+        " #{scope_name}" |> String.pad_trailing(term_width - 1),
       ]
       |> UI.puts
 

--- a/lib/credo/cli/output/issues_grouped_by_category.ex
+++ b/lib/credo/cli/output/issues_grouped_by_category.ex
@@ -103,7 +103,7 @@ defmodule Credo.CLI.Output.IssuesGroupedByCategory do
     [
       :bright, "#{color}_background" |> String.to_atom, color, " ",
         Output.foreground_color(color), :normal,
-      " #{title}" |> String.ljust(term_width - 1),
+      " #{title}" |> String.pad_trailing(term_width - 1),
     ]
     |> UI.puts
 

--- a/lib/credo/cli/output/issues_grouped_by_category.ex
+++ b/lib/credo/cli/output/issues_grouped_by_category.ex
@@ -1,4 +1,6 @@
 defmodule Credo.CLI.Output.IssuesGroupedByCategory do
+  use Backports
+
   alias Credo.CLI.Filter
   alias Credo.CLI.Output
   alias Credo.CLI.Output.IssueHelper
@@ -6,6 +8,7 @@ defmodule Credo.CLI.Output.IssuesGroupedByCategory do
   alias Credo.CLI.Output.Summary
   alias Credo.CLI.Sorter
   alias Credo.Execution
+
 
   @category_starting_order [:design, :readability, :refactor]
   @category_ending_order [:warning, :consistency, :custom, :unknown]

--- a/lib/credo/cli/output/ui.ex
+++ b/lib/credo/cli/output/ui.ex
@@ -1,4 +1,6 @@
 defmodule Credo.CLI.Output.UI do
+  use Backports
+
   @edge "┃"
   @ellipsis "…"
   @shell_service Credo.CLI.Output.Shell

--- a/lib/credo/cli/output/ui.ex
+++ b/lib/credo/cli/output/ui.ex
@@ -4,7 +4,7 @@ defmodule Credo.CLI.Output.UI do
   @shell_service Credo.CLI.Output.Shell
 
   def edge(color, indent \\ 2) when is_integer(indent) do
-    [:reset, color, @edge |> String.ljust(indent)]
+    [:reset, color, @edge |> String.pad_trailing(indent)]
   end
   def edge, do: @edge
 

--- a/lib/credo/code.ex
+++ b/lib/credo/code.ex
@@ -103,7 +103,7 @@ defmodule Credo.Code do
   def to_tokens(source) when is_binary(source) do
     {_, _, _, tokens} =
       source
-      |> String.to_char_list
+      |> String.to_charlist
       |> :elixir_tokenizer.tokenize(1, [])
 
     tokens

--- a/lib/credo/code.ex
+++ b/lib/credo/code.ex
@@ -12,6 +12,8 @@ defmodule Credo.Code do
   `Credo.Check.CodeHelper`.
   """
 
+  use Backports
+
   alias Credo.SourceFile
 
   defmodule ParserError do

--- a/mix.exs
+++ b/mix.exs
@@ -34,8 +34,9 @@ defmodule Credo.Mixfile do
   defp deps do
     [
       {:bunt, "~> 0.2.0"},
+      {:backports, "~> 0.2.0"},
       {:inch_ex, "~> 0.5.3", only: [:dev, :test]},
-      {:coverex, "~> 1.4.9", only: :test}
+      {:coverex, "~> 1.4.9", only: :test},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+%{"backports": {:hex, :backports, "0.2.0", "e5dab900e2176662eb976a8a4e82bdf47cce44bcc4980f33e2041b7f224ada75", [:mix], []},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "coverex": {:hex, :coverex, "1.4.9", "5f923d9fa5d50cf0eea40a55940cfc7dbf73138fb4dbab565c54d7f2e8724722", [:mix], [{:httpoison, "~> 0.8", [hex: :httpoison, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
   "dogma": {:hex, :dogma, "0.0.7"},

--- a/test/credo/check/refactor/pipe_chain_start_test.exs
+++ b/test/credo/check/refactor/pipe_chain_start_test.exs
@@ -13,13 +13,13 @@ defmodule CredoSampleModule do
   def some_function(parameter1, parameter2) do
     "Fahrenheit 451" |> String.to_char_list |> IO.inspect
 
-    "Fahrenheit 451" |> String.strip
+    "Fahrenheit 451" |> String.trim
 
     do_something() |> then_something_else() |> and_last_step()
 
     something
     |> String.downcase
-    |> String.strip
+    |> String.trim
 
     :something
     |> is_atom
@@ -145,9 +145,9 @@ end
 
   test "it should NOT report a violation for an excluded function call" do
 """
-String.strip("users") |> String.upcase
+String.trim("users") |> String.upcase
 """ |> to_source_file
-    |> refute_issues(@described_check, excluded_functions: ~w(String.strip table put_in))
+    |> refute_issues(@described_check, excluded_functions: ~w(String.trim table put_in))
   end
 
   test "it should NOT report a violation for an excluded function call /2" do
@@ -156,7 +156,7 @@ table("users")
 |> insert(%{name: "Bob Jones"})
 |> DB.run
 """ |> to_source_file
-    |> refute_issues(@described_check, excluded_functions: ~w(String.strip table put_in))
+    |> refute_issues(@described_check, excluded_functions: ~w(String.trim table put_in))
   end
 
   test "it should NOT report a violation for an excluded function call /3" do
@@ -164,7 +164,7 @@ table("users")
 put_in(users["john"][:age], 28)
 |> some_other_fun()
 """ |> to_source_file
-    |> refute_issues(@described_check, excluded_functions: ~w(String.strip table put_in))
+    |> refute_issues(@described_check, excluded_functions: ~w(String.trim table put_in))
   end
 
   test "it should NOT report a violation for ++" do
@@ -177,7 +177,7 @@ put_in(users["john"][:age], 28)
     |> wrap()
   end
 """ |> to_source_file
-    |> refute_issues(@described_check, excluded_functions: ~w(String.strip table put_in))
+    |> refute_issues(@described_check, excluded_functions: ~w(String.trim table put_in))
   end
 
   test "it should NOT report a violation for --" do
@@ -215,7 +215,7 @@ defmodule Test do
   end
 end
 """ |> to_source_file
-    |> refute_issues(@described_check, excluded_functions: ~w(String.strip table put_in))
+    |> refute_issues(@described_check, excluded_functions: ~w(String.trim table put_in))
   end
 
   #
@@ -224,10 +224,10 @@ end
 
   test "it should report a violation for a function call" do
 """
-String.strip("nope") |> String.upcase
-String.strip("nope")
+String.trim("nope") |> String.upcase
+String.trim("nope")
 |> String.downcase
-|> String.strip
+|> String.trim
 """ |> to_source_file
     |> assert_issues(@described_check)
   end

--- a/test/credo/check/refactor/pipe_chain_start_test.exs
+++ b/test/credo/check/refactor/pipe_chain_start_test.exs
@@ -11,7 +11,7 @@ defmodule Credo.Check.Refactor.PipeChainStartTest do
 ~S"""
 defmodule CredoSampleModule do
   def some_function(parameter1, parameter2) do
-    "Fahrenheit 451" |> String.to_char_list |> IO.inspect
+    "Fahrenheit 451" |> String.to_charlist |> IO.inspect
 
     "Fahrenheit 451" |> String.trim
 

--- a/test/credo/check/warning/unused_string_operation_test.exs
+++ b/test/credo/check/warning/unused_string_operation_test.exs
@@ -59,7 +59,7 @@ end
 """
 defmodule CredoSampleModule do
   def some_function(parameter1, parameter2) do
-    offset = String.length(line) - String.length(String.strip(line))
+    offset = String.length(line) - String.length(String.trim(line))
 
     parameter1 + parameter2 + offset
   end
@@ -72,9 +72,9 @@ end
 """
 defmodule CredoSampleModule do
   def some_function(parameter1, parameter2) do
-    if String.length(x1) > String.length(String.strip(x2)) do
+    if String.length(x1) > String.length(String.trim(x2)) do
       cond do
-        String.strip(x3) == "" -> IO.puts("1")
+        String.trim(x3) == "" -> IO.puts("1")
         String.length(x) == 15 -> IO.puts("2")
         String.replace(x, "a", "b") == "b" -> IO.puts("2")
       end
@@ -85,7 +85,7 @@ defmodule CredoSampleModule do
         _ -> something
       end
     end
-    unless String.strip(x4) == "" do
+    unless String.trim(x4) == "" do
       IO.puts "empty"
     end
 
@@ -129,7 +129,7 @@ defmodule CredoSampleModule do
     |> IO.puts
 
     if issue.column do
-      offset = String.length(line) - String.length(String.strip(line))
+      offset = String.length(line) - String.length(String.trim(line))
       [
           String.duplicate(" ", x), :faint, String.duplicate("^", w),
       ]
@@ -360,7 +360,7 @@ defmodule CredoSampleModule do
     if issue.column do
       IO.puts "."
     else
-      String.strip(filename)
+      String.trim(filename)
       IO.puts "x"
     end
   end
@@ -435,11 +435,11 @@ defmodule CredoSampleModule do
     parameter1
   end
   def some_function2(parameter1, parameter2) do
-   String.strip(parameter1)
+   String.trim(parameter1)
    parameter1
    end
    def some_function3(parameter1, parameter2) do
-     String.strip(parameter1)
+     String.trim(parameter1)
      parameter1
    end
 end

--- a/test/credo/check/warning/unused_string_operation_test.exs
+++ b/test/credo/check/warning/unused_string_operation_test.exs
@@ -284,7 +284,7 @@ end
 """
   defp print_process(pid_atom, count, own) do
     IO.puts([?", String.duplicate("-", 100)])
-    IO.write format_item(Path.join(path, item), String.ljust(item, width))
+    IO.write format_item(Path.join(path, item), String.pad_trailing(item, width))
     print_row(["s", "B", "s", ".3f", "s"], [count, "", own, ""])
   end
 """ |> to_source_file

--- a/test/credo/check/warning/unused_string_operation_test.exs
+++ b/test/credo/check/warning/unused_string_operation_test.exs
@@ -258,7 +258,7 @@ end
     else
       :ok ->
         {_in, analysis_output} = StringIO.contents(analyse_dest)
-        String.to_char_list(analysis_output)
+        String.to_charlist(analysis_output)
     after
       StringIO.close(analyse_dest)
     end

--- a/test/credo/cli/output/ui_test.exs
+++ b/test/credo/cli/output/ui_test.exs
@@ -9,7 +9,7 @@ defmodule Credo.CLI.Output.UITest do
     lines =
 """
 These checks take a look at your code and ensure a consistent coding style. Using tabs or spaces? Both is fine, just don't mix them or Credo will tell you.
-""" |> String.strip |> UI.wrap_at(80)
+""" |> String.trim |> UI.wrap_at(80)
     expected = [
       "These checks take a look at your code and ensure a consistent coding style. ",
       "Using tabs or spaces? Both is fine, just don't mix them or Credo will tell you."

--- a/test/credo/cli/output/ui_test.exs
+++ b/test/credo/cli/output/ui_test.exs
@@ -1,5 +1,6 @@
 defmodule Credo.CLI.Output.UITest do
   use Credo.TestHelper
+  use Backports
 
   alias Credo.CLI.Output.UI
 


### PR DESCRIPTION
I came across a lot of compiler warning when testing out credo with Elixir 1.5

There is an easy fix, so I applied it