### PR TITLE
Upgrading Erlang to 20.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 20.0
+erlang 20.2
 elixir 1.6.4


### PR DESCRIPTION
# What

Upgrades Erlang to v20.2 in .tool-versions

# Why

Because Erlang 20.0 has [an issue](https://bugs.erlang.org/browse/ERL-439) on Mac OSX High Sierra that crashes whenever the `crypto` module is called. This is due to a change from OpenSSL to BoringSSL.