### PR TITLE
Skip pipe start check on erlang functions

### DIFF
--- a/lib/credo/check/refactor/pipe_chain_start.ex
+++ b/lib/credo/check/refactor/pipe_chain_start.ex
@@ -21,9 +21,10 @@ defmodule Credo.Check.Refactor.PipeChainStart do
 
   @explanation [
     check: @moduledoc,
-    excluded_functions: "All functions listed will be ignored."
+    excluded_functions: "All functions listed will be ignored.",
+    exclude_erlang_funcs: "Specifies that we want to treat erlang functions as raw values"
   ]
-  @default_params [excluded_functions: []]
+  @default_params [excluded_functions: [], exclude_erlang_funcs: false]
 
   use Credo.Check
 
@@ -31,57 +32,72 @@ defmodule Credo.Check.Refactor.PipeChainStart do
   def run(source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
     excluded_functions = Params.get(params, :excluded_functions, @default_params)
+    exclude_erlang_funcs = Params.get(params, :exclude_erlang_funcs, @default_params)
 
-    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta, excluded_functions))
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta, excluded_functions, exclude_erlang_funcs))
   end
 
-  defp traverse({:|>, _, [{:|>, _, _} | _]} = ast, issues, _issue_meta, _excluded_functions) do
+  defp traverse({:|>, _, [{:|>, _, _} | _]} = ast, issues, _issue_meta, _excluded_functions, _exclude_erlang_funcs) do
     {ast, issues}
   end
-  defp traverse({:|>, meta, [lhs | _rhs]} = ast, issues, issue_meta, excluded_functions) do
-    if valid_chain_start?(lhs, excluded_functions) do
+  defp traverse({:|>, meta, [lhs | _rhs]} = ast, issues, issue_meta, excluded_functions, exclude_erlang_funcs) do
+    if valid_chain_start?(lhs, excluded_functions, exclude_erlang_funcs) do
       {ast, issues}
     else
       {ast, issues ++ [issue_for(issue_meta, meta[:line], "TODO")]}
     end
   end
-  defp traverse(ast, issues, _issue_meta, _excluded_functions) do
+  defp traverse(ast, issues, _issue_meta, _excluded_functions, _exclude_erlang_funcs) do
     {ast, issues}
   end
 
 
   for atom <- [:%, :%{}, :.., :<<>>, :@, :__aliases__, :unquote, :{}, :&, :<>, :++, :--, :&&, :||, :-, :for, :with, :<-] do
-    defp valid_chain_start?({unquote(atom), _meta, _arguments}, _excluded_functions) do
+    defp valid_chain_start?({unquote(atom), _meta, _arguments}, _excluded_functions, _exclude_erlang_funcs) do
       true
     end
   end
   # anonymous function
-  defp valid_chain_start?({:fn, _, [{:->, _, [_args, _body]}]}, _excluded_functions) do
+  defp valid_chain_start?({:fn, _, [{:->, _, [_args, _body]}]}, _excluded_functions, _exclude_erlang_funcs) do
     true
   end
   # function_call()
-  defp valid_chain_start?({atom, _, []}, _excluded_functions) when is_atom(atom) do
+  defp valid_chain_start?({atom, _, []}, _excluded_functions, _exclude_erlang_funcs) when is_atom(atom) do
     true
   end
   # function_call(with, args) and sigils
-  defp valid_chain_start?({atom, _, arguments} = ast, excluded_functions) when is_atom(atom) and is_list(arguments) do
+  defp valid_chain_start?({atom, _, arguments} = ast, excluded_functions, _exclude_erlang_funcs) when is_atom(atom) and is_list(arguments) do
     function_name = to_function_call_name(ast)
 
     sigil?(atom) || Enum.member?(excluded_functions, function_name)
   end
   # map[:access]
-  defp valid_chain_start?({{:., _, [Access, :get]}, _, _}, _excluded_functions) do
+  defp valid_chain_start?({{:., _, [Access, :get]}, _, _}, _excluded_functions, _exclude_erlang_funcs) do
     true
   end
   # Module.function_call()
