### PR TITLE
Include test directory in files that can be limited - fixes #487

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -21,7 +21,7 @@
         # You can give explicit globs or simply directories.
         # In the latter case `**/*.{ex,exs}` will be used.
         #
-        included: ["lib/", "src/", "web/", "apps/"],
+        included: ["lib/", "src/", "test/", "web/", "apps/"],
         excluded: [~r"/_build/", ~r"/deps/"]
       },
       #


### PR DESCRIPTION
You have a lot of warnings now on the test directory, but there are a lot of other warnings elsewhere in the project so i wasn't sure if you wanted to bother to fix it

```

[R] ↓ test/credo/code_test.exs:42:81 Line is too long (max is 80, was 86).
[R] → lib/credo/cli/command/suggest/suggest_output.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/service/source_file_scopes.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/command/suggest/output/flycheck.ex:1:11 Modules should have a @moduledoc tag.
[R] ↓ lib/credo/check/warning/io_inspect.ex:23:81 Line is too long (max is 80, was 81).
[R] → lib/credo/execution/task/set_default_command.ex:1:11 Modules should have a @moduledoc tag.
[D] → lib/credo/check/warning/name_redeclaration_by_def.ex:39 Found a TODO tag in a comment: # TODO: make customizable via params
[R] ↓ lib/credo/check/warning/name_redeclaration_by_def.ex:83:81 Line is too long (max is 80, was 81).
[F] → lib/credo/check/warning/name_redeclaration_by_def.ex:148:7 Function is too complex (CC is 11, max is 9).
[R] → lib/credo/check/consistency/tabs_or_spaces/collector.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/execution/task/run_command.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/command/list/output/json.ex:1:11 Modules should have a @moduledoc tag.
[R] ↗ lib/credo/code/token.ex:247:13 Module names should be written in PascalCase.
[R] ↗ lib/credo/code/token.ex:45:13 Module names should be written in PascalCase.
[D] ↓ lib/mix/tasks/credo.gen.check.ex:9:5 Nested modules could be aliased at the top of the invoking module.
[R] → lib/credo/sources.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/check/consistency/line_endings/collector.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/command/suggest/output/default.ex:1:11 Modules should have a @moduledoc tag.
[C] ↗ lib/credo/cli/command/suggest/output/default.ex:143 There is no whitespace around parentheses/brackets most of the time, but here there is.
[D] → lib/credo/code/module.ex:252 Found a TODO tag in a comment: # TODO: write unit test
[R] ↓ lib/credo/code/module.ex:51:81 Line is too long (max is 80, was 81).
[R] → lib/credo/execution/source_files.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/sorter.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/execution/task/validate_config.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ lib/credo/check/find_lint_attributes.ex:34:9 Nested modules could be aliased at the top of the invoking module.
[D] → lib/credo/check/find_lint_attributes.ex:70 Found a TODO tag in a comment: # TODO: warn that a new lint attribute was read while one was still active
[R] ↓ lib/credo/check/find_lint_attributes.ex:70:81 Line is too long (max is 80, was 82).
[R] ↗ test/credo/check/readability/large_numbers_test.exs:126:58 Large numbers should be written with underscores: 50_000
[F] → test/credo/check/readability/large_numbers_test.exs:197 Pipe chain should start with a raw value.
[F] → test/credo/check/readability/large_numbers_test.exs:209 Pipe chain should start with a raw value.
[D] ↓ lib/credo/cli/command/list/output/default.ex:44:14 Nested modules could be aliased at the top of the invoking module.
[R] → lib/credo/cli/command/list/output/default.ex:1:11 Modules should have a @moduledoc tag.
[F] → lib/credo/cli/command/list/output/default.ex:151:11 Function body is nested too deep (max depth is 2, was 3).
[R] → lib/credo/cli/output/formatter/flycheck.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/execution/task/determine_command.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/command/categories/categories_output.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/output.ex:1:11 Modules should have a @moduledoc tag.
[F] → lib/credo/check/warning/name_redeclaration_by_fn.ex:133:7 Function is too complex (CC is 10, max is 9).
[R] → lib/credo/service/source_file_source.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/command.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ test/credo/exs_loader_test.exs:31:24 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/exs_loader_test.exs:30:24 Nested modules could be aliased at the top of the invoking module.
[D] → lib/credo/check/consistency/space_around_operators.ex:27 Found a TODO tag in a comment: # TODO: add *ignored* operators, so you can add "|" and still write
[D] → lib/credo/check/consistency/space_around_operators.ex:80 Found a TODO tag in a comment: # TODO: Consider moving these checks inside the Collector.
[D] → lib/credo/check/consistency/space_around_operators.ex:124 Found a TODO tag in a comment: # TODO: this implementation is a bit naive. improve it.
[D] ↗ lib/credo/check/consistency/space_around_operators.ex:29 Found a FIXME tag in a comment: # FIXME: this seems to be already implemented, but there don't seem to be
[R] ↓ lib/credo/check/readability/specs.ex:36:81 Line is too long (max is 80, was 81).
[D] ↑ lib/credo/check/warning/unused_path_operation.ex:20 Duplicate code found in lib/credo/check/warning/unused_file_operation.ex:20, lib/credo/check/warning/unused_regex_operation.ex:20 (mass: 63).
[R] ↓ lib/credo/check.ex:115:81 Line is too long (max is 80, was 83).
[R] → lib/credo/check.ex:1:11 Modules should have a @moduledoc tag.
[D] → lib/credo/check/design/tag_todo.ex:2 Found a TODO tag in a comment: TODO comments are used to remind yourself of source code related things.

Example:

    # TODO: move this to a Helper module
    defp fun do
      # ...
    end

The premise here is that TODO should be dealt with in the near future and
are therefore reported by Credo.

Like all `Software Design` issues, this is just advice and might not be
applicable to your project/situation.

[D] → lib/credo/code/strings.ex:21 Found a TODO tag in a comment: # TODO v1.0: this should not remove heredocs, since
[R] ↓ lib/credo/check/readability/module_names.ex:54:81 Line is too long (max is 80, was 83).
[R] → lib/credo/source_file.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ lib/credo/cli/command/help.ex:37:5 Nested modules could be aliased at the top of the invoking module.
[R] → lib/credo/cli/task/run_checks.ex:1:11 Modules should have a @moduledoc tag.
[F] → lib/credo/check/readability/prefer_unquoted_atoms.ex:81 Pipe chain should start with a raw value.
[D] → lib/credo/execution/task.ex:54 Found a TODO tag in a comment: # TODO: improve message
[R] → lib/credo/execution/task.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/issue_meta.ex:1:11 Modules should have a @moduledoc tag.
[D] ↑ lib/credo/check/refactor/cyclomatic_complexity.ex:63 Duplicate code found in lib/credo/check/refactor/perceived_complexity.ex:63 (mass: 58).
[D] ↑ lib/credo/check/refactor/cyclomatic_complexity.ex:138 Duplicate code found in lib/credo/check/refactor/perceived_complexity.ex:138 (mass: 52).
[D] ↓ test/test_helper.exs:162:8 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/test_helper.exs:161:8 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/test_helper.exs:40:10 Nested modules could be aliased at the top of the invoking module.
[W] ↗ test/test_helper.exs:82:12 Enum.count(issues) == 0 is expensive. Prefer Enum.empty?/1 or list == []
[R] → lib/credo/check/params.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/task/set_relevant_issues.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/check/consistency/parameter_pattern_matching/collector.ex:1:11 Modules should have a @moduledoc tag.
[D] ↑ lib/credo/check/warning/unused_keyword_operation.ex:19 Duplicate code found in lib/credo/check/warning/unused_list_operation.ex:19, lib/credo/check/warning/unused_tuple_operation.ex:19 (mass: 61).
[D] ↑ lib/credo/check/refactor/perceived_complexity.ex:63 Duplicate code found in lib/credo/check/refactor/cyclomatic_complexity.ex:63 (mass: 58).
[D] ↑ lib/credo/check/refactor/perceived_complexity.ex:138 Duplicate code found in lib/credo/check/refactor/cyclomatic_complexity.ex:138 (mass: 52).
[F] → lib/credo/check/warning/name_redeclaration_by_case.ex:138:7 Function is too complex (CC is 10, max is 9).
[D] ↓ lib/credo/execution/process_definition.ex:23:9 Nested modules could be aliased at the top of the invoking module.
[R] → lib/credo/execution/process_definition.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/command/list/output/oneline.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/execution/task/parse_options.ex:1:11 Modules should have a @moduledoc tag.
[D] → lib/credo/check/lint_attribute.ex:3 Found a TODO tag in a comment: # TODO: remove these
[D] → lib/credo/check/lint_attribute.ex:5 Found a TODO tag in a comment: # TODO: as they are for debug purposes only
[R] → lib/credo/check/lint_attribute.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/execution/task/validate_options.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/task/load_and_validate_source_files.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/command/categories/output/default.ex:1:11 Modules should have a @moduledoc tag.
[R] ↓ lib/credo/check/readability/prefer_implicit_try.ex:43:81 Line is too long (max is 80, was 81).
[D] ↓ lib/credo/check/design/alias_usage.ex:220:18 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/check/design/alias_usage.ex:219:22 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/check/design/alias_usage.ex:216:17 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/check/design/alias_usage.ex:215:17 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/check/design/alias_usage.ex:207:23 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/check/design/alias_usage.ex:206:17 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/check/design/alias_usage.ex:200:17 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/check/design/alias_usage.ex:191:17 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/check/design/alias_usage.ex:190:18 Nested modules could be aliased at the top of the invoking module.
[R] ↓ lib/credo/check/design/alias_usage.ex:212:81 Line is too long (max is 80, was 84).
[R] → lib/credo/cli/output/ui.ex:1:11 Modules should have a @moduledoc tag.
[D] → lib/credo/check/consistency/exception_names/collector.ex:48 Found a TODO tag in a comment: # TODO: how is this `case` necessary
[R] → lib/credo/check/consistency/exception_names/collector.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ lib/credo/cli/command/explain/output/default.ex:43:14 Nested modules could be aliased at the top of the invoking module.
[D] → lib/credo/cli/command/explain/output/default.ex:329 Found a TODO tag in a comment: # TODO: format things in backticks in help texts
[R] → lib/credo/cli/command/explain/output/default.ex:1:11 Modules should have a @moduledoc tag.
[F] → lib/credo/cli/command/explain/output/default.ex:232:11 Function body is nested too deep (max depth is 2, was 3).
[D] ↓ lib/credo/check/readability/max_line_length.ex:50:9 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/check/readability/max_line_length.ex:60:11 Nested modules could be aliased at the top of the invoking module.
[D] → lib/credo/check/readability/max_line_length.ex:40 Found a TODO tag in a comment: # TODO v1.0: this should be two different params
[R] → lib/credo/cli/command/suggest/output/oneline.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ lib/credo/cli/command/explain/explain_command.ex:19:10 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/cli/command/explain/explain_command.ex:20:10 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/cli/command/explain/explain_command.ex:21:10 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/cli/command/explain/explain_command.ex:23:10 Nested modules could be aliased at the top of the invoking module.
[R] → lib/credo/check/config_comment.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/command/list/output/flycheck.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/command/explain/explain_output.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ test/credo/sources_test.exs:188:13 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:166:24 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:156:24 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:148:24 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:137:13 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:120:13 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:108:13 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:91:13 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:81:41 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:71:13 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:51:13 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:42:13 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:28:13 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/sources_test.exs:13:13 Nested modules could be aliased at the top of the invoking module.
[F] → test/credo/sources_test.exs:13 Pipe chain should start with a raw value.
[F] → test/credo/sources_test.exs:28 Pipe chain should start with a raw value.
[F] → test/credo/sources_test.exs:42 Pipe chain should start with a raw value.
[F] → test/credo/sources_test.exs:51 Pipe chain should start with a raw value.
[F] → test/credo/sources_test.exs:71 Pipe chain should start with a raw value.
[F] → test/credo/sources_test.exs:91 Pipe chain should start with a raw value.
[F] → test/credo/sources_test.exs:108 Pipe chain should start with a raw value.
[F] → test/credo/sources_test.exs:120 Pipe chain should start with a raw value.
[F] → test/credo/sources_test.exs:137 Pipe chain should start with a raw value.
[F] → test/credo/sources_test.exs:188 Pipe chain should start with a raw value.
[R] → lib/credo/service/source_file_ast.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/execution/task/convert_cli_options_to_config.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ lib/mix/tasks/credo.ex:9:5 Nested modules could be aliased at the top of the invoking module.
[D] → lib/credo/code/interpolation_helper.ex:141 Found a TODO tag in a comment: # TODO: this seems to be wrong. the closing """ determines the
[R] ↓ lib/credo/code/interpolation_helper.ex:75:81 Line is too long (max is 80, was 81).
[F] → lib/credo/code/interpolation_helper.ex:147 Pipe chain should start with a raw value.
[R] ↓ lib/credo/check/warning/unused_file_operation.ex:13:81 Line is too long (max is 80, was 83).
[D] ↑ lib/credo/check/warning/unused_file_operation.ex:20 Duplicate code found in lib/credo/check/warning/unused_path_operation.ex:20, lib/credo/check/warning/unused_regex_operation.ex:20 (mass: 63).
[D] ↓ lib/credo/cli/command/list/list_command.ex:16:8 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/cli/command/list/list_command.ex:17:8 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/cli/command/list/list_command.ex:19:8 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/cli/command/list/list_command.ex:21:8 Nested modules could be aliased at the top of the invoking module.
[D] ↗ lib/credo/check/design/tag_fixme.ex:2 Found a FIXME tag in a comment: FIXME comments are used to indicate places where source code needs fixing.

Example:

    # FIXME: this does no longer work, research new API url
    defp fun do
      # ...
    end

The premise here is that FIXME should indeed be fixed as soon as possible and
are therefore reported by Credo.

Like all `Software Design` issues, this is just advice and might not be
applicable to your project/situation.

[D] ↓ lib/credo/check/design/duplicated_code.ex:87:13 Nested modules could be aliased at the top of the invoking module.
[D] → lib/credo/check/design/duplicated_code.ex:265 Found a TODO tag in a comment: # TODO: Put in AST helper
[F] → lib/credo/check/design/duplicated_code.ex:86:11 Function body is nested too deep (max depth is 2, was 4).
[D] ↓ lib/credo/cli/task/prepare_checks_to_run.ex:45:7 Nested modules could be aliased at the top of the invoking module.
[R] → lib/credo/cli/task/prepare_checks_to_run.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/execution/task/require_requires.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/execution/task/use_colors.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/config_builder.ex:1:11 Modules should have a @moduledoc tag.
[R] ↓ test/credo/check/refactor/cyclomatic_complexity_test.exs:80:81 Line is too long (max is 80, was 84).
[R] → lib/credo/check/consistency/space_around_operators/space_helper.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/check/consistency/space_in_parentheses/collector.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ lib/credo/config_file.ex:84:8 Nested modules could be aliased at the top of the invoking module.
[R] → lib/credo/config_file.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/service/source_file_lines.ex:1:11 Modules should have a @moduledoc tag.
[C] ↗ lib/credo/check/refactor/append_single_item.ex:37:17 File has the variable name before the pattern while most of the files have the variable name after the pattern when naming parameter pattern matches
[C] ↗ lib/credo/check/refactor/append_single_item.ex:32:17 File has the variable name before the pattern while most of the files have the variable name after the pattern when naming parameter pattern matches
[D] → lib/credo/check/runner.ex:41:9 Found a TODO tag in a comment: TODO: deprecated
[R] → lib/credo/check/runner.ex:1:11 Modules should have a @moduledoc tag.
[F] → lib/credo/check/readability/large_numbers.ex:177 Pipe chain should start with a raw value.
[F] → lib/credo/check/readability/large_numbers.ex:183 Pipe chain should start with a raw value.
[D] ↑ lib/credo/check/warning/unused_tuple_operation.ex:19 Duplicate code found in lib/credo/check/warning/unused_list_operation.ex:19, lib/credo/check/warning/unused_keyword_operation.ex:19 (mass: 61).
[D] ↑ lib/credo/check/warning/unused_list_operation.ex:19 Duplicate code found in lib/credo/check/warning/unused_keyword_operation.ex:19, lib/credo/check/warning/unused_tuple_operation.ex:19 (mass: 61).
[D] → lib/credo/check/warning/unused_function_return_helper.ex:505 Found a TODO tag in a comment: # TODO: move to AST helper?
[R] ↓ lib/credo/check/warning/unused_function_return_helper.ex:410:81 Line is too long (max is 80, was 117).
[R] ↓ lib/credo/check/warning/unused_function_return_helper.ex:344:81 Line is too long (max is 80, was 107).
[R] → lib/credo/check/warning/unused_function_return_helper.ex:1:11 Modules should have a @moduledoc tag.
[D] → lib/credo/exs_loader.ex:41 Found a TODO tag in a comment: # TODO: support regex modifiers
[R] → lib/credo/exs_loader.ex:1:11 Modules should have a @moduledoc tag.
[R] ↓ test/credo/check/find_lint_attributes_test.exs:29:81 Line is too long (max is 80, was 83).
[F] → lib/credo/code/sigils.ex:29 Pipe chain should start with a raw value.
[R] ↓ lib/credo/check/consistency/multi_alias_import_require_use/collector.ex:85:81 Line is too long (max is 80, was 86).
[R] ↓ lib/credo/check/consistency/multi_alias_import_require_use/collector.ex:30:81 Line is too long (max is 80, was 81).
[R] → lib/credo/check/consistency/multi_alias_import_require_use/collector.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ lib/mix/tasks/credo.gen.config.ex:9:5 Nested modules could be aliased at the top of the invoking module.
[R] → lib/credo/service/commands.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/output/formatter/oneline.ex:1:11 Modules should have a @moduledoc tag.
[D] ↑ lib/credo/check/warning/unused_regex_operation.ex:20 Duplicate code found in lib/credo/check/warning/unused_file_operation.ex:20, lib/credo/check/warning/unused_path_operation.ex:20 (mass: 63).
[R] → lib/credo/cli/options.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ lib/credo/execution.ex:131:5 Nested modules could be aliased at the top of the invoking module.
[R] ↓ lib/credo/execution.ex:33:81 Line is too long (max is 80, was 87).
[R] → lib/credo/execution.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ lib/credo/cli/command/suggest/suggest_command.ex:15:8 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/cli/command/suggest/suggest_command.ex:16:8 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/cli/command/suggest/suggest_command.ex:18:8 Nested modules could be aliased at the top of the invoking module.
[D] ↓ lib/credo/cli/command/suggest/suggest_command.ex:20:8 Nested modules could be aliased at the top of the invoking module.
[R] → lib/credo/cli/command/suggest/suggest_command.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/execution/issues.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/application.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/service/ets_table_helper.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/output/formatter/json.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/execution/task/assign_exit_status_for_issues.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/command/suggest/output/json.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ lib/credo/cli/filter.ex:17:8 Nested modules could be aliased at the top of the invoking module.
[R] → lib/credo/cli/filter.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/cli/output/summary.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ test/credo/source_file_test.exs:59:18 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/source_file_test.exs:58:18 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/source_file_test.exs:44:17 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/source_file_test.exs:43:18 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/source_file_test.exs:41:14 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/source_file_test.exs:24:19 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/source_file_test.exs:12:8 Nested modules could be aliased at the top of the invoking module.
[F] → test/credo/check/readability/string_sigils_test.exs:48 Pipe chain should start with a raw value.
[F] → test/credo/check/readability/string_sigils_test.exs:54 Pipe chain should start with a raw value.
[F] → test/credo/check/readability/string_sigils_test.exs:60 Pipe chain should start with a raw value.
[F] → test/credo/check/readability/string_sigils_test.exs:66 Pipe chain should start with a raw value.
[F] → test/credo/check/readability/string_sigils_test.exs:72 Pipe chain should start with a raw value.
[F] → test/credo/check/readability/string_sigils_test.exs:78 Pipe chain should start with a raw value.
[F] → test/credo/check/readability/string_sigils_test.exs:84 Pipe chain should start with a raw value.
[F] → test/credo/check/readability/string_sigils_test.exs:90 Pipe chain should start with a raw value.
[F] → test/credo/check/readability/string_sigils_test.exs:100 Pipe chain should start with a raw value.
[F] → test/credo/check/readability/string_sigils_test.exs:106 Pipe chain should start with a raw value.
[R] → lib/credo/cli/command/list/list_output.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/check/design/tag_helper.ex:1:11 Modules should have a @moduledoc tag.
[R] ↓ lib/credo/check/consistency/space_around_operators/collector.ex:118:81 Line is too long (max is 80, was 81).
[R] ↓ lib/credo/check/consistency/space_around_operators/collector.ex:117:81 Line is too long (max is 80, was 81).
[R] → lib/credo/check/consistency/space_around_operators/collector.ex:1:11 Modules should have a @moduledoc tag.
[D] ↓ test/credo/cli/filename_test.exs:19:21 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/cli/filename_test.exs:17:14 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/cli/filename_test.exs:14:14 Nested modules could be aliased at the top of the invoking module.
[D] ↓ test/credo/cli/filename_test.exs:7:14 Nested modules could be aliased at the top of the invoking module.
[R] → lib/credo/issue.ex:1:11 Modules should have a @moduledoc tag.
[R] → lib/credo/execution/monitor.ex:1:11 Modules should have a @moduledoc tag.
```