### PR TITLE
Add string options for the `--min-priority` switch

### DIFF
--- a/lib/credo/cli/command/list/list_output.ex
+++ b/lib/credo/cli/command/list/list_output.ex
@@ -29,6 +29,7 @@ defmodule Credo.CLI.Command.List.ListOutput do
     List options:
       -a, --all             Show all issues
       -A, --all-priorities  Show all issues including low priority ones
+          --min-priority    Minimum priority to show issues (higher,high,normal,low,ignore or number)
       -c, --checks          Only include checks that match the given strings
       -C, --config-name     Use the given config instead of "default"
       -i, --ignore-checks   Ignore checks that match the given strings

--- a/lib/credo/cli/command/list/list_output.ex
+++ b/lib/credo/cli/command/list/list_output.ex
@@ -29,7 +29,7 @@ defmodule Credo.CLI.Command.List.ListOutput do
     List options:
       -a, --all             Show all issues
       -A, --all-priorities  Show all issues including low priority ones
-          --min-priority    Minimum priority to show issues (higher,high,normal,low,ignore or number)
+          --min-priority    Minimum priority to show issues (high,medium,normal,low,lower or number)
       -c, --checks          Only include checks that match the given strings
       -C, --config-name     Use the given config instead of "default"
       -i, --ignore-checks   Ignore checks that match the given strings

--- a/lib/credo/cli/command/suggest/suggest_output.ex
+++ b/lib/credo/cli/command/suggest/suggest_output.ex
@@ -29,6 +29,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
     Suggest options:
       -a, --all             Show all issues
       -A, --all-priorities  Show all issues including low priority ones
+          --min-priority    Minimum priority to show issues (higher,high,normal,low,ignore or number)
       -c, --checks          Only include checks that match the given strings
       -C, --config-name     Use the given config instead of "default"
       -i, --ignore-checks   Ignore checks that match the given strings

--- a/lib/credo/cli/command/suggest/suggest_output.ex
+++ b/lib/credo/cli/command/suggest/suggest_output.ex
@@ -29,7 +29,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
     Suggest options:
       -a, --all             Show all issues
       -A, --all-priorities  Show all issues including low priority ones
-          --min-priority    Minimum priority to show issues (higher,high,normal,low,ignore or number)
+          --min-priority    Minimum priority to show issues (high,medium,normal,low,lower or number)
       -c, --checks          Only include checks that match the given strings
       -C, --config-name     Use the given config instead of "default"
       -i, --ignore-checks   Ignore checks that match the given strings

--- a/lib/credo/cli/options.ex
+++ b/lib/credo/cli/options.ex
@@ -66,47 +66,26 @@ defmodule Credo.CLI.Options do
   end
 
   defp parse_min_priority({[min_priority: "higher"] = switches, unknown_switches}) do
-    {
-      Keyword.put(switches, :min_priority, 20),
-      unknown_switches
-    }
+    {Keyword.put(switches, :min_priority, 20), unknown_switches}
   end
   defp parse_min_priority({[min_priority: "high"] = switches, unknown_switches}) do
-    {
-      Keyword.put(switches, :min_priority, 10),
-      unknown_switches
-    }
+    {Keyword.put(switches, :min_priority, 10), unknown_switches}
   end
   defp parse_min_priority({[min_priority: "normal"] = switches, unknown_switches}) do
-    {
-      Keyword.put(switches, :min_priority, 1),
-      unknown_switches
-    }
+    {Keyword.put(switches, :min_priority, 1), unknown_switches}
   end
   defp parse_min_priority({[min_priority: "low"] = switches, unknown_switches}) do
-    {
-      Keyword.put(switches, :min_priority, -10),
-      unknown_switches
-    }
+    {Keyword.put(switches, :min_priority, -10), unknown_switches}
   end
   defp parse_min_priority({[min_priority: "ignore"] = switches, unknown_switches}) do
