### PR TITLE
Bang sigil option

### DIFF
--- a/lib/credo/check/refactor/variable_rebinding.ex
+++ b/lib/credo/check/refactor/variable_rebinding.ex
@@ -154,9 +154,9 @@ defmodule Credo.Check.Refactor.VariableRebinding do
   end
 
   defp bang_sigil({name, _}, allowed) do
-    allowed && (name
+    allowed &&
+      name
       |> Atom.to_string()
       |> String.ends_with?("!")
-    )
   end
 end

--- a/lib/credo/check/refactor/variable_rebinding.ex
+++ b/lib/credo/check/refactor/variable_rebinding.ex
@@ -28,6 +28,15 @@ defmodule Credo.Check.Refactor.VariableRebinding do
         verified_time
       end
 
+  In some rare cases you might really want to rebind a variable.  This can be
+  enabled "opt-in" on a per-variable basis by setting the :allow_bang option
+  to true and adding a bang suffix sigil to your variable.
+
+      def uses_mutating_parameters(params!) do
+        params! = do_a_thing(params!)
+        params! = do_another_thing(params!)
+        params! = do_yet_another_thing(params!)
+      end
   """
   @explanation [check: @checkdoc]
 

--- a/lib/credo/check/refactor/variable_rebinding.ex
+++ b/lib/credo/check/refactor/variable_rebinding.ex
@@ -49,7 +49,7 @@ defmodule Credo.Check.Refactor.VariableRebinding do
     Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
   end
 
-  def traverse([do: {:__block__, _, ast}], issues, issue_meta = {_, _, opt}) do
+  def traverse([do: {:__block__, _, ast}], issues, {_, _, opt} = issue_meta) do
     variables =
       ast
       |> Enum.map(&find_assignments/1)

--- a/test/credo/check/refactor/variable_rebinding_test.exs
+++ b/test/credo/check/refactor/variable_rebinding_test.exs
@@ -36,6 +36,19 @@ defmodule Credo.Check.Refactor.VariableRebindingTest do
     |> refute_issues(@described_check)
   end
 
+  test "rebinding opt-in bang sigils is allowed" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        a! = 1
+        a! = 2
+      end
+    end
+    """
+    |> to_source_file
+    |> refute_issues(@described_check, allow_bang: true)
+  end
+
   #
   # cases raising issues
   #
@@ -115,6 +128,19 @@ defmodule Credo.Check.Refactor.VariableRebindingTest do
       def some_function(opts) do
         %{a: foo, b: bar} = opts
         bar = 3
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "rebinding bang sigils is forbidden without the :allow_bang option" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        a! = 1
+        a! = 2
       end
     end
     """


### PR DESCRIPTION
modifies the 'no variable rebinding' to allow for a bang sigil, if the ":allow_bang" option is set.