### PR TITLE
The Spec check shouldn't require functions that implement behaviours to also have a spec

### DIFF
--- a/lib/credo/check/readability/specs.ex
+++ b/lib/credo/check/readability/specs.ex
@@ -47,6 +47,14 @@ defmodule Credo.Check.Readability.Specs do
     {ast, [:impl | specs]}
   end
 
+  defp find_specs({:def, meta, [{:when, _, def_ast} | _]}, [:impl | specs]) do
+    find_specs({:def, meta, def_ast}, [:impl | specs])
+  end
+
+  defp find_specs({:def, _, [{name, _, nil}, _]} = ast, [:impl | specs]) do
+    {ast, [{name, 0} | specs]}
+  end
+
   defp find_specs({:def, _, [{name, _, args}, _]} = ast, [:impl | specs]) do
     {ast, [{name, length(args)} | specs]}
   end

--- a/lib/credo/check/readability/specs.ex
+++ b/lib/credo/check/readability/specs.ex
@@ -43,6 +43,14 @@ defmodule Credo.Check.Readability.Specs do
     {ast, [{name, length(args)} | specs]}
   end
 
+  defp find_specs({:impl, _, [true]} = ast, specs) do
+    {ast, [:impl | specs]}
+  end
+
+  defp find_specs({:def, _, [{name, _, args}, _]} = ast, [:impl | specs]) do
+    {ast, [{name, length(args)} | specs]}
+  end
+
   defp find_specs(ast, issues) do
     {ast, issues}
   end

--- a/test/credo/check/readability/specs_test.exs
+++ b/test/credo/check/readability/specs_test.exs
@@ -68,4 +68,15 @@ defmodule Credo.Check.Readability.SpecsTest do
     |> to_source_file()
     |> assert_issue(@described_check)
   end
+
+  test "it should NOT report functions with `@impl true`" do
+    """
+    defmodule CredoTypespecTest do
+      @impl true
+      def foo(a), do: a
+    end
+    """
+    |> to_source_file()
+    |> refute_issues(@described_check)
+  end
 end

--- a/test/credo/check/readability/specs_test.exs
+++ b/test/credo/check/readability/specs_test.exs
@@ -79,4 +79,26 @@ defmodule Credo.Check.Readability.SpecsTest do
     |> to_source_file()
     |> refute_issues(@described_check)
   end
+
+  test "it should NOT report functions with guards and `@impl true`" do
+    """
+    defmodule CredoTypespecTest do
+      @impl true
+      def foo(a) when is_integer(a), do: a
+    end
+    """
+    |> to_source_file()
+    |> refute_issues(@described_check)
+  end
+
+  test "it should NOT report functions without arguments and `@impl true`" do
+    """
+    defmodule CredoTypespecTest do
+      @impl true
+      def foo, do: :ok
+    end
+    """
+    |> to_source_file()
+    |> refute_issues(@described_check)
+  end
 end


### PR DESCRIPTION
The current `Credo.Check.Readability.Specs` check requires that functions which implement a behaviour (`@impl true`) also include a `@spec`, this PR amends the check to exclude those functions from the final report.

Since the existing check doesn't verify the `@spec` is valid I didn't think it necessary for it to verify that `@impl true` is correct (that you included the behaviour and the function is a callback).

@rrrene what are your thoughts?