-    {
-      Keyword.put(switches, :min_priority, -100),
-      unknown_switches
-    }
+    {Keyword.put(switches, :min_priority, -100), unknown_switches}
   end
   defp parse_min_priority({[min_priority: min_priority] = switches, unknown_switches}) do
     case Integer.parse(min_priority) do
       {n, ""} ->
-        {
-          Keyword.put(switches, :min_priority, n),
-          unknown_switches
-        }
+        {Keyword.put(switches, :min_priority, n), unknown_switches}
       _ ->
-        {
-          switches,
-          Keyword.put(unknown_switches, "--min-priority", min_priority)
-        }
+        {switches, Keyword.put(unknown_switches, "--min-priority", min_priority)}
     end
   end
   defp parse_min_priority(x), do: x

--- a/lib/credo/cli/options.ex
+++ b/lib/credo/cli/options.ex
@@ -69,16 +69,16 @@ defmodule Credo.CLI.Options do
     {switches, unknowns}
   end
 
-  defp patch_switch({:min_priority, "higher"}, unknowns),
-    do: {{:min_priority, 20}, unknowns}
   defp patch_switch({:min_priority, "high"}, unknowns),
+    do: {{:min_priority, 20}, unknowns}
+  defp patch_switch({:min_priority, "medium"}, unknowns),
     do: {{:min_priority, 10}, unknowns}
   defp patch_switch({:min_priority, "normal"}, unknowns),
-    do: {{:min_priority, 1}, unknowns}
+    do: {{:min_priority, 0}, unknowns}
   defp patch_switch({:min_priority, "low"}, unknowns),
-    do: {{:min_priority, -10}, unknowns}
-  defp patch_switch({:min_priority, "ignore"}, unknowns),
-    do: {{:min_priority, -100}, unknowns}
+    do: {{:min_priority, -2}, unknowns}
+  defp patch_switch({:min_priority, "lower"}, unknowns),
+    do: {{:min_priority, -999}, unknowns}
   defp patch_switch({:min_priority, str}, unknowns) do
     case Integer.parse(str) do
       {int, ""} -> {{:min_priority, int}, unknowns}

--- a/lib/credo/cli/options.ex
+++ b/lib/credo/cli/options.ex
@@ -69,22 +69,19 @@ defmodule Credo.CLI.Options do
     {switches, unknowns}
   end
 
-  defp patch_switch({:min_priority, "high"}, unknowns),
-    do: {{:min_priority, 20}, unknowns}
-  defp patch_switch({:min_priority, "medium"}, unknowns),
-    do: {{:min_priority, 10}, unknowns}
-  defp patch_switch({:min_priority, "normal"}, unknowns),
-    do: {{:min_priority, 0}, unknowns}
-  defp patch_switch({:min_priority, "low"}, unknowns),
-    do: {{:min_priority, -2}, unknowns}
-  defp patch_switch({:min_priority, "lower"}, unknowns),
-    do: {{:min_priority, -999}, unknowns}
+  defp patch_switch({:min_priority, "high"}, unknowns), do: {{:min_priority, 20}, unknowns}
+  defp patch_switch({:min_priority, "medium"}, unknowns), do: {{:min_priority, 10}, unknowns}
+  defp patch_switch({:min_priority, "normal"}, unknowns), do: {{:min_priority, 0}, unknowns}
+  defp patch_switch({:min_priority, "low"}, unknowns), do: {{:min_priority, -2}, unknowns}
+  defp patch_switch({:min_priority, "lower"}, unknowns), do: {{:min_priority, -999}, unknowns}
+
   defp patch_switch({:min_priority, str}, unknowns) do
     case Integer.parse(str) do
       {int, ""} -> {{:min_priority, int}, unknowns}
       _ -> {nil, [{"--min-priority", str} | unknowns]}
     end
   end
+
   defp patch_switch(switch, unknowns), do: {switch, unknowns}
 
   defp split_args([], current_dir, _) do

