### PR TITLE
Add new report_card command and optional test coverage check.

### DIFF
--- a/lib/credo/application.ex
+++ b/lib/credo/application.ex
@@ -12,7 +12,8 @@ defmodule Credo.Application do
       worker(Credo.Service.SourceFileScopes, []),
       worker(Credo.Service.SourceFileAST, []),
       worker(Credo.Service.SourceFileLines, []),
-      worker(Credo.Service.SourceFileSource, [])
+      worker(Credo.Service.SourceFileSource, []),
+      worker(Credo.Service.ExcoverallsMissingCoverage, [])
     ]
 
     opts = [strategy: :one_for_one, name: Credo.Supervisor]

--- a/lib/credo/check/warning/ex_coveralls_uncovered.ex
+++ b/lib/credo/check/warning/ex_coveralls_uncovered.ex
@@ -1,0 +1,94 @@
+defmodule Credo.Check.Warning.ExCoverallsUncovered do
+  @moduledoc false
+
+  @checkdoc """
+  Code should be touched at least once by code coverage.
+  """
+  @explanation [check: @checkdoc]
+
+  use Credo.Check, base_priority: :high
+
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    case Credo.Service.ExcoverallsMissingCoverage.data_available?() do
+      false ->
+        []
+
+      _ ->
+        check_coveralls_map(
+          issue_meta,
+          Credo.Service.ExcoverallsMissingCoverage.coverage_map(),
+          source_file.filename
+        )
+    end
+  end
+
+  defp check_coveralls_map(issue_meta, coveralls_map, source_file) do
+    {:ok, data} = Credo.Service.SourceFileLines.get(source_file)
+
+    all_issues =
+      Enum.reduce(data, [], fn {idx, _}, acc ->
+        case line_in_missing_list(coveralls_map, source_file, idx) do
+          true -> [issue_for(issue_meta, idx) | acc]
+          _ -> acc
+        end
+      end)
+
+    contract_issues(all_issues)
+  end
+
+  def contract_issues(all_issues) do
+    sorted_issues =
+      all_issues
+      |> Enum.sort_by(fn issue -> issue.line_no end)
+
+    {last, issues} =
+      Enum.reduce(sorted_issues, {nil, []}, fn issue, acc ->
+        reduce_issue_if_adjacent(issue, acc)
+      end)
+
+    finalize_join(issues, last)
+  end
+
+  defp reduce_issue_if_adjacent(issue, {nil, issues}) do
+    {issue, issues}
+  end
+
+  defp reduce_issue_if_adjacent(issue, {last, issues}) do
+    difference = issue.line_no - (last.line_no + last.severity - 1)
+
+    case difference < 2 do
+      false -> {issue, [last | issues]}
+      _ -> {merge_issues(last, issue), issues}
+    end
+  end
+
+  defp merge_issues(previous, _) do
+    %Credo.Issue{previous | severity: previous.severity + 1}
+  end
+
+  defp finalize_join(issues, nil) do
+    issues
+  end
+
+  defp finalize_join(issues, last) do
+    [last | issues]
+  end
+
+  defp line_in_missing_list(coveralls_map, sf, idx) do
+    case Map.has_key?(coveralls_map, sf) do
+      false -> false
+      _ -> Map.has_key?(Map.fetch!(coveralls_map, sf), idx)
+    end
+  end
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue(
+      issue_meta,
+      message: "Code has no test coverage.",
+      line_no: line_no,
+      severity: 1
+    )
+  end
+end

--- a/lib/credo/cli/command/report_card/output/console.ex
+++ b/lib/credo/cli/command/report_card/output/console.ex
@@ -1,0 +1,81 @@
+defmodule Credo.CLI.Command.ReportCard.Output.Console do
+  @moduledoc false
+
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> print_issues()
+  end
+
+  alias Credo.CLI.Output.UI
+
+  defp print_issues(issues) do
+    UI.puts()
+
+    issues
+    |> Enum.reduce(Map.new(), &Credo.CLI.Output.Formatter.ReportCard.categorize_module/2)
+    |> Enum.map(&score_module/1)
+    |> Enum.sort_by(fn {n, g, rs, ic} -> {g, rs, ic, n} end)
+    |> Enum.reverse()
+    |> Enum.each(fn item -> write_console(item) end)
+  end
+
+  defp write_console({n, g, rs, ic}) do
+    {grade_bg, grade_fg} = grade_colors(g)
+
+    UI.puts([
+      grade_bg,
+      grade_fg,
+      " ",
+      g,
+      " ",
+      :reset,
+      " ",
+      n
+    ])
+
+    UI.puts(["    ", "Issues: ", Integer.to_string(ic)])
+
+    UI.puts([
+      "    ",
+      "Remediation Time: ",
+      Credo.CLI.Output.Formatter.ReportCard.format_remediation_time(rs)
+    ])
+
+    UI.puts()
+  end
+
+  defp score_module({k, v}) do
+    {issue_count, raw_score} = Credo.CLI.Output.Formatter.ReportCard.score_issues(k, v)
+    mod_grade = Credo.CLI.Output.Formatter.ReportCard.grade(raw_score)
+    {k, mod_grade, raw_score, issue_count}
+  end
+
+  defp grade_colors("A") do
+    {:green_background, :bright}
+  end
+
+  defp grade_colors("B") do
+    {:magenta_background, :bright}
+  end
+
+  defp grade_colors("C") do
+    {:blue_background, :bright}
+  end
+
+  defp grade_colors("D") do
+    {:yellow_background, :bright}
+  end
+
+  defp grade_colors("E") do
+    {:orange_background, :bright}
+  end
+
+  defp grade_colors(_) do
+    {:red_background, :bright}
+  end
+end

