### PR TITLE
Remove UTF-8 quotation marks from AliasOrder test name

### DIFF
--- a/test/credo/check/readability/alias_order_test.exs
+++ b/test/credo/check/readability/alias_order_test.exs
@@ -90,7 +90,7 @@ defmodule Credo.Check.Readability.AliasOrderTest do
     |> assert_issue(@described_check)
   end
 
-  test "it should report a violation with “as” option" do
+  test "it should report a violation with as option" do
     """
     defmodule CredoSampleModule do
       alias App.Module2


### PR DESCRIPTION
This should fix the OTP 18 and 19 compilation errors I introduced with #562 😬 