### PR TITLE
Fix some refactoring opportunity warnings

### DIFF
--- a/lib/credo/check/consistency/space_around_operators.ex
+++ b/lib/credo/check/consistency/space_around_operators.ex
@@ -189,7 +189,8 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators do
   defp parameter_in_function_call?(location_tuple, tokens, ast) do
     case find_prev_current_next_token(tokens, location_tuple) do
       {prev, _current, _next} ->
-        Credo.Code.TokenAstCorrelation.find_tokens_in_ast(prev, ast)
+        prev
+        |> Credo.Code.TokenAstCorrelation.find_tokens_in_ast(ast)
         |> List.wrap()
         |> List.first()
         |> is_parameter_in_function_call()

--- a/lib/credo/check/design/duplicated_code.ex
+++ b/lib/credo/check/design/duplicated_code.ex
@@ -103,9 +103,7 @@ defmodule Credo.Check.Design.DuplicatedCode do
   end
 
   def add_masses(found_hashes) do
-    found_hashes
-    |> Enum.map(&add_mass_to_subnode/1)
-    |> Enum.into(%{})
+    Enum.into(found_hashes, %{}, &add_mass_to_subnode/1)
   end
 
   defp add_mass_to_subnode({hash, node_items}) do

--- a/lib/credo/check/readability/alias_order.ex
+++ b/lib/credo/check/readability/alias_order.ex
@@ -104,12 +104,10 @@ defmodule Credo.Check.Readability.AliasOrder do
 
   defp process_group([{line_no1, mod_list_first, _}], _) do
     issue_opts =
-      cond do
-        inner_group_order_issue(mod_list_first) ->
-          issue_opts(line_no1, mod_list_first)
-
-        true ->
-          nil
+      if inner_group_order_issue(mod_list_first) do
+        issue_opts(line_no1, mod_list_first)
+      else
+        nil
       end
 
     if issue_opts do

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -170,13 +170,15 @@ defmodule Credo.Check.Readability.LargeNumbers do
       |> SourceFile.line_at(line_no)
 
     beginning_of_number =
-      Regex.run(~r/[^0-9_oxb]*([0-9_oxb]+$)/, String.slice(line, 1..column1))
+      ~r/[^0-9_oxb]*([0-9_oxb]+$)/
+      |> Regex.run(String.slice(line, 1..column1))
       |> List.wrap()
       |> List.last()
       |> to_string()
 
     ending_of_number =
-      Regex.run(~r/^([0-9_\.]+)/, String.slice(line, (column1 + 1)..-1))
+      ~r/^([0-9_\.]+)/
+      |> Regex.run(String.slice(line, (column1 + 1)..-1))
       |> List.wrap()
       |> List.last()
       |> to_string()

--- a/lib/credo/check/refactor/long_quote_blocks.ex
+++ b/lib/credo/check/refactor/long_quote_blocks.ex
@@ -102,7 +102,8 @@ defmodule Credo.Check.Refactor.LongQuoteBlocks do
         source_file = IssueMeta.source_file(issue_meta)
 
         lines =
-          Credo.Code.to_lines(source_file)
+          source_file
+          |> Credo.Code.to_lines()
           |> Enum.slice(meta[:line] - 1, line_count)
 
         lines =

--- a/lib/credo/cli/command/suggest/output/default.ex
+++ b/lib/credo/cli/command/suggest/output/default.ex
@@ -61,17 +61,11 @@ defmodule Credo.CLI.Command.Suggest.Output.Default do
       |> Enum.map(& &1.category)
       |> Enum.uniq()
 
-    issue_map =
-      categories
-      |> Enum.map(fn category ->
-        {category, issues |> Enum.filter(&(&1.category == category))}
-      end)
-      |> Enum.into(%{})
+    issue_map = Enum.into(categories, %{}, fn category ->
+      {category, issues |> Enum.filter(&(&1.category == category))}
+    end)
 
-    source_file_map =
-      source_files
-      |> Enum.map(&{&1.filename, &1})
-      |> Enum.into(%{})
+    source_file_map = Enum.into(source_files, %{}, &{&1.filename, &1})
 
     categories
     |> Sorter.ensure(@category_starting_order, @category_ending_order)

