### PR TITLE
The arity of call() should be 2. Otherwise, task.ex's run/3 function …

### DIFF
--- a/lib/credo/execution/task/require_requires.ex
+++ b/lib/credo/execution/task/require_requires.ex
@@ -3,7 +3,7 @@ defmodule Credo.Execution.Task.RequireRequires do
 
   alias Credo.Sources
 
-  def call(%Execution{requires: requires} = exec) do
+  def call(%Execution{requires: requires} = exec, _opts) do
     requires
     |> Sources.find
     |> Enum.each(&Code.require_file/1)


### PR DESCRIPTION
…will never actually invoke this function, instead invoking the default call/2 defined in the task macro. This will result in the 'requires' section of .credo.exs to be ignored, causing custom checks specified there to never get loaded.