### PR TITLE
Clean up quoted keyword warnings

### DIFF
--- a/test/credo/check/readability/large_numbers_test.exs
+++ b/test/credo/check/readability/large_numbers_test.exs
@@ -10,12 +10,12 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
   test "it should NOT report expected code" do
     """
     @budgets %{
-      "budget1": 100_000,
-      "budget2": 200_000,
-      "budget3": 300_000,
-      "budget4": 500_000,
-      "budget5": 1_000_000,
-      "budget6": 2_000_000
+      budget1: 100_000,
+      budget2: 200_000,
+      budget3: 300_000,
+      budget4: 500_000,
+      budget5: 1_000_000,
+      budget6: 2_000_000
     }
 
     @int32_min -2_147_483_648

--- a/test/credo/exs_loader_test.exs
+++ b/test/credo/exs_loader_test.exs
@@ -3,11 +3,11 @@ defmodule Credo.ExsLoaderTest do
 
   test "Credo.Execution.parse_exs should work" do
     exs_string = """
-      %{"combine": {:hex, :combine, "0.5.2"},
-        "cowboy": {:hex, :cowboy, "1.0.2"},
-        "dirs": ["lib", "src", "test"],
-        "dirs_sigil": ~w(lib src test),
-        "dirs_regex": ~r(lib src test),
+      %{combine: {:hex, :combine, "0.5.2"},
+        cowboy: {:hex, :cowboy, "1.0.2"},
+        dirs: ["lib", "src", "test"],
+        dirs_sigil: ~w(lib src test),
+        dirs_regex: ~r(lib src test),
         checks: [
           {Style.MaxLineLength, max_length: 100},
           {Style.TrailingBlankLine},


### PR DESCRIPTION
Example warning:

```
warning: found quoted keyword "dirs_regex" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduce keywords with foreign characters in them
```

Fixes #578