### PR TITLE
Work in progress: Track string-only lines when handling line length

### DIFF
--- a/lib/credo/check/readability/max_line_length.ex
+++ b/lib/credo/check/readability/max_line_length.ex
@@ -25,6 +25,12 @@ defmodule Credo.Check.Readability.MaxLineLength do
 
   use Credo.Check, base_priority: :low
 
+  @sigil_delimiters [{"(", ")"}, {"[", "]"}, {"{", "}"}, {"<", ">"},
+                      {"|", "|"}, {"\"", "\""}, {"'", "'"}]
+  @all_string_sigils Enum.flat_map(@sigil_delimiters, fn({b, e}) ->
+                        [{"~s#{b}", e}, {"~S#{b}", e}]
+                      end)
+
   @doc false
   def run(source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
@@ -39,7 +45,7 @@ defmodule Credo.Check.Readability.MaxLineLength do
     source = SourceFile.source(source_file)
     source =
       if ignore_strings do
-        Credo.Code.Strings.replace_with_spaces(source, "")
+        replace_with_spaces(source, "")
       else
         source
       end
@@ -103,5 +109,130 @@ defmodule Credo.Check.Readability.MaxLineLength do
       line_no: line_no,
       column: column,
       trigger: trigger
+  end
+
+  def replace_with_spaces(source, replacement \\ " ") do
+    parse_code(source, "", replacement, false)
+  end
+
+  defp parse_code("", acc, _replacement, _sol) do
+    acc
+  end
+  for {sigil_start, sigil_end} <- @all_string_sigils do
+    defp parse_code(<< unquote(sigil_start)::utf8, t::binary >>, acc, replacement, sol) do
+      parse_string_sigil(t, acc <> unquote(sigil_start), unquote(sigil_end), replacement, sol)
+    end
+  end
+  defp parse_code(<< "\\\""::utf8, t::binary >>, acc, replacement, sol) do
+    parse_code(t, acc <> "\\\"", replacement, false)
+  end
+  defp parse_code(<< "?\""::utf8, t::binary >>, acc, replacement, sol) do
+    parse_code(t, acc <> "?\"", replacement, false)
+  end
+  defp parse_code(<< "#"::utf8, t::binary >>, acc, replacement, sol) do
+    parse_comment(t, acc <> "#", replacement, false)
+  end
+  defp parse_code(<< "\"\"\""::utf8, t::binary >>, acc, replacement, sol) do
+    parse_heredoc(t, acc <> ~s("""), replacement, sol)
+  end
+  defp parse_code(<< "\'\'\'"::utf8, t::binary >>, acc, replacement, sol) do
+    parse_heredoc(t, acc <> ~s("""), replacement, sol)
+  end
+  defp parse_code(<< "\""::utf8, t::binary >>, acc, replacement, sol) do
+    parse_string_literal(t, acc <> "\"", replacement, sol)
+  end
+  defp parse_code(<< "\n"::utf8, t::binary >>, acc, replacement, sol) do
+    parse_code(t, acc <> "\n", replacement, true)
+  end
+  defp parse_code(<< " "::utf8, t::binary >>, acc, replacement, sol) do
+    parse_code(t, acc <> " ", replacement, sol)
+  end
+  defp parse_code(<< h::utf8, t::binary >>, acc, replacement, sol) do
+    parse_code(t, acc <> <<h :: utf8>>, replacement, false)
+  end
+  defp parse_code(str, acc, replacement, sol) when is_binary(str) do
+    {h, t} = String.next_codepoint(str)
+
+    parse_code(t, acc <> h, replacement, sol)
+  end
+
+  defp parse_comment("", acc, _replacement, sol) do
+    acc
+  end
+  defp parse_comment(<< "\n"::utf8, t::binary >>, acc, replacement, sol) do
+    parse_code(t, acc <> "\n", replacement, true)
+  end
+  defp parse_comment(str, acc, replacement, sol) when is_binary(str) do
+    {h, t} = String.next_codepoint(str)
+
+    parse_comment(t, acc <> h, replacement, sol)
+  end
+
+  defp parse_string_literal("", acc, _replacement, sol) do
+    acc
+  end
+  defp parse_string_literal(<< "\\\\"::utf8, t::binary >>, acc, replacement, sol) do
+    parse_string_literal(t, acc, replacement, sol)
+  end
+  defp parse_string_literal(<< "\\\""::utf8, t::binary >>, acc, replacement, sol) do
+    parse_string_literal(t, acc, replacement, sol)
+  end
+  defp parse_string_literal(<< "\""::utf8, t::binary >>, acc, replacement, sol) do
+    parse_code(t, acc <> ~s("), replacement, sol)
+  end
+  defp parse_string_literal(<< "\n"::utf8, t::binary >>, acc, replacement, sol) do
+    parse_string_literal(t, acc <> "\n", replacement, true)
+  end
+  defp parse_string_literal(<< _::utf8, t::binary >>, acc, replacement, true) do
+    parse_string_literal(t, acc <> replacement, replacement, true)
+  end
+  defp parse_string_literal(<< h::utf8, t::binary >>, acc, replacement, false) do
+    parse_string_literal(t, acc <> << h::utf8 >>, replacement, false)
+  end
+
+  for {_sigil_start, sigil_end} <- @all_string_sigils do
+    defp parse_string_sigil("", acc, unquote(sigil_end), _replacement, sol) do
+      acc
+    end
+    defp parse_string_sigil(<< "\\\\"::utf8, t::binary >>, acc, unquote(sigil_end), replacement, sol) do
+      parse_string_sigil(t, acc, unquote(sigil_end), replacement, sol)
+    end
+    defp parse_string_sigil(<< "\\\""::utf8, t::binary >>, acc, unquote(sigil_end), replacement, sol) do
+      parse_string_sigil(t, acc, unquote(sigil_end), replacement, sol)
+    end
+    defp parse_string_sigil(<< unquote(sigil_end)::utf8, t::binary >>, acc, unquote(sigil_end), replacement, sol) do
+      parse_code(t, acc <> unquote(sigil_end), replacement, sol)
+    end
+    defp parse_string_sigil(<< "\n"::utf8, t::binary >>, acc, unquote(sigil_end), replacement, sol) do
+      parse_string_sigil(t, acc <> "\n", unquote(sigil_end), replacement, sol)
+    end
+    defp parse_string_sigil(<< _::utf8, t::binary >>, acc, unquote(sigil_end), replacement, true) do
+      parse_string_sigil(t, acc <> replacement, unquote(sigil_end), replacement, true)
+    end
+    defp parse_string_sigil(<< h::utf8, t::binary >>, acc, unquote(sigil_end), replacement, false) do
+      parse_string_sigil(t, acc <> << h::utf8 >>, unquote(sigil_end), replacement, false)
+    end
+  end
+
+  defp parse_heredoc("", acc, _replacement, sol) do
+    acc
+  end
+  defp parse_heredoc(<< "\\\\"::utf8, t::binary >>, acc, replacement, sol) do
+    parse_heredoc(t, acc, replacement, sol)
+  end
+  defp parse_heredoc(<< "\\\""::utf8, t::binary >>, acc, replacement, sol) do
+    parse_heredoc(t, acc, replacement, sol)
+  end
+  defp parse_heredoc(<< "\"\"\""::utf8, t::binary >>, acc, replacement, sol) do
+    parse_code(t, acc <> ~s("""), replacement, sol)
+  end
+  defp parse_heredoc(<< "\n"::utf8, t::binary >>, acc, replacement, sol) do
+    parse_heredoc(t, acc <> "\n", replacement, sol)
+  end
+  defp parse_heredoc(<< _::utf8, t::binary >>, acc, replacement, true) do
+    parse_heredoc(t, acc <> replacement, replacement, true)
+  end
+  defp parse_heredoc(<< h::utf8, t::binary >>, acc, replacement, false) do
+    parse_heredoc(t, acc <> << h::utf8 >>, replacement, false)
   end
 end

--- a/test/credo/check/readability/max_line_length_test.exs
+++ b/test/credo/check/readability/max_line_length_test.exs
@@ -112,4 +112,102 @@ end
       end)
   end
 
+  test "it should report a violation with strings and code" do
+"""
+defmodule CredoSampleModule do
+  use ExUnit.Case
+  def some_fun do
+    assert "1" <> "1" <> "1" <> "1" <> "1" <> "1" <> "1" <> "1" <> "1" <> "1" <> "1" <> "1" <> "1" <> "1" == "2"
+  end
+end
+"""
+    |> to_source_file
+    |> assert_issue(@described_check, max_length: 100)
+  end
+
+  test "it should report a violation with strings and code again" do
+"""
+defmodule CredoSampleModule do
+  use ExUnit.Case
+  def some_fun do
+    assert "a really long line a really long line a really long line a really long line"
+  end
+end
+"""
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report a violation with strings and code again again" do
+"""
+defmodule CredoSampleModule do
+  def some_fun do
+    blah = ~s{
+        a really long line a really long line a really long line a really long line
+    }
+  end
+end
+"""
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report a violation with strings and code again again again" do
+"""
+defmodule CredoSampleModule do
+  def some_fun do
+    blah = \"\"\"
+        a really long line a really long line a really long line a really long line
+    \"\"\"
+  end
+end
+"""
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should NOT report a violation with strings on their own line" do
+"""
+defmodule CredoSampleModule do
+  use ExUnit.Case
+  def some_fun do
+    assert
+      "a really long line a really long line a really long line a really long line"
+  end
+end
+"""
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  test "it should NOT report a violation with strings on their own line again" do
+"""
+defmodule CredoSampleModule do
+  def some_fun do
+    blah =
+    ~s{
+        a really long line a really long line a really long line a really long line
+    }
+  end
+end
+"""
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  test "it should NOT report a violation with strings on their own line again again" do
+"""
+defmodule CredoSampleModule do
+  def some_fun do
+    blah =
+    \"\"\"
+        a really long line a really long line a really long line a really long line
+    \"\"\"
+  end
+end
+"""
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
 end


### PR DESCRIPTION
This is a work in progress pull request. I am showing one possible solution
to the problem in #389. The solution and its tests still need cleaning.

I did not make the changes to Credo.Code.Strings because
its `replace_with_spaces` is used in other checks, ones
which are sensitive to this update.

Thanks!