### PR TITLE
Fix AliasOrder to make it work with “as” option

### DIFF
--- a/lib/credo/check/readability/alias_order.ex
+++ b/lib/credo/check/readability/alias_order.ex
@@ -105,7 +105,7 @@ defmodule Credo.Check.Readability.AliasOrder do
   end
 
   defp find_alias_groups(
-         {:alias, _, [{:__aliases__, meta, mod_list}]} = ast,
+         {:alias, _, [{:__aliases__, meta, mod_list} | _]} = ast,
          aliases
        ) do
     modules = [{meta[:line], mod_list, mod_list |> Name.full() |> String.downcase()}]

--- a/test/credo/check/readability/alias_order_test.exs
+++ b/test/credo/check/readability/alias_order_test.exs
@@ -90,6 +90,17 @@ defmodule Credo.Check.Readability.AliasOrderTest do
     |> assert_issue(@described_check)
   end
 
+  test "it should report a violation with “as” option" do
+    """
+    defmodule CredoSampleModule do
+      alias App.Module2
+      alias App.Module1, as: Module3
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
   test "it should report a violation with alias groups" do
     """
     defmodule CredoSampleModule do


### PR DESCRIPTION
Aliases using the `as` option were previously dismissed when extracting alias groups. They are not anymore.