### PR TITLE
Fix loading of custom checks

### DIFF
--- a/lib/credo/execution/task/require_requires.ex
+++ b/lib/credo/execution/task/require_requires.ex
@@ -3,7 +3,7 @@ defmodule Credo.Execution.Task.RequireRequires do
 
   alias Credo.Sources
 
-  def call(%Execution{requires: requires} = exec) do
+  def call(%Execution{requires: requires} = exec, _opts) do
     requires
     |> Sources.find
     |> Enum.each(&Code.require_file/1)


### PR DESCRIPTION
This fixes the loading of the RequireRequires task.

Without the 2nd param, the task is not executed and loading of custom checks fails.