### PR TITLE
Guard against unquoting attributes on `ModuleAttributeNames`.

### DIFF
--- a/lib/credo/check/readability/module_attribute_names.ex
+++ b/lib/credo/check/readability/module_attribute_names.ex
@@ -38,11 +38,12 @@ defmodule Credo.Check.Readability.ModuleAttributeNames do
     {ast, issues}
   end
 
-  defp issue_for_name(issue_meta, name, meta) do
+  defp issue_for_name(issue_meta, name, meta) when is_binary(name) or is_atom(name) do
     unless name |> to_string |> Name.snake_case? do
       issue_for(issue_meta, meta[:line], "@#{name}")
     end
   end
+  defp issue_for_name(_, _, _), do: nil
 
   defp issue_for(issue_meta, line_no, trigger) do
     format_issue issue_meta,

--- a/test/credo/check/readability/module_attribute_names_test.exs
+++ b/test/credo/check/readability/module_attribute_names_test.exs
@@ -16,6 +16,19 @@ end
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT fail on a dynamic attribute" do
+"""
+defmodule CredoSampleModule do
+  defmacro define(key, value) do
+    quote do
+      @unquote(key)(unquote(value))
+    end
+  end
+end
+""" |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
   #
   # cases raising issues
   #


### PR DESCRIPTION
Similar scenario as #329, #311, #275 and others. The fix is a carbon copy of how cb0622af407b9bf04fc2d5214020e935d111aca7 handles these cases.