### PR TITLE
Introduce max module dependency check

### DIFF
--- a/lib/credo/check/refactor/module_dependencies.ex
+++ b/lib/credo/check/refactor/module_dependencies.ex
@@ -1,0 +1,143 @@
+defmodule Credo.Check.Refactor.ModuleDependencies do
+  @moduledoc false
+
+  @checkdoc """
+  Module is most probably doing too much. Consider limiting the number of
+  module dependencies.
+
+  As always: This is just a suggestion. Check the configuration options for
+  tweaking or disabling this check.
+  """
+  @explanation [
+    check: @checkdoc,
+    params: [
+      max_deps: "Maximum number of module dependencies.",
+      dependency_namespaces: "List of dependency namespaces to include in this check",
+      excluded_namespaces: "List of namespaces to exclude from this check",
+      excluded_paths: "List of paths to exclude from this check"
+    ]
+  ]
+
+  @default_params [
+    max_deps: 10,
+    dependency_namespaces: [],
+    excluded_namespaces: [],
+    excluded_paths: ["test"]
+  ]
+
+  use Credo.Check, base_priority: :normal
+
+  alias Credo.Code.Name
+  alias Credo.Code.Module
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    max_deps = Params.get(params, :max_deps, @default_params)
+    dependency_namespaces = Params.get(params, :dependency_namespaces, @default_params)
+    excluded_namespaces = Params.get(params, :excluded_namespaces, @default_params)
+    excluded_paths = Params.get(params, :excluded_paths, @default_params)
+
+    case ignore_path?(source_file.filename, excluded_paths) do
+      true ->
+        []
+
+      false ->
+        source_file
+        |> Credo.Code.prewalk(
+          &traverse(
+            &1,
+            &2,
+            issue_meta,
+            dependency_namespaces,
+            excluded_namespaces,
+            max_deps
+          )
+        )
+    end
+  end
+
+  defp ignore_path?(filename, excluded_paths) do
+    directory = Path.dirname(filename)
+    Enum.any?(excluded_paths, &String.starts_with?(directory, &1))
+  end
+
+  defp traverse(
+         {:defmodule, meta, [mod | _]} = ast,
+         issues,
+         issue_meta,
+         dependency_namespaces,
+         excluded_namespaces,
+         max
+       ) do
+    module_name = Name.full(mod)
+
+    new_issues =
+      if has_namespace?(module_name, excluded_namespaces) do
+        []
+      else
+        module_dependencies = get_dependencies(ast, dependency_namespaces)
+        issues_for_module(module_name, module_dependencies, max, issue_meta, meta)
+      end
+
+    {ast, issues ++ new_issues}
+  end
+
+  defp traverse(ast, issues, _issues_meta, _dependency_namespaces, _excluded_namespaces, _max) do
+    {ast, issues}
+  end
+
+  defp get_dependencies(ast, dependency_namespaces) do
+    aliases = Module.aliases(ast)
+
+    ast
+    |> Module.modules()
+    |> with_fullnames(aliases)
+    |> filter_namespaces(dependency_namespaces)
+  end
+
+  defp issues_for_module(mod, deps, max_deps, issue_meta, meta) when length(deps) > max_deps do
+    [
+      format_issue(
+        issue_meta,
+        message: "Module #{Name.last(mod)} has too many dependencies: #{length(deps)}",
+        trigger: deps,
+        line_no: meta[:line],
+        column_no: meta[:column]
+      )
+    ]
+  end
+
+  defp issues_for_module(_, _, _, _, _), do: []
+
+  defp with_fullnames(dependencies, aliases) do
+    dependencies
+    |> Enum.map(&full_name(&1, aliases))
+    |> Enum.uniq()
+  end
+
+  defp filter_namespaces(dependencies, namespaces) do
+    dependencies
+    |> Enum.filter(&keep?(&1, namespaces))
+  end
+
+  defp keep?(_module_name, []), do: true
+
+  defp keep?(module_name, namespaces), do: has_namespace?(module_name, namespaces)
+
+  defp has_namespace?(module_name, namespaces) do
+    namespaces
+    |> Enum.any?(&String.starts_with?(module_name, &1))
+  end
+
+  # Get full module name from list of aliases (if present)
+  defp full_name(dep, aliases) do
+    aliases
+    |> Enum.find(&String.ends_with?(&1, dep))
+    |> case do
+      nil -> dep
+      full_name -> full_name
+    end
+  end
+end

--- a/test/credo/check/refactor/module_dependencies_test.exs
+++ b/test/credo/check/refactor/module_dependencies_test.exs
@@ -1,0 +1,60 @@
+defmodule Credo.Check.Refactor.ModuleDependenciesTest do
+  use Credo.TestHelper
+
+  @described_check Credo.Check.Refactor.ModuleDependencies
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report expected code" do
+    """
+    defmodule CredoSampleModule do
+      def some_function() do
+        [
+          DateTime,
+          Kernel,
+          GenServer,
+          GenEvent,
+          File,
+          Time,
+          IO,
+          Logger,
+          URI,
+          Path
+        ]
+      end
+    end
+    """
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report a violation" do
+    """
+    defmodule CredoSampleModule do
+      def some_function() do
+        [
+          DateTime,
+          Kernel,
+          GenServer,
+          GenEvent,
+          File,
+          Time,
+          IO,
+          Logger,
+          URI,
+          Path,
+          String
+        ]
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+end


### PR DESCRIPTION
This introduces a feature described in https://github.com/rrrene/credo/issues/621.
It is a check to warn whenever modules have more dependencies than configured (defaults to `10`).

Configuration options:

* `max_deps` - Maximum number of module dependencies

* `dependency_namespaces` - Specify which namespaces should be included while counting module dependencies - by default it will count all dependencies (project modules, built-in modules, external dependencies). If you only care about project modules, specify `[MyAppNamespace]`

* `excluded_namespaces` - Specify which namespaces within a project to exclude from this check

* `excluded_paths` - Specify paths within a project to exclude from this check - defaults to `["test"]`