### PR TITLE
Fix a few more issues shown by mix credo

### DIFF
--- a/lib/credo/code/token.ex
+++ b/lib/credo/code/token.ex
@@ -228,6 +228,7 @@ defmodule Credo.Code.Token do
     end
   end
 
+  # credo:disable-for-next-line Credo.Check.Readability.ModuleNames
   defmodule ElixirPre1_6_0 do
     @moduledoc false
 

--- a/lib/credo/execution/execution_timing.ex
+++ b/lib/credo/execution/execution_timing.ex
@@ -18,11 +18,10 @@ defmodule Credo.Execution.ExecutionTiming do
   def inspect(label, fun) do
     {time, result} = :timer.tc(fun)
 
+    # credo:disable-for-lines:3 Credo.Check.Warning.IoInspect
     time
     |> format_time()
     |> IO.inspect(label: label)
-
-    # credo:disable-for-previous-line Credo.Check.Warning.IoInspect
 
     result
   end

--- a/lib/credo/execution/task/convert_cli_options_to_config.ex
+++ b/lib/credo/execution/task/convert_cli_options_to_config.ex
@@ -46,12 +46,7 @@ defmodule Credo.Execution.Task.ConvertCLIOptionsToConfig do
         UI.warn("")
 
         Enum.each(lines, fn {line_no2, line} ->
-          color =
-            if line_no2 == line_no do
-              [:bright, :cyan]
-            else
-              [:faint]
-            end
+          color = color_list(line_no, line_no2)
 
           UI.warn([color, String.pad_leading("#{line_no2}", 5), :reset, "  ", color, line])
         end)
@@ -64,4 +59,7 @@ defmodule Credo.Execution.Task.ConvertCLIOptionsToConfig do
 
     exec
   end
+
+  defp color_list(line_no, line_no2) when line_no == line_no2, do: [:bright, :cyan]
+  defp color_list(_, _), do: [:faint]
 end


### PR DESCRIPTION
This PR doesn't fix more than a handful of issues, but here's what it does:
* Ignore a readability issue. We want a module name to have underscores when designating an Elixir version.
* Remove deep nesting.
* Allow `IO.inspect/1`, but in a way that `mix format` will not undo. `mix format` added a space before `credo:disable-for-previous-line`, so we needed a different way to ignore that `IO.inspect/1` call.

There are a few readability issues flagged by `mix credo` which involve missing `@moduledoc`s. Would you like me to work on documenting those modules, or would you prefer `@moduledoc false`? Additionally, `mix credo` is flagging a 18 TODOs and one FIXME. Would you like me to convert those to GitHub issues, and remove the TODO and FIXME comments from the codebase? I can do one or both of those things in separate PRs if you'd like me to.