### PR TITLE
adding a pattern to match @specs containing `with` clauses

### DIFF
--- a/lib/credo/check/readability/specs.ex
+++ b/lib/credo/check/readability/specs.ex
@@ -32,6 +32,9 @@ defmodule Credo.Check.Readability.Specs do
     Credo.Code.prewalk(source_file, &traverse(&1, &2, specs, issue_meta))
   end
 
+  defp find_specs({:spec, _, [{:when, _, [{:::, _, [{name, _, args}, _]}, _]} | _]} = ast, specs) do
+    {ast, [{name, length(args)} | specs]}
+  end
   defp find_specs({:spec, _, [{_, _, [{name, _, args} | _]}]} = ast, specs) when is_list(args) do
     {ast, [{name, length(args)} | specs]}
   end

--- a/test/credo/check/readability/specs_test.exs
+++ b/test/credo/check/readability/specs_test.exs
@@ -17,6 +17,17 @@ defmodule Credo.Check.Readability.SpecsTest do
         |> refute_issues(@described_check)
   end
 
+  test "it should NOT report functions with specs containing a `with` clause" do
+    """
+    defmodule CredoTypespecTest do
+      @spec foo(a, a) :: a when a: integer
+      @doc "some docs for foo/2"
+      def foo(a, b), do: a + b
+    end
+    """ |> to_source_file()
+        |> refute_issues(@described_check)
+  end
+
   test "it should NOT report private functions" do
     """
     defmodule CredoTypespecTest do


### PR DESCRIPTION
Noticed that these kinds of specs (ones containing a `with` clause) weren't counting as a spec for the function.