### PR TITLE
handle a timeout when reading files

### DIFF
--- a/lib/credo/cli/output.ex
+++ b/lib/credo/cli/output.ex
@@ -131,9 +131,9 @@ defmodule Credo.CLI.Output do
     print_numbered_list(invalid_source_filenames)
   end
 
-  def complain_about_large_source_files([]), do: nil
+  def complain_about_timed_out_source_files([]), do: nil
 
-  def complain_about_large_source_files(large_source_files) do
+  def complain_about_timed_out_source_files(large_source_files) do
     large_source_filenames = Enum.map(large_source_files, & &1.filename)
 
     output = [

--- a/lib/credo/cli/output.ex
+++ b/lib/credo/cli/output.ex
@@ -131,6 +131,25 @@ defmodule Credo.CLI.Output do
     print_numbered_list(invalid_source_filenames)
   end
 
+  def complain_about_large_source_files([]), do: nil
+
+  def complain_about_large_source_files(large_source_files) do
+    large_source_filenames = Enum.map(large_source_files, & &1.filename)
+
+    output = [
+      :reset,
+      :bright,
+      :orange,
+      "info: ",
+      :red,
+      "Some source files were not parsed in the time allotted:\n"
+    ]
+
+    UI.puts(output)
+
+    print_numbered_list(large_source_filenames)
+  end
+
   def print_skipped_checks(%Execution{skipped_checks: []}), do: nil
 
   def print_skipped_checks(%Execution{skipped_checks: skipped_checks}) do

--- a/lib/credo/cli/task/load_and_validate_source_files.ex
+++ b/lib/credo/cli/task/load_and_validate_source_files.ex
@@ -13,7 +13,7 @@ defmodule Credo.CLI.Task.LoadAndValidateSourceFiles do
       end)
 
     Output.complain_about_invalid_source_files(Map.get(source_files, :invalid, []))
-    Output.complain_about_large_source_files(Map.get(source_files, :timed_out, []))
+    Output.complain_about_timed_out_source_files(Map.get(source_files, :timed_out, []))
 
     exec
     |> put_source_files(Map.get(source_files, :valid, []))

--- a/lib/credo/cli/task/load_and_validate_source_files.ex
+++ b/lib/credo/cli/task/load_and_validate_source_files.ex
@@ -5,17 +5,18 @@ defmodule Credo.CLI.Task.LoadAndValidateSourceFiles do
   alias Credo.Sources
 
   def call(exec, _opts \\ []) do
-    {time_load, {valid_source_files, invalid_source_files}} =
+    {time_load, source_files} =
       :timer.tc(fn ->
         exec
         |> Sources.find()
-        |> Credo.Backports.Enum.split_with(& &1.valid?)
+        |> Enum.group_by(& &1.status)
       end)
 
-    Output.complain_about_invalid_source_files(invalid_source_files)
+    Output.complain_about_invalid_source_files(Map.get(source_files, :invalid, []))
+    Output.complain_about_large_source_files(Map.get(source_files, :timed_out, []))
 
     exec
-    |> put_source_files(valid_source_files)
+    |> put_source_files(Map.get(source_files, :valid, []))
     |> put_assign("credo.time.source_files", time_load)
   end
 end