--- a/lib/credo/cli/options.ex
+++ b/lib/credo/cli/options.ex
@@ -52,43 +52,40 @@ defmodule Credo.CLI.Options do
     args = Enum.reject(args, &Enum.member?(ignored_args, &1))
     {command, path, unknown_args} = split_args(args, current_dir, command_names)
 
-    {switches_keywords, unknown_switches_keywords} =
-      {switches_keywords, unknown_switches_keywords}
-      |> parse_min_priority()
+    {switches_keywords, extra_unknown_switches} = patch_switches(switches_keywords)
 
     %__MODULE__{
       command: command,
       path: path,
       args: unknown_args,
       switches: Enum.into(switches_keywords, %{}),
-      unknown_switches: unknown_switches_keywords
+      unknown_switches: unknown_switches_keywords ++ extra_unknown_switches
     }
   end
 
-  defp parse_min_priority({[min_priority: "higher"] = switches, unknown_switches}) do
-    {Keyword.put(switches, :min_priority, 20), unknown_switches}
+  defp patch_switches(switches_keywords) do
+    {switches, unknowns} = Enum.map_reduce(switches_keywords, [], &patch_switch/2)
+    switches = Enum.reject(switches, &(&1 == nil))
+    {switches, unknowns}
   end
-  defp parse_min_priority({[min_priority: "high"] = switches, unknown_switches}) do
-    {Keyword.put(switches, :min_priority, 10), unknown_switches}
-  end
-  defp parse_min_priority({[min_priority: "normal"] = switches, unknown_switches}) do
-    {Keyword.put(switches, :min_priority, 1), unknown_switches}
-  end
-  defp parse_min_priority({[min_priority: "low"] = switches, unknown_switches}) do
-    {Keyword.put(switches, :min_priority, -10), unknown_switches}
-  end
-  defp parse_min_priority({[min_priority: "ignore"] = switches, unknown_switches}) do
-    {Keyword.put(switches, :min_priority, -100), unknown_switches}
-  end
-  defp parse_min_priority({[min_priority: min_priority] = switches, unknown_switches}) do
-    case Integer.parse(min_priority) do
-      {n, ""} ->
-        {Keyword.put(switches, :min_priority, n), unknown_switches}
-      _ ->
-        {switches, Keyword.put(unknown_switches, "--min-priority", min_priority)}
+
+  defp patch_switch({:min_priority, "higher"}, unknowns),
+    do: {{:min_priority, 20}, unknowns}
+  defp patch_switch({:min_priority, "high"}, unknowns),
+    do: {{:min_priority, 10}, unknowns}
+  defp patch_switch({:min_priority, "normal"}, unknowns),
+    do: {{:min_priority, 1}, unknowns}
+  defp patch_switch({:min_priority, "low"}, unknowns),
+    do: {{:min_priority, -10}, unknowns}
+  defp patch_switch({:min_priority, "ignore"}, unknowns),
+    do: {{:min_priority, -100}, unknowns}
+  defp patch_switch({:min_priority, str}, unknowns) do
+    case Integer.parse(str) do
+      {int, ""} -> {{:min_priority, int}, unknowns}
+      _ -> {nil, [{"--min-priority", str} | unknowns]}
     end
   end
-  defp parse_min_priority(x), do: x
+  defp patch_switch(switch, unknowns), do: {switch, unknowns}
 
   defp split_args([], current_dir, _) do
     {path, unknown_args} = extract_path([], current_dir)

--- a/test/credo/cli/options_test.exs
+++ b/test/credo/cli/options_test.exs
@@ -38,33 +38,33 @@ defmodule Credo.CLI.OptionsTest do
     assert expected == switches(args)
   end
 
-  test "switches: it should convert min_priority higher to 20" do
-    args = String.split("--min-priority=higher --version")
+  test "switches: it should convert min_priority high to 20" do
+    args = String.split("--min-priority=high --version")
     expected = %{version: true, min_priority: 20}
     assert expected == switches(args)
   end
 