--- a/lib/credo/cli/command/report_card/output/html.ex
+++ b/lib/credo/cli/command/report_card/output/html.ex
@@ -1,0 +1,676 @@
+defmodule Credo.CLI.Command.ReportCard.Output.Html do
+  @moduledoc false
+
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> print_issues()
+  end
+
+  alias Credo.Issue
+  alias Credo.Service.SourceFileLines
+
+  @head_links """
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-core.min.js" data-manual></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-elixir.min.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/themes/prism.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/plugins/line-numbers/prism-line-numbers.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/plugins/line-highlight/prism-line-highlight.min.css" />
+  """
+
+  @inline_styles """
+  <style>
+    /**
+    * prism.js Code Climate theme based on Coy theme
+    */
+
+    code[class*="language-"],
+    pre[class*="language-"] {
+      color: black;
+      font-family: Consolas, 'Bitstream Vera Sans Mono', Monaco, Courier, monospace;
+      direction: ltr;
+      text-align: left;
+      white-space: pre;
+      word-spacing: normal;
+      word-break: normal;
+      tab-size: 4;
+      hyphens: none;
+      font-size: 12px;
+    }
+
+    pre[class*="language-"] {
+      position:relative;
+      background-color: #fdfdfd;
+      background-image: linear-gradient(rgba(69, 142, 209, 0.0) 50%, rgba(69, 142, 209, 0.04) 50%);
+      background-size: 3em 3em;
+      background-origin: content-box;
+      /*overflow: hidden;
+      border: 1px solid #dde8ef;*/
+      margin-top: 1em;
+    }
+
+    pre > code[class*="language-"] {
+      display: block;
+      z-index: 100;
+    }
+
+    /* Inline code */
+    :not(pre) > code[class*="language-"] {
+      position:relative;
+      padding: .2em;
+      -webkit-border-radius: 0.3em;
+      -moz-border-radius: 0.3em;
+      -ms-border-radius: 0.3em;
+      -o-border-radius: 0.3em;
+      border-radius: 0.3em;
+    }
+
+    .token.punctuation {
+      font-weight: bold;
+    }
+
+    .token.operator {
+      font-weight: bold;
+    }
+
+    .token.keyword {
+      font-weight: bold;
+    }
+
+    .token.class-name {
+      font-weight: bold;
+    }
+
+    .token.important {
+      font-weight: normal;
+    }
+
+    .token.entity {
+      cursor: help;
+    }
+
+    .token.attribute {
+      color: #46b1ae;
+    }
+
+    .namespace {
+      opacity: .7;
+    }
+
+    pre.line-numbers {
+      position: relative;
+      padding-left: 40px;
+      counter-reset: linenumber;
+    }
+
+    pre.line-numbers > code {
+      position: relative;
+      padding-left: 4px;
+    }
+
+    .line-numbers .line-numbers-rows {
+      position: absolute;
+      pointer-events: none;
+      top: 0;
+      font-size: 100%;
+      left: -3.8em;
+      width: 3.8em; /* works for line-numbers below 1000 lines */
+      letter-spacing: -1px;
+      padding-top: 1px;
+      user-select: none;
+      background-color: #f1f1f1;
+      color: #757575;
+    }
+
+    .line-numbers-rows > span {
+      pointer-events: none;
+      display: block;
+      counter-increment: linenumber;
+    }
+
+    .line-numbers-rows > span:before {
+      content: counter(linenumber);
+      color: #999;
+      display: block;
+      padding-right: 0.8em;
+      text-align: right;
+    }
+  </style>
+  <style>
+    /**
+    * Report styles
+    */
+
+    html, body {
+      font-size: 15px;
+      line-height: 1.333;
+      background: #f6f6f5;
+      color: #323543;
+      font-family: "BentonSans", helvetica, arial, sans-serif;
+      font-style: normal;
+      font-weight: normal;
+      min-width: 960px;
+      margin: 0;
+      padding: 0;
+    }
+    a {
+      color:#007dce;
+      text-decoration: none;
+    }
+    a:hover {
+      color:#005e9b;
+      text-decoration: underline;
+    }
+    .container {
+      width: 960px;
+      margin: 0 auto;
+    }
+    #top {
+      color: #fff;
+      background: #323543;
+        padding: 5px 0;
+    }
+    #logo {
+      background: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22144%22%20height%3D%22144%22%20viewBox%3D%220%200%20144%20144%22%3E%3Cg%20fill%3D%22%23FFF%22%3E%3Cpath%20d%3D%22M93.548%2037.327L69.856%2061.02l14.09%2014.09%209.602-9.6%2027.243%2027.243%2014.09-14.092M65.483%2065.393l-14.03-14.03-35.78%2035.783-5.554%205.552%2014.09%2014.09%205.553-5.552%2018.14-18.138%203.55-3.552%2014.03%2014.028%2013.214%2013.216%2014.09-14.093-13.215-13.213%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E') center center no-repeat;
+      background-size: 35px 40px;
+      height: 40px;
+      width: 40px;
+      display: inline-block;
+      overflow: hidden;
+      text-indent: -99999px;
+      color: #fff;
+      vertical-align: middle;
+    }
+    #top h1 {
+      display: inline-block;
+      font-size: 16px;
+      font-weight: normal;
+      margin: 0;
+      vertical-align: middle;
+    }
+    #top h1::before {
+      content: '/ ';
+    }
+    nav ul, #smells {
+      margin: 0;
+      padding: 0;
+    }
+    nav li {
+      list-style: none;
+      padding: 10px 20px;
+      color: #5e637d;
+      position: relative;
+      display: inline-block;
+    }
+    nav li::after {
+      content: '';
+      position: absolute;
+      border-bottom: 8px solid #fff;
+      border-left: 8px solid transparent;
+      border-right: 8px solid transparent;
+      bottom: 0px;
+      left: 50%;
+      margin-left: -8px;
+    }
+    #main-container {
+      background: #fff;
+      padding: 20px;
+      overflow: hidden;
+      position: relative;
+    }
+    .issue-filters {
+      float: right;
+      width: 200px;
+    }
+    .issue-filters label,
+    .issue-filters select {
+      display: block;
+      width: 100%;
+    }
+    .issue-filters label {
+      margin-top: 10px;
+    }
+    #smells {
+      /* max-width: 680px; */
+    }
+    #smells > li {
+      list-style: none;
+      border-bottom: 1px solid #f6f6f5;
+      padding-top: 10px;
+      padding-bottom: 20px;
+    }
+    #smells > li:last-of-type {
+      border-bottom: 0px none;
+      padding-bottom: 0;
+    }
+    #smells > li > h2 {
+      font-weight: bold;
+      margin-top: 0;
+      font-size: inherit;
+    }
+
+    #smells .code {
+      position: relative;
+      /* overflow: hidden; */
+      border-radius: 3px;
+      border: 1px solid #dde8ef;
+      height: 6em;
+      margin: 10px 0;
+    }
+    #smells .code > pre {
+      visibility: hidden;
+    }
+    #smells .code > pre,
+    #smells .code > pre .line-highlight {
+      margin-bottom: 0;
+      margin-top: 0;
+      padding-bottom: 0;
+      padding-top: 0;
+    }
+
+    .found-in {
+      font-size: 12px;
+      line-height: 20px;
+      color: #9999a1;
+      margin-top: 10px;
+      margin-bottom: 15px;
+    }
+    .found-in a {
+      color: #35b0ff;
+    }
+    ::-webkit-details-marker {display: none;}
+    details summary {
+      display: block;
+    }
+    details summary::before {
+      content: "► ";
+
+    }
+    details[open] summary::before {
+      content: "▼ ";
+    }
+
+    #filtered-out-message {
+      display: none;
+      text-align: center;
+      position: absolute;
+      left: 0;
+      width: 720px;
+      text-align: center;
+      top: 50%;
+      margin-top: -1em;
+      line-height: 2em;
+    }
+
+    #no-issues-message {
+      text-align: center;
+    }
+    #no-issues-message::before {
+      content: "🎉";
+      font-size: 3em;
+        display: block;
+    }
+  </style>
+  """
+
+  @table_scripts """
+  <script>
+    // StupidTable.min.js
+    // https://github.com/joequery/Stupid-Table-Plugin
+    (function(c){c.fn.stupidtable=function(a){return this.each(function(){var b=c(this);a=a||{};a=c.extend({},c.fn.stupidtable.default_sort_fns,a);b.data("sortFns",a);b.stupidtable_build();b.on("click.stupidtable","thead th",function(){c(this).stupidsort()});b.find("th[data-sort-onload=yes]").eq(0).stupidsort()})};c.fn.stupidtable.default_settings={should_redraw:function(a){return!0},will_manually_build_table:!1};c.fn.stupidtable.dir={ASC:"asc",DESC:"desc"};c.fn.stupidtable.default_sort_fns={"int":function(a,
+    b){return parseInt(a,10)-parseInt(b,10)},"float":function(a,b){return parseFloat(a)-parseFloat(b)},string:function(a,b){return a.toString().localeCompare(b.toString())},"string-ins":function(a,b){a=a.toString().toLocaleLowerCase();b=b.toString().toLocaleLowerCase();return a.localeCompare(b)}};c.fn.stupidtable_settings=function(a){return this.each(function(){var b=c(this),f=c.extend({},c.fn.stupidtable.default_settings,a);b.stupidtable.settings=f})};c.fn.stupidsort=function(a){var b=c(this),f=b.data("sort")||
+    null;if(null!==f){var d=b.closest("table"),e={$th:b,$table:d,datatype:f};d.stupidtable.settings||(d.stupidtable.settings=c.extend({},c.fn.stupidtable.default_settings));e.compare_fn=d.data("sortFns")[f];e.th_index=h(e);e.sort_dir=k(a,e);b.data("sort-dir",e.sort_dir);d.trigger("beforetablesort",{column:e.th_index,direction:e.sort_dir,$th:b});d.css("display");setTimeout(function(){d.stupidtable.settings.will_manually_build_table||d.stupidtable_build();var a=l(e),a=m(a,e);if(d.stupidtable.settings.should_redraw(e)){d.children("tbody").append(a);
+    var a=e.$table,c=e.$th,f=c.data("sort-dir");a.find("th").data("sort-dir",null).removeClass("sorting-desc sorting-asc");c.data("sort-dir",f).addClass("sorting-"+f);d.trigger("aftertablesort",{column:e.th_index,direction:e.sort_dir,$th:b});d.css("display")}},10);return b}};c.fn.updateSortVal=function(a){var b=c(this);b.is("[data-sort-value]")&&b.attr("data-sort-value",a);b.data("sort-value",a);return b};c.fn.stupidtable_build=function(){return this.each(function(){var a=c(this),b=[];a.children("tbody").children("tr").each(function(a,
+    d){var e={$tr:c(d),columns:[],index:a};c(d).children("td").each(function(a,b){var d=c(b).data("sort-value");"undefined"===typeof d&&(d=c(b).text(),c(b).data("sort-value",d));e.columns.push(d)});b.push(e)});a.data("stupidsort_internaltable",b)})};var l=function(a){var b=a.$table.data("stupidsort_internaltable"),f=a.th_index,d=a.$th.data("sort-multicolumn"),d=d?d.split(","):[],e=c.map(d,function(b,d){var c=a.$table.find("th"),e=parseInt(b,10),f;e||0===e?f=c.eq(e):(f=c.siblings("#"+b),e=c.index(f));
+    return{index:e,$e:f}});b.sort(function(b,c){for(var d=e.slice(0),g=a.compare_fn(b.columns[f],c.columns[f]);0===g&&d.length;){var g=d[0],h=g.$e.data("sort"),g=(0,a.$table.data("sortFns")[h])(b.columns[g.index],c.columns[g.index]);d.shift()}return 0===g?b.index-c.index:g});a.sort_dir!=c.fn.stupidtable.dir.ASC&&b.reverse();return b},m=function(a,b){var f=c.map(a,function(a,c){return[[a.columns[b.th_index],a.$tr,c]]});b.column=f;return c.map(a,function(a){return a.$tr})},k=function(a,b){var f,d=b.$th,
+    e=c.fn.stupidtable.dir;a?f=a:(f=a||d.data("sort-default")||e.ASC,d.data("sort-dir")&&(f=d.data("sort-dir")===e.ASC?e.DESC:e.ASC));return f},h=function(a){var b=0,f=a.$th.index();a.$th.parents("tr").find("th").slice(0,f).each(function(){var a=c(this).attr("colspan")||1;b+=parseInt(a,10)});return b}})(jQuery);
+
+    $(document).ready(function() {
+    $(".stupidTable").each(function(idx, ele) {
+      $(ele).stupidtable();
+    });
+    });
+  </script>
+  """
+
+  @inline_scripts """
+  <script>
+    /**
+    * Report JS
+    */
+
+    (function(){
+      Prism.hooks.add('complete', function(env) {
+        var pre = env.element.parentNode;
+        var lines = pre && pre.dataset.line;
+
+        if (!pre || !lines || !/pre/i.test(pre.nodeName)) {
+          console.log('nope');
+          return;
+        }
+
+        var container = pre.parentElement;
+
+        if (!container || !container.classList.contains('code')) {
+          return;
+        }
+
+        container.style.height = 'auto';
+      });
+    })();
+
+    jQuery(function(){
+      function isVisible(element) {
+        return !!(
+          element.offsetWidth ||
+          element.offsetHeight ||
+          element.getClientRects().length
+        );
+      };
+
+      var pendingElements = [];
+      // Convert node list to arrays
+      pendingElements.push.apply(
+        pendingElements,
+        document.querySelectorAll('#smells .code')
+      );
+
+      var waypoints = [];
+
+      function updateInView() {
+        if (!pendingElements.length) {
+          return;
+        }
+
+        var visibleElements = pendingElements.filter(isVisible);
+        waypoints = visibleElements.map(function(element){
+          var $e = $(element),
+          elementTop = $e.offset().top;
+          return [
+            elementTop,
+            elementTop + $e.outerHeight(),
+            element
+          ];
+        });
+      };
+
+      function inView() {
+        var yTop = window.scrollY,
+        yBottom = window.scrollY + window.innerHeight;
+
+        return waypoints.filter(function(entry){
+          return (entry[0] <= yTop && entry[1] >= yTop) ||
+            (entry[0] > yTop && entry[1] < yBottom) ||
+            (entry[0] <= yBottom && entry[1] >= yBottom);
+        });
+      }
+
+      var inViewHandler = function(){
+        var entries = inView();
+        if (entries.length) {
+          entries.forEach(function(entry){
+            var containerElement = entry[2];
+
+            if (pendingElements.indexOf(containerElement) === -1) {
+              return;
+            }
+
+            element = containerElement.querySelector('pre code');
+
+            element.parentElement.style.visibility = 'visible';
+            Prism.highlightElement(element);
+
+            pendingElements.splice(
+              pendingElements.indexOf(containerElement),
+              1
+            );
+          });
+          updateInView();
+        }
+      };
+
+      function enableInView() {
+        window.addEventListener('scroll', inViewHandler);
+        window.addEventListener('resize', inViewHandler);
+        inViewHandler();
+      }
+
+      updateInView();
+      enableInView();
+
+      $('summary').on('click', function() {
+        setTimeout(function(){
+          updateInView();
+          inViewHandler();
+        },
+        1);
+      });
+    });
+  </script>
+  """
+
+  def print_issues(issues) do
+    issues
+    |> Enum.reduce(Map.new(), &Credo.CLI.Output.Formatter.ReportCard.categorize_module/2)
+    |> write_html()
+  end
+
+  defp write_html(issue_map) do
+    File.mkdir("credo")
+    {:ok, f} = File.open("credo/index.html", [:binary, :write])
+
+    IO.binwrite(f, [
+      "<!doctype html>\n<html>\n<head>\n<title>Credo Report</title>\n",
+      @head_links,
+      @inline_styles,
+      @inline_scripts,
+      @table_scripts,
+      "</head>\n<body>\n",
+      "<div class=\"container\">\n",
+      "<div id=\"main-container\">\n"
+    ])
+
+    IO.binwrite(f, "<h1>Credo Module Scores</h1>")
+
+    IO.binwrite(f, [
+      "<table class=\"stupidTable\">\n",
+      "<thead>\n<tr>\n",
+      "<th data-sort=\"string\" data-sort-default=\"asc\">File</th>\n",
+      "<th data-sort=\"string\" data-sort-default=\"desc\">Grade</th>\n",
+      "<th data-sort=\"int\" data-sort-default=\"desc\">Issues</th>\n",
+      "<th data-sort=\"int\" data-sort-default=\"desc\">Remediation Time</th>",
+      "\n</tr>\n</thead>\n<tbody>\n"
+    ])
+
+    issue_map
+    |> Enum.sort_by(fn {k, _} -> k end)
+    |> Enum.each(fn {k, v} ->
+      module_template(f, k, v)
+    end)
+
+    IO.binwrite(f, [
+      "</tbody>\n</table>\n",
+      "</div>\n</div>\n</body>\n</html>"
+    ])
+
+    File.close(f)
+  end
+
+  defp module_template(io, k, v) do
+    {issue_count, raw_score} = Credo.CLI.Output.Formatter.ReportCard.score_issues(k, v)
+    mod_grade = Credo.CLI.Output.Formatter.ReportCard.grade(raw_score)
+    dir_path = Path.join("credo", Path.dirname(k))
+    file_path = Path.join("credo", k <> ".html")
+    link_path = k <> ".html"
+
+    IO.binwrite(io, [
+      "<tr>\n",
+      "<td><a href=\"",
+      h(link_path),
+      "\">",
+      h(k),
+      "</a>\n</td>\n",
+      "<td>#{mod_grade}</td>",
+      "<td>#{issue_count}</td>",
+      "<td>#{round(raw_score)}</td>",
+      "</tr>\n"
+    ])
+
+    File.mkdir_p(dir_path)
+    {:ok, f} = File.open(file_path, [:binary, :write])
+
+    IO.binwrite(f, [
+      "<!doctype html>\n<html>\n<head>\n<title>",
+      h(k),
+      "</title>\n",
+      @head_links,
+      @inline_styles,
+      @inline_scripts,
+      @table_scripts,
+      "</head>\n<body>\n",
+      "<div class=\"container\">\n",
+      "<div id=\"main-container\">\n",
+      "<h1>",
+      h(k),
+      "</h1>",
+      "<ul id=\"smells\">"
+    ])
+
+    v
+    |> Enum.sort_by(fn i -> i.line_no end)
+    |> Enum.each(fn issue -> format_smell(f, issue) end)
+
+    IO.binwrite(f, [
+      "</ul>",
+      "</div>\n</div>\n</body>\n</html>"
+    ])
+
+    File.close(f)
+  end
+
+  defp format_smell(f, issue) do
+    {target_line, min_line, max_line} = line_indexes(issue)
+    IO.binwrite(f, "<li>\n")
+    IO.binwrite(f, ["<h2>", h(issue.message), "</h2>"])
+
+    IO.binwrite(f, [
+      "<div class=\"code\">\n",
+      "<pre class=\"line-numbers language-elixir\" ",
+      "data-line=\"#{target_line}\" ",
+      "data-start=\"#{min_line}\" ",
+      "data-line-offset=\"#{min_line - 1}\"><code>",
+      line_content(issue, min_line, max_line),
+      "</code>\n</pre>\n</div>\n",
+      "<details>\n<summary>Details</summary>\n"
+    ])
+
+    IO.binwrite(f, format_explanation(issue))
+    IO.binwrite(f, "</details>\n</li>\n")
+  end
+
+  defp format_explanation(issue) do
+    Enum.map(String.split(issue.check.explanation, "\n\n"), fn sv ->
+      case is_source_explanation(sv) do
+        false -> "<p>" <> h(sv) <> "</p>\n\n"
+        _ -> "<pre><code>" <> h(sv) <> "</pre></code>\n\n"
+      end
+    end)
+  end
+
+  defp is_source_explanation(<<"   ", _::binary>>) do
+    true
+  end
+
+  defp is_source_explanation(_) do
+    false
+  end
+
+  defp line_indexes(
+         %Issue{check: Credo.Check.Warning.ExCoverallsUncovered, severity: sev} = issue
+       ) do
+    exact_line = issue.line_no || 1
+    last_line = exact_line + sev - 1
+    first_line = minimum_line(exact_line)
+    {:ok, src_lines} = SourceFileLines.get(issue.filename)
+    keys = :proplists.get_keys(src_lines)
+
+    line_pointer =
+      case sev > 1 do
+        false -> exact_line
+        _ -> "#{exact_line}-#{last_line}"
+      end
+
+    {line_pointer, first_line, max_line(last_line, keys)}
+  end
+
+  defp line_indexes(issue) do
+    exact_line = issue.line_no || 1
+    first_line = minimum_line(exact_line)
+    {:ok, src_lines} = SourceFileLines.get(issue.filename)
+    keys = :proplists.get_keys(src_lines)
+    {exact_line, first_line, max_line(exact_line, keys)}
+  end
+
+  defp line_content(issue, min, max) do
+    {:ok, src_lines} = SourceFileLines.get(issue.filename)
+
+    Enum.join(
+      Enum.map(Range.new(min, max), fn i ->
+        h(:proplists.get_value(i, src_lines))
+      end),
+      "\n"
+    ) <> "\n"
+  end
+
+  defp max_line(target_line, keys) do
+    case Enum.member?(keys, target_line + 2) do
+      false ->
+        case Enum.member?(keys, target_line + 1) do
+          false -> target_line
+          _ -> target_line + 1
+        end
+
+      _ ->
+        target_line + 2
+    end
+  end
+
+  def minimum_line(2), do: 1
+  def minimum_line(1), do: 1
+  def minimum_line(n), do: n - 2
+
+  defp h(binary) do
+    html_escape(binary, <<>>)
+  end
+
+  defp html_escape(<<>>, str) do
+    str
+  end
+
+  defp html_escape(<<"'", rest::binary>>, str) do
+    html_escape(rest, str <> "&#39;")
+  end
+
+  defp html_escape(<<"\"", rest::binary>>, str) do
+    html_escape(rest, str <> "&#34;")
+  end
+
+  defp html_escape(<<"<", rest::binary>>, str) do
+    html_escape(rest, str <> "&#060;")
+  end
+
+  defp html_escape(<<">", rest::binary>>, str) do
+    html_escape(rest, str <> "&#062;")
+  end
+
+  defp html_escape(<<a::size(8), rest::binary>>, str) do
+    html_escape(rest, str <> <<a>>)
+  end
+end