--- a/lib/credo/source_file.ex
+++ b/lib/credo/source_file.ex
@@ -3,14 +3,17 @@ defmodule Credo.SourceFile do
   `SourceFile` structs represent a source file in the codebase.
   """
 
-  @type t :: module
+  @type t :: %__MODULE__{
+          filename: nil | String.t(),
+          status: :valid | :invalid | :timed_out
+        }
 
   alias Credo.Service.SourceFileAST
   alias Credo.Service.SourceFileLines
   alias Credo.Service.SourceFileSource
 
   defstruct filename: nil,
-            valid?: nil
+            status: nil
 
   defimpl Inspect, for: __MODULE__ do
     def inspect(source_file, _opts) do
@@ -40,7 +43,17 @@ defmodule Credo.SourceFile do
 
     %Credo.SourceFile{
       filename: filename,
-      valid?: valid
+      status: if(valid, do: :valid, else: :invalid)
+    }
+  end
+
+  @spec timed_out(String.t()) :: t
+  def timed_out(filename) do
+    filename = Path.relative_to_cwd(filename)
+
+    %Credo.SourceFile{
+      filename: filename,
+      status: :timed_out
     }
   end
 

--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -120,7 +120,7 @@ defmodule Credo.Sources do
       |> Enum.zip(filenames)
       |> Enum.into(%{})
 
-    tasks_with_results = Task.yield_many(tasks, 5000)
+    tasks_with_results = Task.yield_many(tasks)
 
     results =
       Enum.map(tasks_with_results, fn {task, res} ->
@@ -128,13 +128,10 @@ defmodule Credo.Sources do
         {task, res || Task.shutdown(task, :brutal_kill)}
       end)
 
-    completed =
-      Enum.map(results, fn
-        {_task, {:ok, value}} -> value
-        {task, nil} -> SourceFile.timed_out(task_dictionary[task])
-      end)
-
-    completed
+    Enum.map(results, fn
+      {_task, {:ok, value}} -> value
+      {task, nil} -> SourceFile.timed_out(task_dictionary[task])
+    end)
   end
 
   defp to_source_file(filename) do

--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -33,8 +33,7 @@ defmodule Credo.Sources do
     |> exclude(files.excluded)
     |> Enum.sort()
     |> Enum.take(max_file_count())
-    |> Enum.map(&Task.async(fn -> to_source_file(&1) end))
-    |> Enum.map(&Task.await/1)
+    |> read_files()
   end
 
   def find(paths) when is_list(paths) do
@@ -111,6 +110,31 @@ defmodule Credo.Sources do
       end
 
     Enum.map(paths, &Path.expand/1)
+  end
+
+  defp read_files(filenames) do
+    tasks = Enum.map(filenames, &Task.async(fn -> to_source_file(&1) end))
+
+    task_dictionary =
+      tasks
+      |> Enum.zip(filenames)
+      |> Enum.into(%{})
+
+    tasks_with_results = Task.yield_many(tasks, 5000)
+
+    results =
+      Enum.map(tasks_with_results, fn {task, res} ->
+        # Shutdown the tasks that did not reply nor exit
+        {task, res || Task.shutdown(task, :brutal_kill)}
+      end)
+
+    completed =
+      Enum.map(results, fn
+        {_task, {:ok, value}} -> value
+        {task, nil} -> SourceFile.timed_out(task_dictionary[task])
+      end)
+
+    completed
   end
 
   defp to_source_file(filename) do

--- a/test/credo/source_file_test.exs
+++ b/test/credo/source_file_test.exs
@@ -23,7 +23,7 @@ defmodule Credo.SourceFileTest do
 
     source_file = Credo.SourceFile.parse(s1, "example.ex")
 
-    refute source_file.valid?
+    assert source_file.status == :invalid
   end
 
   test "it should return line and column correctly" do

--- a/test/credo/sources_test.exs
+++ b/test/credo/sources_test.exs
@@ -78,7 +78,7 @@ defmodule Credo.SourcesTest do
       files: %{excluded: [], included: ["lib/mix/tasks/credo.ex"]}
     }
 
-    [%Credo.SourceFile{valid?: true}] = Credo.Sources.find(exec)
+    [%Credo.SourceFile{status: :valid}] = Credo.Sources.find(exec)
   end
 
   test "it excludes paths that match the `excluded` patterns" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -38,7 +38,7 @@ defmodule CredoSourceFileCase do
 
   def to_source_file(source, filename) do
     case Credo.SourceFile.parse(source, filename) do
-      %{valid?: true} = source_file ->
+      %{status: :valid} = source_file ->
         source_file
 
       _ ->


### PR DESCRIPTION
Credo in our CI environment has been timing out in load_and_validate_source_files.ex. Here is what is displayed:
```
** (exit) exited in: Task.await(%Task{owner: #PID<0.74.0>, pid: #PID<0.406.0>, ref: #Reference<0.2449986766.523763713.102619>}, 5000)
    ** (EXIT) time out
    (elixir) lib/task.ex:501: Task.await/2
    (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
    (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
    lib/credo/cli/task/load_and_validate_source_files.ex:11: anonymous fn/1 in Credo.CLI.Task.LoadAndValidateSourceFiles.call/2
    (stdlib) timer.erl:166: :timer.tc/1
    lib/credo/cli/task/load_and_validate_source_files.ex:9: Credo.CLI.Task.LoadAndValidateSourceFiles.call/2
    lib/credo/cli/command/suggest/suggest_command.ex:15: Credo.CLI.Command.Suggest.SuggestCommand.call/2
    lib/credo/execution/task.ex:45: Credo.Execution.Task.do_run/3
```
I determined that we had one fairly large exs file that we use to mock an external service was causing the issue.  This PR will list any files that timeout, in a manner similar to files that will not parse.