-  test "switches: it should convert min_priority high to 10" do
-    args = String.split("--min-priority=high --version")
+  test "switches: it should convert min_priority medium to 10" do
+    args = String.split("--min-priority=medium --version")
     expected = %{version: true, min_priority: 10}
     assert expected == switches(args)
   end
 
-  test "switches: it should convert min_priority normal to 1" do
+  test "switches: it should convert min_priority normal to 0" do
     args = String.split("--min-priority=normal --version")
-    expected = %{version: true, min_priority: 1}
+    expected = %{version: true, min_priority: 0}
     assert expected == switches(args)
   end
 
-  test "switches: it should convert min_priority low to -10" do
+  test "switches: it should convert min_priority low to -2" do
     args = String.split("--min-priority=low --version")
-    expected = %{version: true, min_priority: -10}
+    expected = %{version: true, min_priority: -2}
     assert expected == switches(args)
   end
 
-  test "switches: it should convert min_priority ignore to -100" do
-    args = String.split("--min-priority=ignore --version")
-    expected = %{version: true, min_priority: -100}
+  test "switches: it should convert min_priority lower to -999" do
+    args = String.split("--min-priority=lower --version")
+    expected = %{version: true, min_priority: -999}
     assert expected == switches(args)
   end
 

--- a/test/credo/cli/options_test.exs
+++ b/test/credo/cli/options_test.exs
@@ -38,6 +38,48 @@ defmodule Credo.CLI.OptionsTest do
     assert expected == switches(args)
   end
 
+  test "switches: it should convert min_priority higher to 20" do
+    args = String.split("--min-priority=higher --version")
+    expected = %{version: true, min_priority: 20}
+    assert expected == switches(args)
+  end
+
+  test "switches: it should convert min_priority high to 10" do
+    args = String.split("--min-priority=high --version")
+    expected = %{version: true, min_priority: 10}
+    assert expected == switches(args)
+  end
+
+  test "switches: it should convert min_priority normal to 1" do
+    args = String.split("--min-priority=normal --version")
+    expected = %{version: true, min_priority: 1}
+    assert expected == switches(args)
+  end
+
+  test "switches: it should convert min_priority low to -10" do
+    args = String.split("--min-priority=low --version")
+    expected = %{version: true, min_priority: -10}
+    assert expected == switches(args)
+  end
+
+  test "switches: it should convert min_priority ignore to -100" do
+    args = String.split("--min-priority=ignore --version")
+    expected = %{version: true, min_priority: -100}
+    assert expected == switches(args)
+  end
+
+  test "switches: it should convert min_priority to integer" do
+    args = String.split("--min-priority=-1234 --version")
+    expected = %{version: true, min_priority: -1234}
+    assert expected == switches(args)
+  end
+
+  test "switches: it should reject float min_priority" do
+    args = String.split("--min-priority=-1234.12 --version")
+    expected = %{version: true}
+    assert expected == switches(args)
+  end
+
   test "command: it should work w/o command" do
     args = String.split("--strict --version")
     options = parse(args)


### PR DESCRIPTION
Fixes #532

This does 2 things:

1.  It documents the `--min-priority` switch
1.  It adds 5 new possible values to the `--min-priority` (`high`, `medium`, `normal`, `low`, `lower`)

There's one caveat with this PR. It piggies back on the unknown flags handling feature of credo. If the `--min-priority` switch is given a string it can't parse (not one of the values above nor an integer) it'll report that the `--min-priority` switch is unknown. 

This is not great for users but it's consistent with the current behavior of credo. I didn't want to improve the error reporting for non-parsed flags in this PR since it seemed complicated and beyond the scope of the original issue. At least it's not worse than it was before.

Error output from master:

```sh
$ mix credo --min-priority what
Unknown switch: --min-priority
```

Error output from this PR:

```sh
$ mix credo --min-priority what
Unknown switch: --min-priority
```