### PR TITLE
Fix bug on counting function calls in ABC

### DIFF
--- a/test/credo/check/refactor/abc_size_test.exs
+++ b/test/credo/check/refactor/abc_size_test.exs
@@ -15,6 +15,26 @@ defmodule Credo.Check.Refactor.ABCSizeTest do
     |> Float.round(2)
   end
 
+  test "it should return the correct ABC size for nullary function calls" do
+    source = """
+    def foo() do
+      baz()
+    end
+    """
+
+    assert rounded_abc_size(source) == 1.0
+  end
+
+  test "it should return the correct ABC size for regular function calls" do
+    source = """
+    def foo() do
+      baz 1, 2
+    end
+    """
+
+    assert rounded_abc_size(source) == 1.0
+  end  
+
   test "it should return the correct ABC size for value assignment" do
     source = """
     def first_fun do


### PR DESCRIPTION
The {atom, _, list} pattern matches function calls but
was not counting any points as branches in the B component
of the metric.

This commit fixes it.

Also, I had to add a whitelist (@non_calls) so that :__aliases__,
:__block__ and other constructs that syntactically are functions
calls are properly skipped.

I added two tests to check for the new cases.