### PR TITLE
Fix Credo warnings

### DIFF
--- a/lib/credo/execution/timing.ex
+++ b/lib/credo/execution/timing.ex
@@ -9,6 +9,7 @@ defmodule Credo.Execution.Timing do
     time
     |> format_time()
     |> IO.inspect(label: label)
+    # credo:disable-for-previous-line Credo.Check.Warning.IoInspect
 
     result
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -77,7 +77,7 @@ defmodule CredoCheckCase do
   def assert_issue(source_file, check \\ nil, params \\ [], callback \\ nil) do
     issues = issues_for(source_file, check, create_config(), params)
 
-    refute Enum.count(issues) == 0, "There should be one issue, got none."
+    refute Enum.empty?(issues), "There should be one issue, got none."
 
     assert Enum.count(issues) == 1,
            "There should be only 1 issue, got #{Enum.count(issues)}: #{to_inspected(issues)}"


### PR DESCRIPTION
Running `mix credo` resulted in these warnings:

```
  Warnings - please take a look
┃
┃ [W] ↗ Enum.count(issues) == 0 is expensive. Prefer Enum.empty?/1 or list == []
┃       test/test_helper.exs:80:12 #(CredoCheckCase.assert_issue)
┃ [W] ↗ There should be no calls to IO.inspect/1.
┃       lib/credo/execution/timing.ex:11:8 #(Credo.Execution.Timing.inspect)
```

This commit fixes those.

It didn't look like anything in the repo is using `Credo.Execution.Timing.inspect/2`. However, I didn't remove it, just in case any consumers of the library use this function.