--- a/lib/credo/cli/command/report_card/report_card_command.ex
+++ b/lib/credo/cli/command/report_card/report_card_command.ex
@@ -1,0 +1,47 @@
+defmodule Credo.CLI.Command.ReportCard.ReportCardCommand do
+  @moduledoc false
+
+  @shortdoc "Provide a report card for your modules."
+
+  use Credo.CLI.Command
+
+  alias Credo.CLI.Command.ReportCard.ReportCardOutput
+  alias Credo.CLI.Filter
+  alias Credo.CLI.Task
+  alias Credo.Execution
+
+  @doc false
+  def call(%Execution{help: true} = exec, _opts), do: ReportCardOutput.print_help(exec)
+
+  def call(exec, _opts) do
+    exec
+    |> run_task(Task.LoadAndValidateSourceFiles)
+    |> run_task(Task.PrepareChecksToRun)
+    |> print_before_info()
+    |> run_task(Task.RunChecks)
+    |> run_task(Task.SetRelevantIssues)
+    |> print_results_and_summary()
+  end
+
+  defp print_before_info(exec) do
+    source_files =
+      exec
+      |> Execution.get_source_files()
+      |> Filter.important(exec)
+
+    ReportCardOutput.print_before_info(source_files, exec)
+
+    exec
+  end
+
+  defp print_results_and_summary(exec) do
+    source_files = Execution.get_source_files(exec)
+
+    time_load = Execution.get_assign(exec, "credo.time.source_files")
+    time_run = Execution.get_assign(exec, "credo.time.run_checks")
+
+    ReportCardOutput.print_after_info(source_files, exec, time_load, time_run)
+
+    exec
+  end
+end

