### PR TITLE
Write all warnings to stderr

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -21,7 +21,7 @@
         # You can give explicit globs or simply directories.
         # In the latter case `**/*.{ex,exs}` will be used.
         #
-        included: ["lib/", "src/", "test/", "web/", "apps/"],
+        included: ["lib/", "src/", "test/", "web/", "apps/", "dupa"],
         excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
       },
       #

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Use `--format` to format the output in one of the following formats:
 
 - `--format=flycheck` for [Flycheck](http://www.flycheck.org/) output
 - `--format=json` for [JSON](https://www.json.org/) output
+- `--format=codeclimate` for [Codeclimate](https://github.com/codeclimate/spec/blob/master/SPEC.md) output
 
 
 ### Only run some checks

--- a/lib/credo/cli/command/info/info_output.ex
+++ b/lib/credo/cli/command/info/info_output.ex
@@ -34,6 +34,8 @@ defmodule Credo.CLI.Command.Info.InfoOutput do
       -i, --ignore-checks   Ignore checks that match the given strings
           --format          Display the list in a specific format (oneline,flycheck)
           --verbose         Display more information (e.g. checked files)
+          --include         Include files that match the given strings
+          --exclude         Exclude files that match the given strings
 
     General options:
       -v, --version         Show version

--- a/lib/credo/cli/command/info/info_output.ex
+++ b/lib/credo/cli/command/info/info_output.ex
@@ -32,7 +32,7 @@ defmodule Credo.CLI.Command.Info.InfoOutput do
       -c, --checks          Only include checks that match the given strings
       -C, --config-name     Use the given config instead of "default"
       -i, --ignore-checks   Ignore checks that match the given strings
-          --format          Display the list in a specific format (oneline,flycheck)
+          --format          Display the list in a specific format (oneline,flycheck,codeclimate)
           --verbose         Display more information (e.g. checked files)
           --include         Include files that match the given strings
           --exclude         Exclude files that match the given strings

--- a/lib/credo/cli/command/list/list_output.ex
+++ b/lib/credo/cli/command/list/list_output.ex
@@ -3,7 +3,8 @@ defmodule Credo.CLI.Command.List.ListOutput do
     default: Credo.CLI.Command.List.Output.Default,
     flycheck: Credo.CLI.Command.List.Output.FlyCheck,
     oneline: Credo.CLI.Command.List.Output.Oneline,
-    json: Credo.CLI.Command.List.Output.Json
+    json: Credo.CLI.Command.List.Output.Json,
+    codeclimate: Credo.CLI.Command.List.Output.Codeclimate
 
   alias Credo.CLI.Output.UI
 
@@ -34,7 +35,7 @@ defmodule Credo.CLI.Command.List.ListOutput do
           --config-file       Use the given config file
       -C, --config-name       Use the given config instead of "default"
       -i, --ignore-checks     Ignore checks that match the given strings
-          --format            Display the list in a specific format (oneline,flycheck)
+          --format            Display the list in a specific format (oneline,flycheck,codeclimate)
           --mute-exit-status  Exit with status zero even if there are issues
           --include           Include files that match the given strings
           --exclude           Exclude files that match the given strings

--- a/lib/credo/cli/command/list/list_output.ex
+++ b/lib/credo/cli/command/list/list_output.ex
@@ -36,6 +36,8 @@ defmodule Credo.CLI.Command.List.ListOutput do
       -i, --ignore-checks     Ignore checks that match the given strings
           --format            Display the list in a specific format (oneline,flycheck)
           --mute-exit-status  Exit with status zero even if there are issues
+          --include           Include files that match the given strings
+          --exclude           Exclude files that match the given strings
 
     General options:
           --[no-]color        Toggle colored output

--- a/lib/credo/cli/command/list/output/codeclimate.ex
+++ b/lib/credo/cli/command/list/output/codeclimate.ex
@@ -1,0 +1,12 @@
+defmodule Credo.CLI.Command.List.Output.Codeclimate do
+  alias Credo.CLI.Output.Formatter.Codeclimate
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> Codeclimate.print_issues()
+  end
+end

--- a/lib/credo/cli/command/list/output/codeclimate.ex
+++ b/lib/credo/cli/command/list/output/codeclimate.ex
@@ -7,6 +7,6 @@ defmodule Credo.CLI.Command.List.Output.Codeclimate do
   def print_after_info(_source_files, exec, _time_load, _time_run) do
     exec
     |> Execution.get_issues()
-    |> Codeclimate.print_issues()
+    |> Codeclimate.print_issues(exec.cli_options.path)
   end
 end

--- a/lib/credo/cli/command/suggest/output/codeclimate.ex
+++ b/lib/credo/cli/command/suggest/output/codeclimate.ex
@@ -1,0 +1,12 @@
+defmodule Credo.CLI.Command.Suggest.Output.Codeclimate do
+  alias Credo.CLI.Output.Formatter.Codeclimate
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> Codeclimate.print_issues()
+  end
+end

--- a/lib/credo/cli/command/suggest/output/codeclimate.ex
+++ b/lib/credo/cli/command/suggest/output/codeclimate.ex
@@ -7,6 +7,6 @@ defmodule Credo.CLI.Command.Suggest.Output.Codeclimate do
   def print_after_info(_source_files, exec, _time_load, _time_run) do
     exec
     |> Execution.get_issues()
-    |> Codeclimate.print_issues()
+    |> Codeclimate.print_issues(exec.cli_options.path)
   end
 end

--- a/lib/credo/cli/command/suggest/output/default.ex
+++ b/lib/credo/cli/command/suggest/output/default.ex
@@ -61,9 +61,10 @@ defmodule Credo.CLI.Command.Suggest.Output.Default do
       |> Enum.map(& &1.category)
       |> Enum.uniq()
 
-    issue_map = Enum.into(categories, %{}, fn category ->
-      {category, issues |> Enum.filter(&(&1.category == category))}
-    end)
+    issue_map =
+      Enum.into(categories, %{}, fn category ->
+        {category, issues |> Enum.filter(&(&1.category == category))}
+      end)
 
     source_file_map = Enum.into(source_files, %{}, &{&1.filename, &1})
 

--- a/lib/credo/cli/command/suggest/suggest_output.ex
+++ b/lib/credo/cli/command/suggest/suggest_output.ex
@@ -3,7 +3,8 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
     default: Credo.CLI.Command.Suggest.Output.Default,
     flycheck: Credo.CLI.Command.Suggest.Output.FlyCheck,
     oneline: Credo.CLI.Command.Suggest.Output.Oneline,
-    json: Credo.CLI.Command.Suggest.Output.Json
+    json: Credo.CLI.Command.Suggest.Output.Json,
+    codeclimate: Credo.CLI.Command.Suggest.Output.Codeclimate
 
   alias Credo.CLI.Output.UI
 
@@ -34,7 +35,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
           --config-file       Use the given config file
       -C, --config-name       Use the given config instead of "default"
       -i, --ignore-checks     Ignore checks that match the given strings
-          --format            Display the list in a specific format (oneline,flycheck)
+          --format            Display the list in a specific format (oneline,flycheck,codeclimate)
           --mute-exit-status  Exit with status zero even if there are issues
           --include           Include files that match the given strings
           --exclude           Exclude files that match the given strings

--- a/lib/credo/cli/command/suggest/suggest_output.ex
+++ b/lib/credo/cli/command/suggest/suggest_output.ex
@@ -36,6 +36,8 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
       -i, --ignore-checks     Ignore checks that match the given strings
           --format            Display the list in a specific format (oneline,flycheck)
           --mute-exit-status  Exit with status zero even if there are issues
+          --include           Include files that match the given strings
+          --exclude           Exclude files that match the given strings
 
     General options:
           --[no-]color        Toggle colored output

--- a/lib/credo/cli/options.ex
+++ b/lib/credo/cli/options.ex
@@ -22,7 +22,9 @@ defmodule Credo.CLI.Options do
     read_from_stdin: :boolean,
     strict: :boolean,
     verbose: :boolean,
-    version: :boolean
+    version: :boolean,
+    include: :keep,
+    exclude: :keep
   ]
   @aliases [
     a: :all,
@@ -72,9 +74,19 @@ defmodule Credo.CLI.Options do
       command: command,
       path: path,
       args: unknown_args,
-      switches: Enum.into(switches_keywords, %{}),
+      switches: Enum.reduce(switches_keywords, %{}, &convert_switches/2),
       unknown_switches: unknown_switches_keywords ++ extra_unknown_switches
     }
+  end
+
+  defp convert_switches(switch, acc) do
+    {key, value} = switch
+
+    if old = Map.get(acc, key) do
+      Map.put(acc, key, List.wrap(old) ++ [value])
+    else
+      Map.put(acc, key, value)
+    end
   end
 
   defp patch_switches(switches_keywords) do

--- a/lib/credo/cli/output.ex
+++ b/lib/credo/cli/output.ex
@@ -126,7 +126,7 @@ defmodule Credo.CLI.Output do
       "Some source files could not be parsed correctly and are excluded:\n"
     ]
 
-    UI.puts(output)
+    UI.warn(output)
 
     print_numbered_list(invalid_source_filenames)
   end
@@ -145,7 +145,7 @@ defmodule Credo.CLI.Output do
       "Some source files were not parsed in the time allotted:\n"
     ]
 
