### PR TITLE
Fix Markdown link to bunt in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Do note with the passed option as filename is a stub that is just used to prefix
 
 ### Using Credo as stand alone
 
-If you do not want or are not allowed to include Credo in the current project you can also install it as an archive. For this, you also need to install [https://github.com/rrrene/bunt](bunt):
+If you do not want or are not allowed to include Credo in the current project you can also install it as an archive. For this, you also need to install [bunt](https://github.com/rrrene/bunt):
 
 ```bash
 $ git clone git@github.com:rrrene/bunt.git


### PR DESCRIPTION
I think the Markdown syntax was backwards for this link, which was pointing to the following (404) location:
https://github.com/rrrene/credo/blob/master/bunt

The updated syntax in this commit should fix the link so it points to the correct location:
https://github.com/rrrene/bunt

/cc @rrrene