### PR TITLE
321 add check name when verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ You will now be able to invoke credo as usual through Mix with `mix credo`. This
 
 ### Show code snippets in the output
 
-Use the `--verbose` switch to include the code snippets in question in the output.
+Use the `--verbose` switch to include the code snippets in question as well as the module name of teh failed check in the output.
 
 
 ### Show compact list

--- a/lib/credo/cli/output/issue_helper.ex
+++ b/lib/credo/cli/output/issue_helper.ex
@@ -56,6 +56,10 @@ defmodule Credo.CLI.Output.IssueHelper do
     |> UI.wrap_at(term_width - @indent)
     |> print_issue_message(check, outer_color, message_color, tag_style, priority)
 
+    if exec.verbose do
+      print_issue_check(issue, outer_color, inner_color, message_color)
+    end
+
     [
       UI.edge(outer_color, @indent),
         filename_color, :faint, filename |> to_string,
@@ -69,6 +73,24 @@ defmodule Credo.CLI.Output.IssueHelper do
 
       UI.puts_edge([outer_color, :faint])
     end
+  end
+
+  defp print_issue_check(issue, outer_color, inner_color, message_color) do
+    outer_color
+    |> UI.edge
+    |> UI.puts
+
+    [
+      UI.edge(outer_color),
+        outer_color,
+        String.duplicate(" ", @indent - 3),
+        :normal, message_color, " ", "Failed #{issue.check}",
+    ]
+    |> UI.puts
+
+    outer_color
+    |> UI.edge
+    |> UI.puts
   end
 
   defp print_issue_message([first_line | other_lines], check, outer_color, message_color, tag_style, priority) do


### PR DESCRIPTION
# Why
https://github.com/rrrene/credo/issues/321

# What changed
Added the name of the module of the failed check to output when verbose
<img width="706" alt="screen shot 2017-09-07 at 8 19 21 pm" src="https://user-images.githubusercontent.com/607860/30194739-e1fda558-9409-11e7-9dac-ecbdf8023525.png">