-    UI.puts(output)
+    UI.warn(output)
 
     print_numbered_list(large_source_filenames)
   end
@@ -169,8 +169,8 @@ defmodule Credo.CLI.Output do
       "get the most out of Credo!\n"
     ]
 
-    UI.puts()
-    UI.puts(msg)
+    UI.warn()
+    UI.warn(msg)
 
     skipped_checks
     |> Enum.map(&check_name/1)

--- a/lib/credo/cli/output.ex
+++ b/lib/credo/cli/output.ex
@@ -196,6 +196,6 @@ defmodule Credo.CLI.Output do
         " #{string}\n"
       ]
     end)
-    |> UI.puts()
+    |> UI.warn()
   end
 end

--- a/lib/credo/cli/output/format_delegator.ex
+++ b/lib/credo/cli/output/format_delegator.ex
@@ -9,7 +9,8 @@ defmodule Credo.CLI.Output.FormatDelegator do
         default: Credo.CLI.Command.Suggest.Output.Default,
         flycheck: Credo.CLI.Command.Suggest.Output.FlyCheck,
         oneline: Credo.CLI.Command.Suggest.Output.Oneline,
-        json: Credo.CLI.Command.Suggest.Output.Json
+        json: Credo.CLI.Command.Suggest.Output.Json,
+        codeclimate: Credo.CLI.Command.Suggest.Output.Codeclimate
 
   """
 

--- a/lib/credo/cli/output/formatter/codeclimate.ex
+++ b/lib/credo/cli/output/formatter/codeclimate.ex
@@ -19,21 +19,24 @@ defmodule Credo.CLI.Output.Formatter.Codeclimate do
     Credo.Check.Warning.OperationWithConstantResult => ["Bug Risk"]
   }
 
-  def print_issues(issues) do
+  def print_issues(issues, path) do
     issues
-    |> Enum.map(&to_json/1)
+    |> Enum.map(&to_json(&1, path))
     |> Enum.join("\0")
     |> UI.puts()
   end
 
-  def to_json(%Issue{
-        check: check,
-        message: message,
-        line_no: line,
-        column: column,
-        filename: filename,
-        priority: priority
-      }) do
+  def to_json(
+        %Issue{
+          check: check,
+          message: message,
+          line_no: line,
+          column: column,
+          filename: filename,
+          priority: priority
+        },
+        path
+      ) do
     %{
       type: "issue",
       categories: categories(check),
@@ -45,7 +48,7 @@ defmodule Credo.CLI.Output.Formatter.Codeclimate do
         body: check.explanation
       },
       location: %{
-        path: filename,
+        path: Path.relative_to(filename, path),
         positions: %{
           begin: %{
             line: line || 1,

--- a/lib/credo/cli/output/formatter/codeclimate.ex
+++ b/lib/credo/cli/output/formatter/codeclimate.ex
@@ -46,7 +46,7 @@ defmodule Credo.CLI.Output.Formatter.Codeclimate do
       },
       location: %{
         path: filename,
-        lines: %{
+        positions: %{
           begin: %{
             line: line || 1,
             column: column || 1

--- a/lib/credo/cli/output/formatter/codeclimate.ex
+++ b/lib/credo/cli/output/formatter/codeclimate.ex
@@ -1,0 +1,86 @@
+defmodule Credo.CLI.Output.Formatter.Codeclimate do
+  alias Credo.CLI.Output.UI
+  alias Credo.Issue
+
+  @issue_category %{
+    Credo.Check.Design.DuplicatedCode => ["Duplication"],
+    Credo.Check.Readability.ModuleDoc => ["Clarity"],
+    Credo.Check.Readability.ModuleNames => ["Clarity"],
+    Credo.Check.Refactor.ABCSize => ["Complexity"],
+    Credo.Check.Refactor.CyclomaticComplexity => ["Complexity"],
+    Credo.Check.Warning.NameRedeclarationByFn => ["Clarity"],
+    Credo.Check.Warning.OperationOnSameValues => ["Bug Risk"],
+    Credo.Check.Warning.BoolOperationOnSameValues => ["Bug Risk"],
+    Credo.Check.Warning.UnusedEnumOperation => ["Bug Risk"],
+    Credo.Check.Warning.UnusedKeywordOperation => ["Bug Risk"],
+    Credo.Check.Warning.UnusedListOperation => ["Bug Risk"],
+    Credo.Check.Warning.UnusedStringOperation => ["Bug Risk"],
+    Credo.Check.Warning.UnusedTupleOperation => ["Bug Risk"],
+    Credo.Check.Warning.OperationWithConstantResult => ["Bug Risk"]
+  }
+
+  def print_issues(issues) do
+    issues
+    |> Enum.map(&to_json/1)
+    |> Enum.join("\0")
+    |> UI.puts()
+  end
+
+  def to_json(%Issue{
+        check: check,
+        message: message,
+        line_no: line,
+        column: column,
+        filename: filename,
+        priority: priority
+      }) do
+    %{
+      type: "issue",
+      categories: categories(check),
+      check_name: check_name(check),
+      description: message,
+      remediation_points: 50_000,
+      severity: severity(priority),
+      content: %{
+        body: check.explanation
+      },
+      location: %{
+        path: filename,
+        lines: %{
+          begin: %{
+            line: line || 1,
+            column: column || 1
+          },
+          end: %{
+            line: line || 1,
+            column: column || 1
+          }
+        }
+      }
+    }
+    |> Jason.encode!()
+  end
+
+  defp categories(issue) do
+    @issue_category[issue] || ["Style"]
+  end
+
+  defp check_name(issue) do
+    issue
+    |> Module.split()
+    |> List.last()
+    |> Macro.underscore()
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  defp severity(priority) do
+    case priority do
+      priority when priority > 20 -> "blocker"
+      priority when priority in 10..19 -> "critical"
+      priority when priority in 0..9 -> "major"
+      priority when priority in -10..-1 -> "minor"
+      priority when priority < -10 -> "info"
+    end
+  end
+end

--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -19,14 +19,11 @@ defmodule Credo.CLI.Output.Summary do
 
   def print(
         _source_files,
-        %Execution{format: "flycheck"},
+        %Execution{format: format},
         _time_load,
         _time_run
-      ) do
-    nil
-  end
-
-  def print(_source_files, %Execution{format: "oneline"}, _time_load, _time_run) do
+      )
+      when format in ["oneline", "flycheck", "codeclimate"] do
     nil
   end
 

--- a/lib/credo/code/sigils.ex
+++ b/lib/credo/code/sigils.ex
@@ -23,10 +23,10 @@ defmodule Credo.Code.Sigils do
   @all_sigil_starts Enum.map(@all_sigil_chars, fn c -> "~#{c}" end)
   @removable_sigils @sigil_delimiters
                     |> Enum.flat_map(fn {b, e} ->
-                         Enum.flat_map(@all_sigil_starts, fn start ->
-                           [{"#{start}#{b}", e}, {"#{start}#{b}", e}]
-                         end)
-                       end)
+                      Enum.flat_map(@all_sigil_starts, fn start ->
+                        [{"#{start}#{b}", e}, {"#{start}#{b}", e}]
+                      end)
+                    end)
                     |> Enum.uniq()
 
   @doc """

