### PR TITLE
add link to changelog

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,10 @@ defmodule Credo.Mixfile do
       ],
       maintainers: ["René Föhring"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/rrrene/credo"}
+      links: %{
+        "GitHub" => "https://github.com/rrrene/credo",
+        "Changelog" => "https://github.com/rrrene/credo/blob/master/CHANGELOG.md"
+      }
     ]
   end
 


### PR DESCRIPTION
direct link from https://hex.pm/packages/credo to changelog (will be published with next version)

