### PR TITLE
Prevent exception thrown when run against empty umbrella project

### DIFF
--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -153,6 +153,7 @@ defmodule Credo.CLI.Output.Summary do
   defp scope_count(%SourceFile{} = source_file) do
     Credo.Code.prewalk(source_file, &scope_count_traverse/2, 0)
   end
+  defp scope_count([]), do: 0
   defp scope_count(source_files) when is_list(source_files) do
     source_files
     |> Enum.map(&scope_count/1)

--- a/test/credo/cli/output/summary_test.exs
+++ b/test/credo/cli/output/summary_test.exs
@@ -1,0 +1,16 @@
+defmodule Credo.CLI.Output.SummaryTest do
+  use Credo.TestHelper
+
+  alias Credo.CLI.Output.Summary
+  alias Credo.Execution
+
+  doctest Credo.CLI.Output.Summary
+
+  test "print/4 it does not blow up on an empty umbrella project" do
+    config =
+      %Credo.Execution{}
+      |> Credo.Execution.SourceFiles.start_server
+      |> Credo.Execution.Issues.start_server
+    Summary.print([], config, 0, 0)
+  end
+end


### PR DESCRIPTION
# Defect (Erlang 20, Elixir 1.5.1)
- create an empty umbrella project
- install credo
- run credo
- exception is thrown because there are no source files.

# Changes
- added test to demonstrate issue
- Added pattern match for empty source_files list to `Credo.CLI.Output.Summary.scope_count/1`