### PR TITLE
Moving SpaceAroundOperator for pipe_op from Consistency to Readability

### DIFF
--- a/lib/credo/check/consistency/space_around_operators/collector.ex
+++ b/lib/credo/check/consistency/space_around_operators/collector.ex
@@ -9,7 +9,9 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators.Collector do
       space_between?: 2,
       no_space_between?: 2,
       usually_no_space_before?: 3,
-      usually_no_space_after?: 3
+      usually_no_space_after?: 3,
+      usually_space_before?: 3,
+      usually_space_after?: 3
     ]
 
   def collect_matches(source_file, _params) do
@@ -110,7 +112,8 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators.Collector do
   end
 
   defp with_space?(prev, op, next) do
-    space_between?(prev, op) || space_between?(op, next)
+    (!usually_space_before?(prev, op, next) && space_between?(prev, op)) ||
+      (!usually_space_after?(prev, op, next) && space_between?(op, next))
   end
 
   defp without_space?(prev, op, next) do

--- a/lib/credo/check/consistency/space_around_operators/space_helper.ex
+++ b/lib/credo/check/consistency/space_around_operators/space_helper.ex
@@ -29,6 +29,24 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper do
   def usually_no_space_after?(_, {_, _, :..}, _), do: true
   def usually_no_space_after?(_, _, _), do: false
 
+  @doc """
+  Returns true if there is space before the operator (usually).
+
+  Examples:
+  [head | tail]   # | is the operator here and there is usually space before that
+  """
+  def usually_space_before?(_, {_, _, :|}, _), do: true
+  def usually_space_before?(_, _, _), do: false
+
+  @doc """
+  Returns true if there is space after the operator (usually).
+
+  Examples:
+  [head | tail]   # | is the operator here and there is usually space after that
+  """
+  def usually_space_after?(_, {_, _, :|}, _), do: true
+  def usually_space_after?(_, _, _), do: false
+
   def operator?({:comp_op, _, _}), do: true
   def operator?({:comp_op2, _, _}), do: true
   def operator?({:dual_op, _, _}), do: true
@@ -42,7 +60,7 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators.SpaceHelper do
   def operator?({:match_op, _, _}), do: true
   def operator?({:in_match_op, _, _}), do: true
   def operator?({:stab_op, _, _}), do: true
-  def operator?({:pipe_op, _, _}), do: true
+  def operator?({:pipe_op, _, _}), do: false
   def operator?(_), do: false
 
   def no_space_between?(arg1, arg2) do

--- a/lib/credo/check/readability/space_helper.ex
+++ b/lib/credo/check/readability/space_helper.ex
@@ -1,0 +1,20 @@
+defmodule Credo.Check.Readability.SpaceHelper do
+  alias Credo.Code.Token
+
+  def expected_spaces({:pipe_op, _, _}), do: :with_space
+  def expected_spaces(_), do: :ignore
+
+  def no_space_between?(arg1, arg2) do
+    {line_no, _col_start, _line_no_end, col_end} = Token.position(arg1)
+    {line_no2, col_start2, _line_no_end, _col_end} = Token.position(arg2)
+
+    line_no == line_no2 && col_end == col_start2
+  end
+
+  def space_between?(arg1, arg2) do
+    {line_no, _col_start, _line_no_end, col_end} = Token.position(arg1)
+    {line_no2, col_start2, _line_no_end, _col_end} = Token.position(arg2)
+
+    line_no == line_no2 && col_end < col_start2
+  end
+end

--- a/test/credo/check/consistency/line_endings_test.exs
+++ b/test/credo/check/consistency/line_endings_test.exs
@@ -1,4 +1,4 @@
-defmodule Credo.Check.Readability.LineEndingsTest do
+defmodule Credo.Check.Consistency.LineEndingsTest do
   use Credo.TestHelper
 
   @described_check Credo.Check.Consistency.LineEndings

--- a/test/credo/check/consistency/space_around_operators/collector_test.exs
+++ b/test/credo/check/consistency/space_around_operators/collector_test.exs
@@ -19,6 +19,7 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators.CollectorTest do
         4 > 3
         4 >= 3
         4 <= 3
+        [[1] | 2]
         range = -999..-1
         for op <- [:{}, :%{}, :^, :|, :<>] do
         end
@@ -37,6 +38,15 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators.CollectorTest do
   defmodule Credo.Sample2 do
     def foobar do
       1+2
+    end
+  end
+  """
+  @not_listed_operators """
+  defmodule Credo.Sample2 do
+    def foobar do
+      [head | list]
+      [head| list]
+      [head |list]
     end
   end
   """
@@ -86,6 +96,15 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators.CollectorTest do
       |> Collector.collect_matches([])
 
     assert %{without_space: 1} == result
+  end
+
+  test "it should ignore counting spaces for not listed operators" do
+    result =
+      @not_listed_operators
+      |> to_source_file()
+      |> Collector.collect_matches([])
+
+    assert %{} == result
   end
 
   test "it should report correct frequencies for mixed cases" do

--- a/test/credo/check/consistency/space_around_operators_test.exs
+++ b/test/credo/check/consistency/space_around_operators_test.exs
@@ -117,6 +117,8 @@ defmodule Credo.Check.Consistency.SpaceAroundOperatorsTest do
         c = n / -1
         c = n - -1
 
+        [1 | 2]
+
         [(3 * 4) + (2 / 2) - (-1 * 4) / 1 - 4]
         [(3 * 4) + (2 / 2) - (-1 * 4) / 1 - 4]
         [(3 * 4) + (2 / 2) - (-1 * 4) / 1 - 4]
@@ -223,6 +225,23 @@ defmodule Credo.Check.Consistency.SpaceAroundOperatorsTest do
   test "it should not report issues if spaces are used everywhere in a single file" do
     [
       @with_spaces5
+    ]
+    |> to_source_files()
+    |> refute_issues(@described_check)
+  end
+
+  @pipe_op_mixed """
+  defmodule CredoTest do
+    def test do
+      [[3] | 3]
+      [[3]|3]
+    end
+  end
+  """
+
+  test "it should not report an issue a according to the pipe_op" do
+    [
+      @pipe_op_mixed
     ]
     |> to_source_files()
     |> refute_issues(@described_check)

--- a/test/credo/check/readability/space_around_operators_test.exs
+++ b/test/credo/check/readability/space_around_operators_test.exs
@@ -1,0 +1,50 @@
+defmodule Credo.Check.Readability.SpaceAroundOperatorsTest do
+  use Credo.TestHelper
+
+  @described_check Credo.Check.Readability.SpaceAroundOperators
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report when op_pipe has spaces" do
+    """
+    defmodule CredoSampleModule do
+      [1 | [2, 3]]
+    end
+    """
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report when op_pipe has no spaces" do
+    """
+    defmodule CredoSampleModule do
+      [1|[2, 3]]
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check, fn issue ->
+      assert 5 == issue.column
+      assert :| == issue.trigger
+    end)
+  end
+
+  test "it should report when op_pipe has a space only" do
+    """
+    defmodule CredoSampleModule do
+      [1 |[2, 3]]
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check, fn issue ->
+      assert 6 == issue.column
+      assert :| == issue.trigger
+    end)
+  end
+end


### PR DESCRIPTION
Fixes #477 

I copypasted `SpaceAroundOperator` to `Readability` and set the spaces around `|` to be checked in the `Readability`. Though I believe that we should move ALL the `SpaceAroundOperator` to `Readability` because `Code.format_string!/2` shows how exactly the spaces should be used and it is not a matter of consistancy anymore.