### PR TITLE
add `nil_else` check for else blocks containing only `nil`

### DIFF
--- a/lib/credo/check/readability/nil_else.ex
+++ b/lib/credo/check/readability/nil_else.ex
@@ -1,0 +1,52 @@
+defmodule Credo.Check.Readability.NilElse do
+  @moduledoc false
+
+  @checkdoc """
+  Do not use `nil` as a return value of `else` in `if` or `unless`.
+  The function returns `nil` by default, so adding an else block
+  just adds unnecessary code.
+
+  The code in this example ...
+      if x > 5 do
+        x * 2
+      else
+        nil
+      end
+  ... should be refactored to look like this:
+      if x > 5 do
+        x * 2
+      end
+  """
+  @explanation [check: @checkdoc]
+
+  use Credo.Check, base_priority: :high
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse(
+         {conditional, meta, [_, [{:do, _} | [{:else, nil} | _]]]} = ast,
+         issues,
+         issue_meta
+       )
+       when conditional in [:if, :unless] do
+    {ast, [issue_for(issue_meta, meta[:line]) | issues]}
+  end
+
+  defp traverse(ast, issues, _) do
+    {ast, issues}
+  end
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue(
+      issue_meta,
+      message: "Do not use `nil` as the result of `else` in `if` or `unless`",
+      trigger: "no_nil_else",
+      line_no: line_no
+    )
+  end
+end

--- a/test/credo/check/readability/nil_else_test.exs
+++ b/test/credo/check/readability/nil_else_test.exs
@@ -1,0 +1,74 @@
+defmodule Credo.Check.Readability.NilElseTest do
+  use Credo.TestHelper
+
+  @described_check Credo.Check.Readability.NilElse
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report expected code" do
+    """
+    defmodule CredoSampleModule do
+      use ExUnit.Case
+
+      def some_fun(x) do
+        if x > 10 do
+          x
+        else
+          :foo
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  # #
+  # # cases raising issues
+  # #
+
+  test "it should report a violation" do
+    """
+    defmodule CredoSampleModule do
+      use ExUnit.Case
+
+      def some_fun(x) do
+        if x > 10 do
+          x
+        else
+          nil
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report a violation for multiple violations" do
+    """
+    defmodule CredoSampleModule do
+      use ExUnit.Case
+
+      def some_fun(x) do
+        y =
+          if x > 10 do
+            x
+          else
+            nil
+          end
+
+        if y do
+          y * 2
+        else
+          nil
+        end
+     end
+    end
+    """
+    |> to_source_file
+    |> assert_issues(@described_check)
+  end
+end


### PR DESCRIPTION
Adds a check that will fail on an `else` block containing only `nil`.