### PR TITLE
Allow empty enum params

### DIFF
--- a/lib/credo/check/consistency/space_in_parentheses.ex
+++ b/lib/credo/check/consistency/space_in_parentheses.ex
@@ -16,7 +16,10 @@ defmodule Credo.Check.Consistency.SpaceInParentheses do
   you should use a consistent style throughout your codebase.
   """
 
-  @explanation [check: @moduledoc]
+  @explanation [
+    check: @moduledoc,
+    allow_empty_enums: "Allows [], %{} and similar empty enum values to be used regardless of spacing throughout the codebase"
+  ]
 
   @collector Credo.Check.Consistency.SpaceInParentheses.Collector
 
@@ -29,8 +32,12 @@ defmodule Credo.Check.Consistency.SpaceInParentheses do
 
   defp issues_for(expected, source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
+    options =
+      %{}
+      |> Map.put(:allow_empty_enums, Params.get(params, :allow_empty_enums, @default_params))
+
     lines_with_issues =
-      @collector.find_locations_not_matching(expected, source_file)
+      @collector.find_locations_not_matching(expected, source_file, options)
 
     lines_with_issues
     |> Enum.filter(&create_issue?(expected, &1[:trigger]))

--- a/lib/credo/check/consistency/space_in_parentheses/collector.ex
+++ b/lib/credo/check/consistency/space_in_parentheses/collector.ex
@@ -5,8 +5,9 @@ defmodule Credo.Check.Consistency.SpaceInParentheses.Collector do
   alias Credo.Code
 
   @regex [
-    with_space: ~r/[^\?]([\{\[\(]\s+\S|\S\s+[\)\]\}])/,
-    without_space: ~r/[^\?]([\{\[\(]\S|\S[\)\]\}])/
+    with_space: ~r/[^\?]([\{\[\(]\s+\S|\S\s+[\)\]\}]])/,
+    without_space: ~r/[^\?]([\{\[\(]\S|\S[\)\]\}])/,
+    without_space_allow_empty_enums: ~r/[^\?](?!\{\}|\[\])([\{\[\(]\S|\S[\)\]\}])/
   ]
 
   def collect_matches(source_file, _params) do
@@ -16,8 +17,9 @@ defmodule Credo.Check.Consistency.SpaceInParentheses.Collector do
     |> Enum.reduce(%{}, &spaces/2)
   end
 
-  def find_locations_not_matching(expected, source_file) do
+  def find_locations_not_matching(expected, source_file, %{allow_empty_enums: allow_empty_enums}) do
     actual = case expected do
+      :with_space when allow_empty_enums == true -> :without_space_allow_empty_enums
       :with_space -> :without_space
       :without_space -> :with_space
     end

--- a/test/credo/check/consistency/space_in_parentheses/collector_test.exs
+++ b/test/credo/check/consistency/space_in_parentheses/collector_test.exs
@@ -25,6 +25,21 @@ defmodule Credo.Sample2 do
   end
 end
 """
+  @empty_enum """
+  defmodule Credo.Sample2 do
+    defmodule InlineModule do
+      def foobar do
+        exists = File.exists?(filename)
+        { result, %{} } = File.read( filename )
+      end
+
+      def barfoo do
+        exists = File.exists?(filename)
+        { result, [] } = File.read( filename )
+      end
+    end
+  end
+"""
 
   @heredoc_example """
 string = ~s\"\"\"
@@ -42,7 +57,7 @@ another_string = ~s\"\"\"
       |> to_source_file()
       |> Collector.collect_matches([])
 
-    assert %{without_space: 2} == without_spaces
+    assert %{without_space: 2, without_space_allow_empty_enums: 2} == without_spaces
 
     with_spaces =
       @with_spaces
@@ -50,6 +65,13 @@ another_string = ~s\"\"\"
       |> Collector.collect_matches([])
 
     assert %{with_space: 1} == with_spaces
+
+    empty_enum =
+      @empty_enum
+      |> to_source_file()
+      |> Collector.collect_matches([])
+
+    assert %{with_space: 2, without_space: 4, without_space_allow_empty_enums: 2} == empty_enum
   end
 
   test "it should NOT report heredocs containing sigil chars" do

--- a/test/credo/check/consistency/space_in_parentheses_test.exs
+++ b/test/credo/check/consistency/space_in_parentheses_test.exs
@@ -47,6 +47,24 @@ defmodule OtherModule3 do
   end
 end
 """
+@with_spaces_empty_params1 """
+defmodule Credo.Sample2 do
+  defmodule InlineModule do
+    def foobar do
+      { :ok } = File.read( %{} )
+    end
+  end
+end
+"""
+@with_spaces_empty_params2 """
+defmodule Credo.Sample2 do
+  defmodule InlineModule do
+    def foobar do
+      { :ok } = File.read( [] )
+    end
+  end
+end
+"""
   @with_and_without_spaces """
 defmodule OtherModule3 do
   defmacro foo do
@@ -100,6 +118,36 @@ end
         assert 7 == issue.line_no
         assert "{:" == issue.trigger
       end)
+  end
+
+  test "it should trigger error with no config on empty map" do
+    [
+      @with_spaces_empty_params1
+    ]
+    |> to_source_files()
+    |> assert_issue(@described_check, fn(issue) ->
+        assert 4 == issue.line_no
+        assert "{}" == issue.trigger
+      end)
+  end
+
+  test "it should trigger error with no config on empty array" do
+    [
+      @with_spaces_empty_params2
+    ]
+    |> to_source_files()
+    |> assert_issue(@described_check, fn(issue) ->
+        assert 4 == issue.line_no
+        assert "[]" == issue.trigger
+      end)
+  end
+
+  test "it should not trigger error with config on empty params" do
+    [
+      @with_spaces_empty_params1, @with_spaces_empty_params2
+    ]
+    |> to_source_files()
+    |> refute_issues(@described_check, allow_empty_enums: true)
   end
 
 end


### PR DESCRIPTION
For issue #176. Adds a new config value for the spaceInParenthesis check to allow for empty enum params to be skipped for consistency. 

`{Credo.Check.Consistency.SpaceInParentheses, allow_empty_enums: true}`