### PR TITLE
Fix StringSigils to not crash with strings containing non-UTF8 characters

### DIFF
--- a/lib/credo/check/readability/string_sigils.ex
+++ b/lib/credo/check/readability/string_sigils.ex
@@ -128,6 +128,10 @@ defmodule Credo.Check.Readability.StringSigils do
     too_many_quotes?(rest, count, limit)
   end
 
+  defp too_many_quotes?(<<_::binary>>, _count, _limit) do
+    false
+  end
+
   defp issue_for(issue_meta, line_no, trigger, maximum_allowed_quotes) do
     format_issue(
       issue_meta,

--- a/test/credo/check/readability/string_sigils_test.exs
+++ b/test/credo/check/readability/string_sigils_test.exs
@@ -98,6 +98,16 @@ defmodule Credo.Check.Readability.StringSigilsTest do
     |> refute_issues(@described_check)
   end
 
+  test "does NOT crash if string contains non utf8 characters" do
+    snippet = ~S(defmodule CredoTest do
+      @module_var "\xFF"
+    end)
+
+    snippet
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
   #
   # cases raising issues
   #


### PR DESCRIPTION
Currently credo is crashing for the following code:

```elixir
@bad_data %{
  "key" => "\xFF"
}
```
```
** (EXIT from #PID<0.91.0>) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Credo.Check.Readability.StringSigils.too_many_quotes?/3
        lib/credo/check/readability/string_sigils.ex:114: Credo.Check.Readability.StringSigils.too_many_quotes?(<<255>>, 0, 3)
        lib/credo/check/readability/string_sigils.ex:96: Credo.Check.Readability.StringSigils.issues_for_string_literal/5
        lib/credo/check/readability/string_sigils.ex:63: Credo.Check.Readability.StringSigils.traverse/4
        (elixir) lib/macro.ex:282: anonymous fn/4 in Macro.do_traverse_args/4
        (elixir) lib/enum.ex:1418: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        (elixir) lib/macro.ex:248: Macro.do_traverse/4
        (elixir) lib/enum.ex:1418: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        (elixir) lib/enum.ex:1418: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
```