--- a/lib/credo/cli/command/report_card/report_card_output.ex
+++ b/lib/credo/cli/command/report_card/report_card_output.ex
@@ -1,0 +1,52 @@
+defmodule Credo.CLI.Command.ReportCard.ReportCardOutput do
+  @moduledoc false
+
+  use Credo.CLI.Output.FormatDelegator,
+    default: Credo.CLI.Command.ReportCard.Output.Console,
+    console: Credo.CLI.Command.ReportCard.Output.Console,
+    html: Credo.CLI.Command.ReportCard.Output.Html
+
+  alias Credo.CLI.Output.UI
+
+  def print_help(exec) do
+    usage = ["Usage: ", :olive, "mix credo report_card [paths] [options]"]
+
+    description = """
+
+    Shows a report card for your modules based on Credo checks.
+    """
+
+    example = [
+      "Example: ",
+      :olive,
+      :faint,
+      "$ mix credo report_card lib/**/*.ex --format=html"
+    ]
+
+    options = """
+
+    Report Card options:
+      -a, --all               Show all issues
+      -A, --all-priorities    Show all issues including low priority ones
+          --min-priority      Minimum priority to show issues (high,medium,normal,low,lower or number)
+      -c, --checks            Only include checks that match the given strings
+          --config-file       Use the given config file
+      -C, --config-name       Use the given config instead of "default"
+      -i, --ignore-checks     Ignore checks that match the given strings
+          --format            Display the list in a specific format (console,html)
+          --mute-exit-status  Exit with status zero even if there are issues
+
+    General options:
+          --[no-]color        Toggle colored output
+      -v, --version           Show version
+      -h, --help              Show this help
+    """
+
+    UI.puts(usage)
+    UI.puts(description)
+    UI.puts(example)
+    UI.puts(options)
+
+    exec
+  end
+end

