### PR TITLE
fix explanation for pipechain

### DIFF
--- a/lib/credo/check/refactor/pipe_chain_start.ex
+++ b/lib/credo/check/refactor/pipe_chain_start.ex
@@ -21,7 +21,10 @@ defmodule Credo.Check.Refactor.PipeChainStart do
 
   @explanation [
     check: @moduledoc,
-    excluded_functions: "All functions listed will be ignored."
+    params: [
+      excluded_functions: "All functions listed will be ignored.",
+      excluded_argument_types: "All pipes with argument types listed will be ignored."
+    ]
   ]
   @default_params [excluded_argument_types: [], excluded_functions: []]
 


### PR DESCRIPTION
The pipechain check supports `excluded_functions` and `excluded_argument_types` but it is not obvious if you use `mix credo explain file:line:column` format