### PR TITLE
Add warning for Enum.map/2 |> Enum.into/2 to prefer Enum.into/3.

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -109,6 +109,7 @@
         {Credo.Check.Refactor.CyclomaticComplexity},
         {Credo.Check.Refactor.FunctionArity},
         {Credo.Check.Refactor.LongQuoteBlocks},
+        {Credo.Check.Refactor.MapInto},
         {Credo.Check.Refactor.MatchInCondition},
         {Credo.Check.Refactor.NegatedConditionsInUnless},
         {Credo.Check.Refactor.NegatedConditionsWithElse},

--- a/lib/credo/check/refactor/map_into.ex
+++ b/lib/credo/check/refactor/map_into.ex
@@ -55,6 +55,20 @@ defmodule Credo.Check.Refactor.MapInto do
 
   defp traverse(
          ast =
+           {{:., meta, [{:__aliases__, _, [:Enum]}, :into]}, _,
+            [
+              {:|>, _, [_, {{:., _, [{:__aliases__, _, [:Enum]}, :map]}, _, _}]},
+              _
+            ]},
+         issues,
+         issue_meta
+       ) do
+    new_issue = issue_for(issue_meta, meta[:line], "map_into")
+    {ast, issues ++ List.wrap(new_issue)}
+  end
+
+  defp traverse(
+         ast =
            {:|>, meta,
             [
               {:|>, _,

--- a/lib/credo/check/refactor/map_into.ex
+++ b/lib/credo/check/refactor/map_into.ex
@@ -1,0 +1,72 @@
+defmodule Credo.Check.Refactor.MapInto do
+  @moduledoc """
+  `Enum.into/3` is more efficient than `Enum.map/2 |> Enum.into/2`.
+
+  This should be refactored:
+
+      [:apple, :banana, :carrot]
+      |> Enum.map(&({&1, to_string(&1)}))
+      |> Enum.into(%{})
+
+  to look like this:
+
+      Enum.into([:apple, :banana, :carrot], %{}, &({&1, to_string(&1)}))
+
+  The reason for this is performance, because the separate calls to
+  `Enum.map/2` and `Enum.into/2` require two iterations whereas
+  `Enum.into/3` only requires one.
+  """
+
+  @explanation [check: @moduledoc]
+
+  use Credo.Check, base_priority: :high
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse(
+         ast =
+           {{:., _, [{:__aliases__, meta, [:Enum]}, :into]}, _,
+            [{{:., _, [{:__aliases__, _, [:Enum]}, :map]}, _, _}, _]},
+         issues,
+         issue_meta
+       ) do
+    new_issue = issue_for(issue_meta, meta[:line], "map_into")
+    {ast, issues ++ List.wrap(new_issue)}
+  end
+
+  defp traverse(
+         ast =
+           {:|>, meta,
+            [
+              {:|>, _,
+               [
+                 _,
+                 {{:., _, [{:__aliases__, _, [:Enum]}, :map]}, _, _}
+               ]},
+              {{:., _, [{:__aliases__, _, [:Enum]}, :into]}, _, _}
+            ]},
+         issues,
+         issue_meta
+       ) do
+    new_issue = issue_for(issue_meta, meta[:line], "map_into")
+    {ast, issues ++ List.wrap(new_issue)}
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue(
+      issue_meta,
+      message: "`Enum.into/3` is more efficient than `Enum.map/2 |> Enum.into/2`",
+      trigger: trigger,
+      line_no: line_no
+    )
+  end
+end

--- a/lib/credo/check/refactor/map_into.ex
+++ b/lib/credo/check/refactor/map_into.ex
@@ -43,6 +43,20 @@ defmodule Credo.Check.Refactor.MapInto do
          ast =
            {:|>, meta,
             [
+              {{:., _, [{:__aliases__, _, [:Enum]}, :map]}, _, _},
+              {{:., _, [{:__aliases__, _, [:Enum]}, :into]}, _, _}
+            ]},
+         issues,
+         issue_meta
+       ) do
+    new_issue = issue_for(issue_meta, meta[:line], "map_into")
+    {ast, issues ++ List.wrap(new_issue)}
+  end
+
+  defp traverse(
+         ast =
+           {:|>, meta,
+            [
               {:|>, _,
                [
                  _,

--- a/test/credo/check/refactor/map_into_test.exs
+++ b/test/credo/check/refactor/map_into_test.exs
@@ -63,4 +63,32 @@ defmodule Credo.Check.Refactor.MapIntoTest do
     |> to_source_file
     |> assert_issue(@described_check)
   end
+
+  test "it should report a violation 4" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        [:apple, :banana, :carrot]
+        |> Enum.map(&({&1, to_string(&1)}))
+        |> Enum.into(%{})
+        |> Map.keys()
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report a violation 5" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        Enum.map([:apple, :banana, :carrot], &({&1, to_string(&1)}))
+        |> Enum.into(%{})
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
 end

--- a/test/credo/check/refactor/map_into_test.exs
+++ b/test/credo/check/refactor/map_into_test.exs
@@ -1,0 +1,66 @@
+defmodule Credo.Check.Refactor.MapIntoTest do
+  use Credo.TestHelper
+
+  @described_check Credo.Check.Refactor.MapInto
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report expected code" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        Enum.into([:apple, :banana, :carrot], %{}, &({&1, to_string(&1)}))
+      end
+    end
+    """
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report a violation" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        [:apple, :banana, :carrot]
+        |> Enum.map(&({&1, to_string(&1)}))
+        |> Enum.into(%{})
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report a violation 2" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5, p6) do
+        Enum.into(Enum.map([:a, :b, :c], &({&1, to_string(&1)})), %{})
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report a violation 3" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        [:apple, :banana, :carrot]
+        |> Enum.sort()
+        |> Enum.map(&({&1, to_string(&1)}))
+        |> Enum.into(%{})
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+end

--- a/test/credo/check/refactor/map_into_test.exs
+++ b/test/credo/check/refactor/map_into_test.exs
@@ -91,4 +91,16 @@ defmodule Credo.Check.Refactor.MapIntoTest do
     |> to_source_file
     |> assert_issue(@described_check)
   end
+
+  test "it should report a violation 6" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        Enum.into([:apple, :banana, :carrot] |> Enum.map(&({&1, to_string(&1)})), %{})
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
 end


### PR DESCRIPTION
Enum.into/3 only requires one iteration, not two.