### PR TITLE
Disable logger check on elixir >= 1.7

### DIFF
--- a/lib/credo/check/warning/lazy_logging.ex
+++ b/lib/credo/check/warning/lazy_logging.ex
@@ -31,7 +31,7 @@ defmodule Credo.Check.Warning.LazyLogging do
     ignore: [:error, :warn, :info]
   ]
 
-  use Credo.Check, base_priority: :high
+  use Credo.Check, base_priority: :high, elixir_version: "< 1.7.0"
 
   @doc false
   def run(source_file, params \\ []) do


### PR DESCRIPTION
As logger is lazy per default on 1.7+ this check is not needed any longer.