### PR TITLE
Fix warning on unused @lint

### DIFF
--- a/lib/credo/check/find_lint_attributes.ex
+++ b/lib/credo/check/find_lint_attributes.ex
@@ -21,6 +21,7 @@ defmodule Credo.Check.FindLintAttributes do
   end
 
   @lint false
+  _ = @lint
   defp traverse(
          {:defmodule, _meta, _arguments} = ast,
          attribute_list,


### PR DESCRIPTION
We're using warnings as errors and this warning keeps popping up on Elixir 1.6. This PR is an attempt to suppress the warning.

```
==> credo
Compiling 178 files (.ex)
warning: module attribute @lint was set but never used
  lib/credo/check/find_lint_attributes.ex:23
```