### PR TITLE
Support sigils in elixir 1.6

### DIFF
--- a/lib/credo/check/consistency/space_around_operators/space_helper.ex
+++ b/lib/credo/check/consistency/space_around_operators/space_helper.ex
@@ -55,6 +55,7 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper do
     line_no == line_no2 && col_end < col_start2
   end
 
+  def position({_, pos, _, _, _, _}), do: pos
   def position({_, pos, _, _, _}), do: pos
   def position({_, pos, _, _}), do: pos
   def position({_, pos, _}), do: pos

--- a/test/credo/check/consistency/space_around_operators_test.exs
+++ b/test/credo/check/consistency/space_around_operators_test.exs
@@ -26,6 +26,16 @@ defmodule OtherModule3 do
   end
 end
 """
+  @without_spaces3 """
+defmodule OtherModule4 do
+  defp dictionary_changeset() do
+    fields = ~W(
+      a
+      b
+    )a
+  end
+end
+"""
   @with_spaces """
 defmodule Credo.Sample2 do
   defmodule InlineModule do
@@ -185,6 +195,14 @@ end
   #
   # cases NOT raising issues
   #
+
+  test "it should not report issues when used with sigil" do
+    [
+      @without_spaces3
+    ]
+    |> to_source_files()
+    |> refute_issues(@described_check)
+  end
 
   test "it should not report issues if spaces are used everywhere" do
     [


### PR DESCRIPTION
When using elixir from master (primarily because of [this](https://github.com/elixir-lang/elixir/pull/6307)), credo crashes with the following error:

<details>

```
15:19:34.077 [error] Task #PID<0.182.0> started from #PID<0.73.0> terminating
** (FunctionClauseError) no function clause matching in Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper.position/1
    lib/credo/check/consistency/space_around_operators/space_helper.ex:58: Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper.position({:sigil, {3, 14, 6}, 87, ["\n      name\n      is_active1\n    "], 'a', '('})
    lib/credo/check/consistency/space_around_operators/space_helper.ex:46: Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper.no_space_between?/2
    lib/credo/check/consistency/space_around_operators/collector.ex:88: Credo.Check.Consistency.SpaceAroundOperators.Collector.without_space?/3
    lib/credo/check/consistency/space_around_operators/collector.ex:53: Credo.Check.Consistency.SpaceAroundOperators.Collector.record_spaces/4
    lib/credo/check/consistency/space_around_operators/collector.ex:28: Credo.Check.Consistency.SpaceAroundOperators.Collector.traverse_tokens/3
    lib/credo/check/consistency/collector.ex:126: anonymous fn/3 in Credo.Check.Consistency.Collector.find_issues/4
    (elixir) lib/enum.ex:1255: Enum."-map/2-lists^map/1-0-"/2
    (elixir) lib/enum.ex:1255: Enum."-map/2-lists^map/1-0-"/2
Function: #Function<11.20071509/0 in Credo.Check.Runner.run_checks_that_run_on_all/2>
    Args: []

15:19:34.084 [error] GenServer Credo.Supervisor terminating
** (FunctionClauseError) no function clause matching in Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper.position/1
    lib/credo/check/consistency/space_around_operators/space_helper.ex:58: Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper.position({:sigil, {3, 14, 6}, 87, ["\n      name\n      is_active1\n    "], 'a', '('})
    lib/credo/check/consistency/space_around_operators/space_helper.ex:46: Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper.no_space_between?/2
    lib/credo/check/consistency/space_around_operators/collector.ex:88: Credo.Check.Consistency.SpaceAroundOperators.Collector.without_space?/3
    lib/credo/check/consistency/space_around_operators/collector.ex:53: Credo.Check.Consistency.SpaceAroundOperators.Collector.record_spaces/4
    lib/credo/check/consistency/space_around_operators/collector.ex:28: Credo.Check.Consistency.SpaceAroundOperators.Collector.traverse_tokens/3
    lib/credo/check/consistency/collector.ex:126: anonymous fn/3 in Credo.Check.Consistency.Collector.find_issues/4
    (elixir) lib/enum.ex:1255: Enum."-map/2-lists^map/1-0-"/2
    (elixir) lib/enum.ex:1255: Enum."-map/2-lists^map/1-0-"/2
Last message: {:EXIT, #PID<0.73.0>, {%FunctionClauseError{args: nil, arity: 1, clauses: nil, function: :position, kind: nil, module: Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper}, [{Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper, :position, [{:sigil, {3, 14, 6}, 87, ["\n      name\n      is_active1\n    "], 'a', '('}], [file: 'lib/credo/check/consistency/space_around_operators/space_helper.ex', line: 58]}, {Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper, :no_space_between?, 2, [file: 'lib/credo/check/consistency/space_around_operators/space_helper.ex', line: 46]}, {Credo.Check.Consistency.SpaceAroundOperators.Collector, :without_space?, 3, [file: 'lib/credo/check/consistency/space_around_operators/collector.ex', line: 88]}, {Credo.Check.Consistency.SpaceAroundOperators.Collector, :record_spaces, 4, [file: 'lib/credo/check/consistency/space_around_operators/collector.ex', line: 53]}, {Credo.Check.Consistency.SpaceAroundOperators.Collector, :traverse_tokens, 3, [file: 'lib/credo/check/consistency/space_around_operators/collector.ex', line: 28]}, {Credo.Check.Consistency.Collector, :"-find_issues/4-fun-0-", 3, [file: 'lib/credo/check/consistency/collector.ex', line: 126]}, {Enum, :"-map/2-lists^map/1-0-", 2, [file: 'lib/enum.ex', line: 1255]}, {Enum, :"-map/2-lists^map/1-0-", 2, [file: 'lib/enum.ex', line: 1255]}]}}
State: {:state, {:local, Credo.Supervisor}, :one_for_one, [{:child, #PID<0.171.0>, Credo.Service.SourceFileSource, {Credo.Service.SourceFileSource, :start_link, []}, :permanent, 5000, :worker, [Credo.Service.SourceFileSource]}, {:child, #PID<0.170.0>, Credo.Service.SourceFileLines, {Credo.Service.SourceFileLines, :start_link, []}, :permanent, 5000, :worker, [Credo.Service.SourceFileLines]}, {:child, #PID<0.169.0>, Credo.Service.SourceFileAST, {Credo.Service.SourceFileAST, :start_link, []}, :permanent, 5000, :worker, [Credo.Service.SourceFileAST]}, {:child, #PID<0.168.0>, Credo.Service.SourceFileScopes, {Credo.Service.SourceFileScopes, :start_link, []}, :permanent, 5000, :worker, [Credo.Service.SourceFileScopes]}, {:child, #PID<0.167.0>, Credo.Service.Commands, {Credo.Service.Commands, :start_link, []}, :permanent, 5000, :worker, [Credo.Service.Commands]}, {:child, #PID<0.166.0>, Credo.CLI.Output.Shell, {Credo.CLI.Output.Shell, :start_link, []}, :permanent, 5000, :worker, [Credo.CLI.Output.Shell]}], :undefined, 3, 5, [], 0, Supervisor.Default, {[{Credo.CLI.Output.Shell, {Credo.CLI.Output.Shell, :start_link, []}, :permanent, 5000, :worker, [Credo.CLI.Output.Shell]}, {Credo.Service.Commands, {Credo.Service.Commands, :start_link, []}, :permanent, 5000, :worker, [Credo.Service.Commands]}, {Credo.Service.SourceFileScopes, {Credo.Service.SourceFileScopes, :start_link, []}, :permanent, 5000, :worker, [Credo.Service.SourceFileScopes]}, {Credo.Service.SourceFileAST, {Credo.Service.SourceFileAST, :start_link, []}, :permanent, 5000, :worker, [Credo.Service.SourceFileAST]}, {Credo.Service.SourceFileLines, {Credo.Service.SourceFileLines, :start_link, []}, :permanent, 5000, :worker, [Credo.Service.SourceFileLines]}, {Credo.Service.SourceFileSource, {Credo.Service.SourceFileSource, :start_link, []}, :permanent, 5000, :worker, [Credo.Service.SourceFileSource]}], [strategy: :one_for_one]}}
```
</details>


Recently changes were introduced to sigils (https://github.com/elixir-lang/elixir/pull/6305 for more info). This PR attempts to make credo compatible with those changes.