-  defp valid_chain_start?({{:., _, _}, _, []}, _excluded_functions), do: true
+  defp valid_chain_start?({{:., _, _}, _, []}, _excluded_functions, _exclude_erlang_funcs), do: true
+  defp valid_chain_start?({{:., _, [module_name, _]}, _, _} = ast, excluded_functions, exclude_erlang_funcs) when is_atom(module_name) do
+    function_name = to_function_call_name(ast)
+
+    try do
+      module_name.module_info # ensure erlang module is loaded
+      :erlang.get_module_info(module_name, :module) # check if module is a erlang one
+
+      # Is a Erlang lib
+      exclude_erlang_funcs || Enum.member?(excluded_functions, function_name)
+    rescue
+      # Not a Erlang lib
+      [UndefinedFunctionError, ArgumentError] -> Enum.member?(excluded_functions, function_name)
+    end
+  end
   # Module.function_call(with, parameters)
-  defp valid_chain_start?({{:., _, _}, _, _} = ast, excluded_functions) do
+  defp valid_chain_start?({{:., _, _}, _, _} = ast, excluded_functions, _exclude_erlang_funcs) do
     function_name = to_function_call_name(ast)
 
     Enum.member?(excluded_functions, function_name)
   end
-  defp valid_chain_start?(_, _excluded_functions), do: true
+  defp valid_chain_start?(_, _excluded_functions, _exclude_erlang_funcs), do: true
 
   defp sigil?(atom) do
     atom

--- a/test/credo/check/refactor/pipe_chain_start_test.exs
+++ b/test/credo/check/refactor/pipe_chain_start_test.exs
@@ -183,6 +183,13 @@ put_in(users["john"][:age], 28)
     |> refute_issues(@described_check, excluded_functions: ~w(:crypto.hash))
   end
 
+  test "it should report a violation for a erlang function call" do
+"""
+:crypto.hash(:md5, "test") |> Base.encode16(case: :lower)
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
   test "it should NOT report a violation for a erlang function call" do
 """
 :crypto.hash(:md5, "test") |> Base.encode16(case: :lower)

--- a/test/credo/check/refactor/pipe_chain_start_test.exs
+++ b/test/credo/check/refactor/pipe_chain_start_test.exs
@@ -190,6 +190,20 @@ put_in(users["john"][:age], 28)
     |> refute_issues(@described_check, exclude_erlang_funcs: true)
   end
 
+  test "it should report a violation for a function call from a random atom excluding erlang" do
+"""
+:test.hash(:md5, "test") |> Base.encode16(case: :lower)
+""" |> to_source_file
+    |> assert_issue(@described_check, exclude_erlang_funcs: true)
+  end
+
+  test "it should report a violation for a function call from a random atom NOT excluding erlang" do
+"""
+:test.hash(:md5, "test") |> Base.encode16(case: :lower)
+""" |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
   test "it should NOT report a violation for ++" do
 """
   def build(%Ecto.Query{} = query) do

--- a/test/credo/check/refactor/pipe_chain_start_test.exs
+++ b/test/credo/check/refactor/pipe_chain_start_test.exs
@@ -183,6 +183,13 @@ put_in(users["john"][:age], 28)
     |> refute_issues(@described_check, excluded_functions: ~w(:crypto.hash))
   end
 
+  test "it should NOT report a violation for a erlang function call" do
+"""
+:crypto.hash(:md5, "test") |> Base.encode16(case: :lower)
+""" |> to_source_file
+    |> refute_issues(@described_check, exclude_erlang_funcs: true)
+  end
+
   test "it should NOT report a violation for ++" do
 """
   def build(%Ecto.Query{} = query) do


### PR DESCRIPTION
Attempted to add a config option to allow credo to think erlang functions are valid for beginning a pipe stanza as per issue #431. Currently the only way I am seeing to determine for sure that the module is from erlang  is to call some erlang module specific functions and handle the try rescue response accordingly. If it doesn't throw a exception then we can pretty safely assume it is a erlang module. Otherwise it is something else.