--- a/lib/credo/config_builder.ex
+++ b/lib/credo/config_builder.ex
@@ -190,7 +190,7 @@ defmodule Credo.ConfigBuilder do
 
   # DEPRECATED command line switches
   defp add_switch_deprecated_switches(exec, %{one_line: true}) do
-    UI.puts([
+    UI.warn([
       :yellow,
       "[DEPRECATED] ",
       :faint,

--- a/lib/credo/config_builder.ex
+++ b/lib/credo/config_builder.ex
@@ -72,6 +72,8 @@ defmodule Credo.ConfigBuilder do
     |> add_switch_read_from_stdin(switches)
     |> add_switch_verbose(switches)
     |> add_switch_version(switches)
+    |> add_switch_included(switches)
+    |> add_switch_excluded(switches)
   end
 
   defp add_switch_all(exec, %{all: true}) do
@@ -199,4 +201,16 @@ defmodule Credo.ConfigBuilder do
   end
 
   defp add_switch_deprecated_switches(exec, _), do: exec
+
+  defp add_switch_included(exec, %{include: include}) do
+    %Execution{exec | files: %{exec.files | included: List.wrap(include)}}
+  end
+
+  defp add_switch_included(exec, _), do: exec
+
+  defp add_switch_excluded(exec, %{exclude: exclude}) do
+    %Execution{exec | files: %{exec.files | excluded: List.wrap(exclude)}}
+  end
+
+  defp add_switch_excluded(exec, _), do: exec
 end

--- a/lib/credo/execution/timing.ex
+++ b/lib/credo/execution/timing.ex
@@ -9,6 +9,7 @@ defmodule Credo.Execution.Timing do
     time
     |> format_time()
     |> IO.inspect(label: label)
+
     # credo:disable-for-previous-line Credo.Check.Warning.IoInspect
 
     result


### PR DESCRIPTION
Because codeclimate engine read data from stdin, all warnings should go to stderr.

This PR fixes this problem.