### PR TITLE
Clean up contribution guide file to match the one in the readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 1. [Fork it!](http://github.com/rrrene/credo/fork)
-1. Create your feature branch (`git checkout -b my-new-feature`)
-1. Commit your changes (`git commit -am 'Add some feature'`)
-1. Push to the branch (`git push origin my-new-feature`)
-1. Create new Pull Request
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
-[Fork the repository](http://github.com/rrrene/credo/fork)
-Create your feature branch (`git checkout -b my-new-feature`)
-Commit your changes (`git commit -am 'Add some feature'`)
-Push to the branch (`git push origin my-new-feature`)
-Create new Pull Request
+1. [Fork it!](http://github.com/rrrene/credo/fork)
+1. Create your feature branch (`git checkout -b my-new-feature`)
+1. Commit your changes (`git commit -am 'Add some feature'`)
+1. Push to the branch (`git push origin my-new-feature`)
+1. Create new Pull Request


### PR DESCRIPTION
I was wanting to contribute to this repo. Out of habbit, I just opened up `CONTRIBUTING.md` and I noticed that the markdown was not rendering really well. I saw that there was also a contributing guide in the README (this one rendered properly) so I figured that I would just make them match to avoid confusion.