### PR TITLE
[Fix #409] Fix explicit `explain` command usage

### DIFF
--- a/lib/credo/execution/task/convert_cli_options_to_config.ex
+++ b/lib/credo/execution/task/convert_cli_options_to_config.ex
@@ -36,6 +36,10 @@ defmodule Credo.Execution.Task.ConvertCLIOptionsToConfig do
       set_command_and_path(exec, options, @default_command_name, options.path)
     end
   end
+  defp determine_command(exec, %Options{command: "explain", args: args} = options) do
+    potential_path = List.first(args)
+    set_command_and_path(exec, options, "explain", potential_path)
+  end
   defp determine_command(exec, _options), do: exec
 
   defp set_command_and_path(exec, options, command, path) do


### PR DESCRIPTION
Hi guys,

I am very new to Elixir and this is my first try to contribute to any Elixir project.

I have found the issue #409 which is marked as good for beginners.
@philipdexter even managed to provide code snippet with solution.

I debug the issue to understand how it works (should I say _how it doesn't work_ 😄) and came to almost the same solution.

The difference is that I didn't touch `Credo.CLI.Command.Explain` itself and just prepared proper `exec` structure in `Credo.Execution.Task.ConvertCLIOptionsToConfig`.

It works fine for me now but maybe I have missed something?

Any comments are welcome.

Thank you.