### PR TITLE
Fix "not expr1 in expr2" warnings

### DIFF
--- a/test/credo/code/parameters_test.exs
+++ b/test/credo/code/parameters_test.exs
@@ -38,7 +38,7 @@ defmodule Credo.Code.ParametersTest do
 
     {:ok, ast} =
       """
-      defp foobar(<<h, t :: binary>>, prev) when h in ?A..?Z and not prev in ?A..?Z do
+      defp foobar(<<h, t :: binary>>, prev) when h in ?A..?Z and not(prev in ?A..?Z) do
       :ok
       end
       """
@@ -127,7 +127,7 @@ defmodule Credo.Code.ParametersTest do
 
     {:ok, ast} =
       """
-      defp foobar(<<h, t :: binary>>, prev) when h in ?A..?Z and not prev in ?A..?Z do
+      defp foobar(<<h, t :: binary>>, prev) when h in ?A..?Z and not(prev in ?A..?Z) do
       :ok
       end
       """


### PR DESCRIPTION
Fix "not expr1 in expr2" warnings

Example warning:

```
warning: "not expr1 in expr2" is deprecated. Instead use "expr1 not in expr2" if you require Elixir v1.5+, or "not(expr1 in expr2)" if you have to support earlier Elixir versions
```

Fixes #578 