--- a/lib/credo/code/interpolation_helper.ex
+++ b/lib/credo/code/interpolation_helper.ex
@@ -142,7 +142,8 @@ defmodule Credo.Code.InterpolationHelper do
     #       indentation, not the first line of the heredoc.
     padding_in_first_line = determine_padding_at_start_of_line(first_line_in_heredoc)
 
-    find_interpolations(list, source)
+    list
+    |> find_interpolations(source)
     |> Enum.reject(&is_nil/1)
     |> add_to_col_start_and_end(padding_in_first_line)
   end

--- a/lib/credo/code/sigils.ex
+++ b/lib/credo/code/sigils.ex
@@ -21,11 +21,12 @@ defmodule Credo.Code.Sigils do
                      [a, String.upcase(a)]
                    end)
   @all_sigil_starts Enum.map(@all_sigil_chars, fn c -> "~#{c}" end)
-  @removable_sigils Enum.flat_map(@sigil_delimiters, fn {b, e} ->
-                      Enum.flat_map(@all_sigil_starts, fn start ->
-                        [{"#{start}#{b}", e}, {"#{start}#{b}", e}]
-                      end)
-                    end)
+  @removable_sigils @sigil_delimiters
+                    |> Enum.flat_map(fn {b, e} ->
+                         Enum.flat_map(@all_sigil_starts, fn start ->
+                           [{"#{start}#{b}", e}, {"#{start}#{b}", e}]
+                         end)
+                       end)
                     |> Enum.uniq()
 
   @doc """

--- a/lib/credo/execution/process_definition.ex
+++ b/lib/credo/execution/process_definition.ex
@@ -38,9 +38,8 @@ defmodule Credo.Execution.ProcessDefinition do
 
     exec = Execution.set_parent_and_current_task(exec, exec.current_task, current_task)
 
-    tasks = compiled_tasks
-
-    Enum.reduce(tasks, exec, fn task, exec ->
+    compiled_tasks
+    |> Enum.reduce(exec, fn task, exec ->
       Credo.Execution.Task.run(task, exec)
     end)
     |> Execution.set_parent_and_current_task(old_parent_task, old_current_task)

--- a/lib/credo/execution/task.ex
+++ b/lib/credo/execution/task.ex
@@ -53,7 +53,8 @@ defmodule Credo.Execution.Task do
         |> Execution.set_parent_and_current_task(old_parent_task, old_current_task)
 
       %Execution{halted: true} = exec ->
-        task.error(exec, opts)
+        exec
+        |> task.error(opts)
         |> Execution.set_parent_and_current_task(old_parent_task, old_current_task)
 
       value ->

--- a/lib/credo/execution/timing.ex
+++ b/lib/credo/execution/timing.ex
@@ -41,7 +41,8 @@ defmodule Credo.Execution.Timing do
 
   def grouped_by_tag(exec, tag_name) do
     map =
-      all(exec)
+      exec
+      |> all()
       |> Enum.filter(fn {tags, _started_at, _time} -> tags[tag_name] end)
       |> Enum.group_by(fn {tags, _started_at, _time} -> tags[tag_name] end)
 

--- a/lib/credo/priority.ex
+++ b/lib/credo/priority.ex
@@ -41,8 +41,7 @@ defmodule Credo.Priority do
 
     lookup = Enum.into(base_map, %{})
 
-    base_map
-    |> Enum.map(fn {scope_name, prio} ->
+    Enum.into(base_map, %{}, fn {scope_name, prio} ->
       names = String.split(scope_name, ".")
 
       if names |> List.last() |> String.match?(~r/^[a-z]/) do
@@ -58,7 +57,6 @@ defmodule Credo.Priority do
         {scope_name, prio}
       end
     end)
-    |> Enum.into(%{})
   end
 
   defp make_base_map(priority_list, %SourceFile{} = source_file) do

--- a/test/credo/check/readability/large_numbers_test.exs
+++ b/test/credo/check/readability/large_numbers_test.exs
@@ -204,7 +204,7 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
     """
     |> to_source_file
     |> assert_issue(@described_check, fn %Credo.Issue{message: message} ->
-      assert Regex.run(~r/[\d\._]+/, message) |> hd == "10_000.00001"
+      assert ~r/[\d\._]+/ |> Regex.run(message) |> hd == "10_000.00001"
     end)
   end
 
