### PR TITLE
Exclude config option for IO.inspect check.

### DIFF
--- a/lib/credo/check/warning/io_inspect.ex
+++ b/lib/credo/check/warning/io_inspect.ex
@@ -7,6 +7,14 @@ defmodule Credo.Check.Warning.IoInspect do
 
   This check warns about those calls, because they might have been committed
   in error.
+
+  Pass [excluded: [r/regex_pattern/]] as params in your configuration to exclude
+  files, like setup scripts, where you expect IO.inspect to be present.
+
+  Example:
+  To exclude all `.exs` files you will add this to your `.credo.exs` file:
+
+  `{Credo.Check.Warning.IoInspect, [excluded: [~r/.exs$/]]}`
   """
   @explanation [check: @checkdoc]
   @call_string "IO.inspect"
@@ -15,9 +23,20 @@ defmodule Credo.Check.Warning.IoInspect do
 
   @doc false
   def run(source_file, params \\ []) do
-    issue_meta = IssueMeta.for(source_file, params)
+    params
+    |> Keyword.get(:excluded, [])
+    |> match_filename?(source_file.filename)
+    |> case do
+      true -> []
+      _ ->
+        issue_meta = IssueMeta.for(source_file, params)
+        Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+    end
+  end
 
-    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  defp match_filename?([], _filename), do: false
+  defp match_filename?([h|t] = excluded_patterns, filename) when is_list(excluded_patterns) do
+    String.match?(filename, h) || match_filename?(t, filename)
   end
 
   defp traverse(

--- a/test/credo/check/warning/io_inspect_test.exs
+++ b/test/credo/check/warning/io_inspect_test.exs
@@ -59,4 +59,28 @@ defmodule Credo.Check.Warning.IoInspectTest do
     |> to_source_file
     |> assert_issue(@described_check)
   end
+
+  test "should not report if filename excluded" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(a, b, c) do
+        map([a,b,c], &IO.inspect(&1))
+      end
+    end
+    """
+    |> to_source_file("its_a_match.exs")
+    |> refute_issues(@described_check, excluded: [~r/its_a_match\.exs$/])
+  end
+
+  test "should report if filename is not excluded" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(a, b, c) do
+        map([a,b,c], &IO.inspect(&1))
+      end
+    end
+    """
+    |> to_source_file("its_a_not_a_match.exs")
+    |> assert_issue(@described_check, excluded: [~r/its_a_match\.exs$/])
+  end
 end


### PR DESCRIPTION
Add configuration option to exclude filenames matching the`:excluded` patterns for io_inspect check.

For example, to skip the check for `.exs` files: 

  `{Credo.Check.Warning.IoInspect, [excluded: [~r/.exs$/]]},`

