### PR TITLE
Add Specs to readability checks

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -94,6 +94,7 @@
         {Credo.Check.Readability.PredicateFunctionNames},
         {Credo.Check.Readability.PreferImplicitTry},
         {Credo.Check.Readability.RedundantBlankLines},
+        {Credo.Check.Readability.Specs},
         {Credo.Check.Readability.StringSigils},
         {Credo.Check.Readability.TrailingBlankLine},
         {Credo.Check.Readability.TrailingWhiteSpace},


### PR DESCRIPTION
## Problem
Running `mix credo gen.config` results in an incomplete example config, as it's missing the Spec readability check.

## Solution
Add it to `.credo.exs`, which is used in generation.