### PR TITLE
Fixed the bug with FQ module names.

### DIFF
--- a/lib/credo/code/module.ex
+++ b/lib/credo/code/module.ex
@@ -227,6 +227,16 @@ defmodule Credo.Code.Module do
 
 
 
+  @doc "Returns the not fully qualified name of a module's given ast node."
+  def just_name({:defmodule, _, [{:__aliases__, _, name_list}, _]}) do
+    name_list
+    |> List.last()
+    |> Atom.to_string()
+  end
+  def just_name(_), do: "<Unknown Module Name>"
+
+
+
   # TODO: write unit test
   def exception?({:defmodule, _, [{:__aliases__, _, _name_list}, arguments]}) do
     arguments
@@ -238,4 +248,3 @@ defmodule Credo.Code.Module do
   defp defexception?({:defexception, _, _}), do: true
   defp defexception?(_), do: false
 end
-

--- a/test/credo/check/consistency/exception_names_test.exs
+++ b/test/credo/check/consistency/exception_names_test.exs
@@ -54,6 +54,21 @@ end
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report correct behaviour (same prefix, same module)" do
+    [
+"""
+defmodule MyModule.Errors.FeatureOne do
+  defexception [:message]
+end
+defmodule MyModule.Errors.FeatureTwo do
+  defexception [:message]
+end
+"""
+    ]
+    |> to_source_files
+    |> refute_issues(@described_check)
+  end
+
   test "it should NOT report correct behaviour (only one exception class)" do
     [
 """


### PR DESCRIPTION
There were false positives for the consistency check `Credo.Check.Consistency.ExceptionNames`:
```
  Consistency                                                                   
┃ 
┃ [C] ↗ Exception modules should be named consistently. It seems your strategy 
┃       is to prefix them with `Unexpected`, but 
┃       `Markright.Errors.UnexpectedFeature` does not follow that convention."
┃       lib/markright/errors/unexpected_feature.ex:1:11 #(Markright.Errors.UnexpectedFeature)
┃ [C] ↗ Exception modules should be named consistently. It seems your strategy 
┃       is to prefix them with `Unexpected`, but 
┃       `Markright.Errors.UnexpectedContinuation` does not follow that 
┃       convention."
┃       lib/markright/errors/unexpected_continuation.ex:1:11 #(Markright.Errors.UnexpectedContinuation)
```
The cause was that `Module.name` returned the whole fully qualified module name `Markright.Errors.UnexpectedFeature` when defined as:
```elixir
defmodule Markright.Errors.UnexpectedFeature do
```

and just the `UnexpectedFeature` when defined as:
```elixir
defmodule Markright.Errors do
  defmodule UnexpectedFeature do
```

That is the reason tests passed: there in tests the latter declaration was used.

I am not proud of the function name `Module.just_name/1`, please feel free to introduce a better one.