### PR TITLE
Fix bugs on function calls in ABC check

### DIFF
--- a/test/credo/check/refactor/abc_size_test.exs
+++ b/test/credo/check/refactor/abc_size_test.exs
@@ -14,6 +14,26 @@ defmodule Credo.Check.Refactor.ABCSizeTest do
     |> Float.round(2)
   end
 
+  test "it should return the correct ABC size for nullary function calls" do
+    source = """
+    def foo() do
+      baz()
+    end
+    """
+
+    assert rounded_abc_size(source) == 1.0
+  end
+
+  test "it should return the correct ABC size for regular function calls" do
+    source = """
+    def foo() do
+      baz 1, 2
+    end
+    """
+
+    assert rounded_abc_size(source) == 1.0
+  end  
+
   test "it should return the correct ABC size for value assignment" do
     source = """
     def first_fun do


### PR DESCRIPTION
There was no clause for the AST pattern {name, _meta, args} with
name being an atom and args a list, which is what local function
calls look like.

I added two tests.

:if and :__aliases__ syntatically are function calls, so
I had to rely on a list of non-function calls to skip for now.

Refers to #602 