--- a/lib/credo/cli/output/formatter/report_card.ex
+++ b/lib/credo/cli/output/formatter/report_card.ex
@@ -1,0 +1,100 @@
+defmodule Credo.CLI.Output.Formatter.ReportCard do
+  @moduledoc false
+
+  def categorize_module(issue, module_map) do
+    Map.update(
+      module_map,
+      issue.filename,
+      [issue],
+      fn v ->
+        [issue | v]
+      end
+    )
+  end
+
+  def grade(adjusted_score) do
+    case adjusted_score do
+      adjusted_score when adjusted_score < 16 -> "A"
+      adjusted_score when adjusted_score < 61 -> "B"
+      adjusted_score when adjusted_score < 121 -> "C"
+      adjusted_score when adjusted_score < 241 -> "D"
+      adjusted_score when adjusted_score < 481 -> "E"
+      _ -> "F"
+    end
+  end
+
+  def score_issues(_, issues) do
+    issue_count = Enum.count(issues)
+
+    total =
+      Enum.reduce(issues, 0.0, fn issue, acc ->
+        acc + issue_score(issue)
+      end)
+
+    {issue_count, Float.ceil(total, 2)}
+  end
+
+  def format_remediation_time(val) do
+    case val do
+      val when val < 2 -> "1 minute"
+      val when val < 46 -> Integer.to_string(round(val)) <> " minutes"
+      val when val < 70 and val > 45 -> "1 hour"
+      _ -> format_remediation_greater_than_one_hour(val)
+    end
+  end
+
+  defp format_remediation_greater_than_one_hour(val) do
+    case val do
+      val when val < 504 and val > 419 -> "1 day"
+      val when val > 503 -> single_decimal_string_from(val / 60.0 / 8.0) <> " days"
+      val when val < 130 and val > 69 -> "2 hours"
+      _ -> single_decimal_string_from(val / 60.0) <> " hours"
+    end
+  end
+
+  @issue_remediation %{
+    Credo.Check.Consistency.SpaceInParentheses => 1,
+    Credo.Check.Consistency.TabsOrSpaces => 2,
+    Credo.Check.Design.AliasUsage => 3,
+    Credo.Check.Design.DuplicatedCode => 15,
+    Credo.Check.Readability.AliasOrder => 1,
+    Credo.Check.Readability.MaxLineLength => 1,
+    Credo.Check.Readability.ModuleDoc => 10,
+    Credo.Check.Readability.ModuleNames => 10,
+    Credo.Check.Readability.RedundantBlankLines => 1,
+    Credo.Check.Readability.SpaceAfterCommas => 1,
+    Credo.Check.Readability.TrailingBlankLine => 1,
+    Credo.Check.Readability.TrailingWhiteSpace => 1,
+    Credo.Check.Refactor.ABCSize => 15,
+    Credo.Check.Refactor.CyclomaticComplexity => 15,
+    Credo.Check.Refactor.Nesting => 15,
+    Credo.Check.Warning.NameRedeclarationByFn => 10,
+    Credo.Check.Warning.OperationOnSameValues => 10,
+    Credo.Check.Warning.BoolOperationOnSameValues => 10,
+    Credo.Check.Warning.UnusedEnumOperation => 5,
+    Credo.Check.Warning.UnusedKeywordOperation => 5,
+    Credo.Check.Warning.UnusedListOperation => 5,
+    Credo.Check.Warning.UnusedStringOperation => 5,
+    Credo.Check.Warning.UnusedTupleOperation => 5,
+    Credo.Check.Warning.OperationWithConstantResult => 5,
+    Credo.Check.Readability.Specs => 5
+  }
+
+  alias Credo.Issue
+
+  defp issue_score(%Issue{check: Credo.Check.Refactor.CyclomaticComplexity, severity: sev}) do
+    15 * sev
+  end
+
+  defp issue_score(%Issue{check: Credo.Check.Warning.ExCoverallsUncovered, severity: sev}) do
+    10 * sev
+  end
+
+  defp issue_score(issue) do
+    @issue_remediation[issue.check] || 5
+  end
+
+  defp single_decimal_string_from(val) do
+    :erlang.float_to_binary(val, decimals: 1)
+  end
+end

