### PR TITLE
Fix Elixir warning about Enum.into being ambiguous in ABC Size.

### DIFF
--- a/lib/credo/check/refactor/abc_size.ex
+++ b/lib/credo/check/refactor/abc_size.ex
@@ -150,7 +150,7 @@ defmodule Credo.Check.Refactor.ABCSize do
           var_names
 
         name ->
-          Enum.into(var_names, [name])
+          var_names ++ [name]
       end
 
     {rhs, [a: a + 1, b: b, c: c, var_names: var_names]}
@@ -162,7 +162,7 @@ defmodule Credo.Check.Refactor.ABCSize do
          [a: a, b: b, c: c, var_names: var_names],
          _excluded_functions
        ) do
-    var_names = Enum.into(var_names, fn_parameters(arguments))
+    var_names = var_names ++ fn_parameters(arguments)
     {ast, [a: a, b: b + 1, c: c, var_names: var_names]}
   end
 


### PR DESCRIPTION
```
warning: the Collectable protocol is deprecated for non-empty lists. The behaviour of things like Enum.into/2 or "for" comprehensions with an :into option is incorrect when collecting into non-empty lists. If you're collecting into a non-empty keyword list, consider using Keyword.merge/2 instead. If you're collecting into a non-empty list, consider concatenating the two lists with the ++ operator.
  (elixir) lib/collectable.ex:83: Collectable.List.into/1
  (elixir) lib/enum.ex:1227: Enum.into_protocol/2
  lib/credo/check/refactor/abc_size.ex:164: Credo.Check.Refactor.ABCSize.traverse_abc/3
  (elixir) lib/macro.ex:286: anonymous fn/4 in Macro.do_traverse_args/4
  (elixir) lib/enum.ex:1431: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
```