### PR TITLE
Dialyzer does not ignore functions without typespecs

### DIFF
--- a/lib/credo/check/readability/specs.ex
+++ b/lib/credo/check/readability/specs.ex
@@ -2,9 +2,8 @@ defmodule Credo.Check.Readability.Specs do
   @moduledoc """
   Functions, callbacks and macros need typespecs.
 
-  Adding typespecs allows tools like dialyzer to perform success typing on
-  functions. Without a spec functions and macros are ignored by the type
-  checker.
+  Adding typespecs gives tools like Dialyzer more information when performing
+  checks for type errors in function calls and definitions.
 
       @spec add(integer, integer) :: integer
       def add(a, b), do: a + b


### PR DESCRIPTION
Correct the documentation on the value of function typespecs. 
Dialyzer analyzes the types used in all expression whether or 
not the related functions have typespecs. Typespecs only 
assist in the analysis.

http://erlang.org/doc/reference_manual/typespec.html
http://erlang.org/doc/man/dialyzer.html