--- a/lib/credo/service/commands.ex
+++ b/lib/credo/service/commands.ex
@@ -14,6 +14,7 @@ defmodule Credo.Service.Commands do
     "info" => Credo.CLI.Command.Info.InfoCommand,
     "list" => Credo.CLI.Command.List.ListCommand,
     "suggest" => Credo.CLI.Command.Suggest.SuggestCommand,
+    "report_card" => Credo.CLI.Command.ReportCard.ReportCardCommand,
     "version" => Credo.CLI.Command.Version
   }
 

--- a/lib/credo/service/excoveralls_missing_coverage.ex
+++ b/lib/credo/service/excoveralls_missing_coverage.ex
@@ -1,0 +1,100 @@
+defmodule Credo.Service.ExcoverallsMissingCoverage do
+  @moduledoc """
+  Supports lookup of missing lines of test coverage from the
+  ExCoveralls JSON file, if it is present.
+
+  Note that the map is sparse, meaning it only contains source
+  lines which SHOULD have coverage, but DON'T.
+  """
+
+  use GenServer
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    new_state =
+      case slurp_coveralls_json() do
+        {:ok, data} -> parse_coveralls_json(data)
+        _ -> :no_data
+      end
+
+    {:ok, new_state}
+  end
+
+  def data_available?() do
+    GenServer.call(__MODULE__, :has_data)
+  end
+
+  def coverage_map() do
+    GenServer.call(__MODULE__, :coverage_map)
+  end
+
+  def handle_call(:has_data, _from, :no_data) do
+    {:reply, false, :no_data}
+  end
+
+  def handle_call(:has_data, _from, state) do
+    {:reply, true, state}
+  end
+
+  def handle_call(:coverage_map, _from, state) do
+    {:reply, state, state}
+  end
+
+  defp slurp_coveralls_json() do
+    case File.exists?("cover/excoveralls.json") do
+      false -> :no_file
+      _ -> read_coveralls_json()
+    end
+  end
+
+  defp read_coveralls_json() do
+    case File.read("cover/excoveralls.json") do
+      {:ok, bin} -> Jason.decode(bin)
+      e -> e
+    end
+  end
+
+  defp parse_coveralls_json(structure) do
+    case Map.fetch(structure, "source_files") do
+      :error -> %{}
+      {:ok, c_items} -> items_into_map(c_items)
+    end
+  end
+
+  defp items_into_map(c_items) do
+    Enum.reduce(c_items, %{}, fn c_item, acc ->
+      case Map.fetch(c_item, "name") do
+        :error ->
+          acc
+
+        {:ok, name} ->
+          Map.put(
+            acc,
+            name,
+            map_code_lines(c_item)
+          )
+      end
+    end)
+  end
+
+  defp map_code_lines(c_item) do
+    case Map.fetch(c_item, "coverage") do
+      :error -> %{}
+      {:ok, l} -> index_and_map_code_lines(l)
+    end
+  end
+
+  defp index_and_map_code_lines(lines) do
+    lines
+    |> Enum.with_index(lines)
+    |> Enum.reduce(%{}, fn {e, idx}, acc ->
+      case e do
+        0 -> Map.put(acc, idx + 1, e)
+        _ -> acc
+      end
+    end)
+  end
+end


### PR DESCRIPTION
This adds a new optional check:
Credo.Check.Warning.ExCoverallsUncovered.

If this check is configured to run, and you have also generated a
previous "cover/excoveralls.json" file, it will search for files missing
test coverage.

It also adds a new command:
report_card - generates a report card grading your modules.
It supports both console and HTML output formats.
The HTML output will add a file in credo/index.html.