@@ -216,7 +216,7 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
     """
     |> to_source_file
     |> assert_issue(@described_check, fn %Credo.Issue{message: message} ->
-      assert Regex.run(~r/[\d\._]+/, message) |> hd == "10_000.000010"
+      assert ~r/[\d\._]+/ |> Regex.run(message) |> hd == "10_000.000010"
     end)
   end
 

--- a/test/credo/check/readability/string_sigils_test.exs
+++ b/test/credo/check/readability/string_sigils_test.exs
@@ -50,43 +50,50 @@ defmodule Credo.Check.Readability.StringSigilsTest do
   end
 
   test "does NOT report when exactly 3 quotes are found" do
-    create_snippet(~s(f\\"b\\"\\"))
+    ~s(f\\"b\\"\\")
+    |> create_snippet()
     |> to_source_file
     |> refute_issues(@described_check)
   end
 
   test "does NOT report when less than :maximum_allowed_quotes quotes are found" do
-    create_snippet(~s(f\\"\\"\\"\\"))
+    ~s(f\\"\\"\\"\\")
+    |> create_snippet()
     |> to_source_file
     |> refute_issues(@described_check, maximum_allowed_quotes: 5)
   end
 
   test "does NOT report when exactly :maximum_allowed_quotes quotes are found" do
-    create_snippet(~s(f\\"\\"\\"\\"))
+    ~s(f\\"\\"\\"\\")
+    |> create_snippet()
     |> to_source_file
     |> refute_issues(@described_check, maximum_allowed_quotes: 4)
   end
 
   test "does NOT report for quotes in sigil_s" do
-    create_sigil_snippet(~s(f\\"\\"b\\"\\"))
+    ~s(f\\"\\"b\\"\\")
+    |> create_sigil_snippet()
     |> to_source_file
     |> refute_issues(@described_check)
   end
 
   test "does NOT report for quotes in sigil_r" do
-    create_sigil_snippet(~s(f\\"\\"b\\"\\"), "r")
+    ~s(f\\"\\"b\\"\\")
+    |> create_sigil_snippet("r")
     |> to_source_file
     |> refute_issues(@described_check)
   end
 
   test "does NOT report for double quotes in heredoc" do
-    create_heredoc_snippet_w_double_quotes(~s(f\\"\\"b\\"\\"))
+    ~s(f\\"\\"b\\"\\")
+    |> create_heredoc_snippet_w_double_quotes()
     |> to_source_file
     |> refute_issues(@described_check)
   end
 
   test "does NOT report for single quotes in heredoc" do
-    create_heredoc_snippet_w_single_quotes(~s(f\\"\\"b\\"\\"))
+    ~s(f\\"\\"b\\"\\")
+    |> create_heredoc_snippet_w_single_quotes()
     |> to_source_file
     |> refute_issues(@described_check)
   end
@@ -96,13 +103,15 @@ defmodule Credo.Check.Readability.StringSigilsTest do
   #
 
   test "reports for more than 3 quotes" do
-    create_snippet(~s(f\\"\\"b\\"\\"))
+    ~s(f\\"\\"b\\"\\")
+    |> create_snippet()
     |> to_source_file
     |> assert_issue(@described_check)
   end
 
   test "reports for more than :maximum_allowed_quotes quotes" do
-    create_snippet(~s(f\\"\\"b\\"\\\"\\"\\"))
+    ~s(f\\"\\"b\\"\\\"\\"\\")
+    |> create_snippet()
     |> to_source_file
     |> assert_issue(@described_check, maximum_allowed_quotes: 5)
   end

--- a/test/credo/sources_test.exs
+++ b/test/credo/sources_test.exs
@@ -10,7 +10,10 @@ defmodule Credo.SourcesTest do
       "lib/mix/tasks/credo.gen.config.ex"
     ]
 
-    files = Credo.Sources.find(exec) |> Enum.map(& &1.filename)
+    files =
+      exec
+      |> Credo.Sources.find()
+      |> Enum.map(& &1.filename)
 
     assert expected == files
   end
@@ -25,7 +28,10 @@ defmodule Credo.SourcesTest do
       "lib/mix/tasks/credo.gen.config.ex"
     ]
 
-    files = Credo.Sources.find(exec) |> Enum.map(& &1.filename)
+    files =
+      exec
+      |> Credo.Sources.find()
+      |> Enum.map(& &1.filename)
 
     assert expected == files
   end
@@ -39,7 +45,10 @@ defmodule Credo.SourcesTest do
       "lib/mix/tasks/credo.gen.config.ex"
     ]
 
-    files = Credo.Sources.find(exec) |> Enum.map(& &1.filename)
+    files =
+      exec
+      |> Credo.Sources.find()
+      |> Enum.map(& &1.filename)
 
     assert expected == files
   end
@@ -48,7 +57,10 @@ defmodule Credo.SourcesTest do
     full_paths = ["lib/credo.ex", "lib/mix/tasks/credo.ex"]
     exec = %Credo.Execution{files: %{excluded: [], included: full_paths}}
 
-    files = Credo.Sources.find(exec) |> Enum.map(& &1.filename)
+    files =
+      exec
+      |> Credo.Sources.find()
+      |> Enum.map(& &1.filename)
 
     assert full_paths == files
   end
@@ -68,7 +80,10 @@ defmodule Credo.SourcesTest do
       "lib/mix/tasks/credo.gen.config.ex"
     ]
 
-    files = Credo.Sources.find(exec) |> Enum.map(& &1.filename)
+    files =
+      exec
+      |> Credo.Sources.find()
+      |> Enum.map(& &1.filename)
 
     assert expected == files
   end
@@ -88,7 +103,10 @@ defmodule Credo.SourcesTest do
 
     expected = ["lib/mix/tasks/credo.ex"]
 
-    files = Credo.Sources.find(exec) |> Enum.map(& &1.filename)
+    files =
+      exec
+      |> Credo.Sources.find()
+      |> Enum.map(& &1.filename)
 
     assert expected == files
   end
@@ -105,7 +123,10 @@ defmodule Credo.SourcesTest do
       "lib/mix/tasks/credo.gen.config.ex"
     ]
 
-    files = Credo.Sources.find(exec) |> Enum.map(& &1.filename)
+    files =
+      exec
+      |> Credo.Sources.find()
+      |> Enum.map(& &1.filename)
 
     assert expected == files
   end
@@ -117,7 +138,10 @@ defmodule Credo.SourcesTest do
 
     expected = ["lib/mix/tasks/credo.ex"]
 
-    files = Credo.Sources.find(exec) |> Enum.map(& &1.filename)
+    files =
+      exec
+      |> Credo.Sources.find()
+      |> Enum.map(& &1.filename)
 
     assert expected == files
   end
@@ -134,7 +158,10 @@ defmodule Credo.SourcesTest do
       "lib/mix/tasks/credo.gen.config.ex"
     ]
 
-    files = Credo.Sources.find(exec) |> Enum.map(& &1.filename)
+    files =
+      exec
+      |> Credo.Sources.find()
+      |> Enum.map(& &1.filename)
 
     assert expected == files
   end
@@ -185,7 +212,10 @@ defmodule Credo.SourcesTest do
       }
     }
 
-    files = Credo.Sources.find(exec) |> Enum.map(& &1.filename)
+    files =
+      exec
+      |> Credo.Sources.find()
+      |> Enum.map(& &1.filename)
 
     assert files |> Enum.count() > 0
   end


### PR DESCRIPTION
Running `mix credo` on the Credo codebase revealed several "Refactoring opportunity" warnings. This commit fixes some of them. Except for removing the `tasks` temporary variable in `lib/credo/execution/process_definition.ex`, I tried keeping the changes in this PR limited to what would eliminate some refactoring opportunity warnings.

All tests still pass.