### PR TITLE
Report violation for not/2 as well in Refactor.NegatedConditionWithElse

### DIFF
--- a/lib/credo/check/refactor/negated_conditions_with_else.ex
+++ b/lib/credo/check/refactor/negated_conditions_with_else.ex
@@ -4,13 +4,13 @@ defmodule Credo.Check.Refactor.NegatedConditionsWithElse do
 
   So while this is fine:
 
-      if !allowed? do
+      if not allowed? do
         raise "Not allowed!"
       end
 
   The code in this example ...
 
-      if !allowed? do
+      if not allowed? do
         raise "Not allowed!"
       else
         proceed_as_planned()
@@ -23,6 +23,8 @@ defmodule Credo.Check.Refactor.NegatedConditionsWithElse do
       else
         raise "Not allowed!"
       end
+
+  The same goes for negation through `!` instead of `not`.
 
   The reason for this is not a technical but a human one. It is easier to wrap
   your head around a positive condition and then thinking "and else we do ...".
@@ -63,6 +65,10 @@ defmodule Credo.Check.Refactor.NegatedConditionsWithElse do
   end
 
   defp negated_condition?({:!, _meta, _arguments}) do
+    true
+  end
+
+  defp negated_condition?({:not, _meta, _arguments}) do
     true
   end
 

--- a/test/credo/check/refactor/negated_conditions_with_else_test.exs
+++ b/test/credo/check/refactor/negated_conditions_with_else_test.exs
@@ -59,4 +59,20 @@ defmodule Credo.Check.Refactor.NegatedConditionsWithElseTest do
     |> to_source_file
     |> assert_issue(@described_check)
   end
+
+  test "it should report a violation with not/2 as well" do
+    """
+    defmodule Mix.Tasks.Credo do
+      def run(argv) do
+        if not allowed? do
+          true
+        else
+          false
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
 end


### PR DESCRIPTION
`!` should be used only when the condition is not strictly boolean. In my experience, most of the time `not/2` is the better choice so I defaulted to `not/2` in the examples (but mentioned `!` as well) and fixed the check so that it checks for `not/2` as well.