### PR TITLE
Fix custom tasks by resolving config before validating it

### DIFF
--- a/lib/credo/main_process.ex
+++ b/lib/credo/main_process.ex
@@ -33,13 +33,13 @@ defmodule Credo.MainProcess do
     run Task.SetDefaultCommand
   end
 
-  activity :validate_config do
-    run Task.ValidateConfig
-  end
-
   activity :resolve_config do
     run Task.UseColors
     run Task.RequireRequires
+  end
+
+  activity :validate_config do
+    run Task.ValidateConfig
   end
 
   activity :run_command do


### PR DESCRIPTION
Using Credo Version 0.9.2, I did something like:

`mix credo gen.check my_new_custom_check` 

I added the two items it told me to my `.credo.exs` file.  But when I ran credo it said something like:

`Ignoring an undefined check: MyNewCustomCheck`

I dug into the code a bit, and saw it was "validating" before "resolving".  I switched these, and the check worked fine.

Travis passes: https://travis-ci.org/harlantwood/credo/builds/383527554

If I had more time, I would add a failing test as well; perhaps adding to the [smoke test](https://github.com/rrrene/credo/blob/master/test/smoke_test.sh) to run the new custom check and make sure the output contains the expected, or stderr is empty.

Anyway, hope this helps, and doesn't break other things!

Wonderful tool, BTW, so happy to have Credo, and all the thoughtful detail written in the reports.