### PR TITLE
add :allow_bang :params to @ explanation of VariableRebinding check

### DIFF
--- a/lib/credo/check/refactor/variable_rebinding.ex
+++ b/lib/credo/check/refactor/variable_rebinding.ex
@@ -38,7 +38,12 @@ defmodule Credo.Check.Refactor.VariableRebinding do
         params! = do_yet_another_thing(params!)
       end
   """
-  @explanation [check: @checkdoc]
+  @explanation [
+    check: @checkdoc,
+    params: [
+      allow_bang: "Variables with a bang suffix will be ignored."
+    ]
+  ]
 
   use Credo.Check
 


### PR DESCRIPTION
The `:allow_bang` option wasn't added to `:params` of the `@explanation` attribute of `Credo.Check.Refactor.VariableRebinding` resulting in the option/parameter not being included in the configuration options:
```
┃    __ CONFIGURATION OPTIONS
┃
┃       You can disable this check by using this tuple
┃
┃         {Credo.Check.Refactor.VariableRebinding, false}
┃
┃       There are no other configuration options.
```

After adding the option the output is as expected:
```
┃    __ CONFIGURATION OPTIONS
┃
┃       To configure this check, use this tuple
┃
┃         {Credo.Check.Refactor.VariableRebinding, <params>}
┃
┃       with <params> being false or any combination of these keywords:
┃
┃         allow_bang:            Variables with a bang suffix will be ignored.
```