### PR TITLE
Clarify what should be used in place of a two condition `cond`.

### DIFF
--- a/lib/credo/check/refactor/cond_statements.ex
+++ b/lib/credo/check/refactor/cond_statements.ex
@@ -53,7 +53,7 @@ defmodule Credo.Check.Refactor.CondStatements do
   def issue_for(issue_meta, line_no, trigger) do
     format_issue(
       issue_meta,
-      message: "Cond statements should contain at least two conditions besides `true`.",
+      message: "Cond statements should contain at least two conditions besides `true`, consider using `if` instead.",
       trigger: trigger,
       line_no: line_no
     )

--- a/lib/credo/check/refactor/cond_statements.ex
+++ b/lib/credo/check/refactor/cond_statements.ex
@@ -53,7 +53,8 @@ defmodule Credo.Check.Refactor.CondStatements do
   def issue_for(issue_meta, line_no, trigger) do
     format_issue(
       issue_meta,
-      message: "Cond statements should contain at least two conditions besides `true`, consider using `if` instead.",
+      message:
+        "Cond statements should contain at least two conditions besides `true`, consider using `if` instead.",
       trigger: trigger,
       line_no: line_no
     )


### PR DESCRIPTION
An `if` statement should be recommended when a cond with less than two conditions besides `true` is found.