### PR TITLE
Adds missing descriptions for some parameters

### DIFF
--- a/lib/credo/check/consistency/space_in_parentheses.ex
+++ b/lib/credo/check/consistency/space_in_parentheses.ex
@@ -18,8 +18,9 @@ defmodule Credo.Check.Consistency.SpaceInParentheses do
 
   @explanation [
     check: @moduledoc,
-    allow_empty_enums:
-      "Allows [], %{} and similar empty enum values to be used regardless of spacing throughout the codebase"
+    params: [
+      allow_empty_enums: "Allows [], %{} and similar empty enum values to be used regardless of spacing throughout the codebase."
+    ]    
   ]
   @default_params [
     allow_empty_enums: false

--- a/lib/credo/check/readability/max_line_length.ex
+++ b/lib/credo/check/readability/max_line_length.ex
@@ -11,7 +11,8 @@ defmodule Credo.Check.Readability.MaxLineLength do
       max_length: "The maximum number of characters a line may consist of.",
       ignore_definitions: "Set to `true` to ignore lines including function definitions.",
       ignore_specs: "Set to `true` to ignore lines including `@spec`s.",
-      ignore_strings: "Set to `true` to ignore lines that are strings or in heredocs"
+      ignore_strings: "Set to `true` to ignore lines that are strings or in heredocs.",
+      ignore_urls: "Set to `true` to ignore lines that contain urls."
     ]
   ]
   @default_params [


### PR DESCRIPTION
The `allow_empty_enums` already had a description but it was not inside a `params` array as it seems to be for all the other patterns 