### PR TITLE
Convert missing check params to an empty list

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -50,7 +50,7 @@ defmodule Credo.Check do
       end
 
       def explanation_for_params do
-        Check.explanation_for(@explanation, :params)
+        Check.explanation_for(@explanation, :params) || []
       end
 
       def format_issue(issue_meta, opts) do


### PR DESCRIPTION
Fix #411


There are about 3 different places a fix for this issue could fit. I
figured this might be the simplest.