### PR TITLE
Add :allow_shorter_alias param to AliasUsage

### DIFF
--- a/test/credo/check/design/alias_usage_test.exs
+++ b/test/credo/check/design/alias_usage_test.exs
@@ -152,6 +152,20 @@ end
     |> assert_issue(@described_check)
   end
 
+  test "it should report even when allowing shorter alias" do
+"""
+defmodule CredoSampleModule do
+  alias ExUnit.Case
+
+  def fun1 do
+    something
+    |> Credo.Foo.Bar.Baz.call
+  end
+end
+""" |> to_source_file
+    |> assert_issue(@described_check, allow_shorter_alias: true)
+  end
+
   test "it should report if configured to complain start at a certain depth" do
 """
 defmodule CredoSampleModule do
@@ -223,6 +237,21 @@ defmodule Test do
 end
 """ |> to_source_file
     |> refute_issues(@described_check)
+  end
+
+  test "it should NOT report when allowing shorter alias" do
+"""
+defmodule CredoSampleModule do
+  alias ExUnit.Case
+  alias Credo.Foo
+
+  def fun1 do
+    something
+    |> Foo.Bar.Baz.call
+  end
+end
+""" |> to_source_file
+    |> refute_issues(@described_check, allow_shorter_alias: true)
   end
 
   #


### PR DESCRIPTION
This adds an option allowing to use a shorter alias than possible, as this sometimes improves readability.

The AliasUsage check requires to alias used modules so that dependencies are easier to spot [[1]], for example:

```elixir
defmodule Test do
  alias MyApp.External.MyProto.Client

  def something do
    Client.search(...)
  end
end
```

But sometimes it is more readable to call "MyProto.Client.search" instead of "Client.search". The dependency can still be seen at the top of the file (only slightly less specific):

```elixir
defmodule Test do
  alias MyApp.External.MyProto

  def something do
    MyProto.Client.search(...)
  end
end
```

[1]: https://github.com/rrrene/elixir-style-guide#alias-modules