### PR TITLE
Write all warnings to stderr

### DIFF
--- a/lib/credo/cli/output.ex
+++ b/lib/credo/cli/output.ex
@@ -126,7 +126,7 @@ defmodule Credo.CLI.Output do
       "Some source files could not be parsed correctly and are excluded:\n"
     ]
 
-    UI.puts(output)
+    UI.warn(output)
 
     print_numbered_list(invalid_source_filenames)
   end
@@ -145,7 +145,7 @@ defmodule Credo.CLI.Output do
       "Some source files were not parsed in the time allotted:\n"
     ]
 
-    UI.puts(output)
+    UI.warn(output)
 
     print_numbered_list(large_source_filenames)
   end
@@ -169,8 +169,8 @@ defmodule Credo.CLI.Output do
       "get the most out of Credo!\n"
     ]
 
-    UI.puts()
-    UI.puts(msg)
+    UI.warn()
+    UI.warn(msg)
 
     skipped_checks
     |> Enum.map(&check_name/1)

--- a/lib/credo/cli/output.ex
+++ b/lib/credo/cli/output.ex
@@ -196,6 +196,6 @@ defmodule Credo.CLI.Output do
         " #{string}\n"
       ]
     end)
-    |> UI.puts()
+    |> UI.warn()
   end
 end

--- a/lib/credo/config_builder.ex
+++ b/lib/credo/config_builder.ex
@@ -188,7 +188,7 @@ defmodule Credo.ConfigBuilder do
 
   # DEPRECATED command line switches
   defp add_switch_deprecated_switches(exec, %{one_line: true}) do
-    UI.puts([
+    UI.warn([
       :yellow,
       "[DEPRECATED] ",
       :faint,


### PR DESCRIPTION
Because codeclimate engine read data from stdin, all warnings should go to stderr.

This PR fixes this problem.