### PR TITLE
add check to use `true` for always matching cond clause

### DIFF
--- a/lib/credo/check/readability/always_matching_cond_clause.ex
+++ b/lib/credo/check/readability/always_matching_cond_clause.ex
@@ -1,0 +1,77 @@
+defmodule Credo.Check.Readability.AlwaysMatchingCondClause do
+  @moduledoc false
+
+  @checkdoc """
+  If you provide an "always true" clause in `cond`, it should be the literal value `true`.
+
+  Correct:
+      cond do
+        x > 5 -> 10
+        x < 5 -> 0
+        true -> 5
+      end
+  Incorrect
+      cond do
+        x > 5 -> 10
+        x < 5 -> 0
+        :other -> 5
+      end
+  Consistency in this regard helps developers quickly identify fall through cases and not
+  mistake the "always true" clause for relevant code.
+  """
+  @explanation [check: @checkdoc]
+
+  alias Credo.Code.Block
+
+  use Credo.Check, base_priority: :high
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+    allowed_values = params[:allowed_values] || [true, :else]
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta, allowed_values))
+  end
+
+  defp traverse({:cond, meta, arguments} = ast, issues, issue_meta, allowed_values) do
+    last_clause =
+      arguments
+      |> Block.do_block_for!()
+      |> List.wrap()
+      |> List.last()
+
+    case last_clause do
+      {:->, _, [[value] | _]} when is_tuple(value) ->
+        {ast, issues}
+
+      {:->, _, [[value] | _]} ->
+        if value in allowed_values do
+          {ast, issues}
+        else
+          {ast, [issue_for(issue_meta, meta[:line], allowed_values) | issues]}
+        end
+
+      _ ->
+        {ast, [issue_for(issue_meta, meta[:line], allowed_values) | issues]}
+    end
+  end
+
+  defp traverse(ast, issues, _, _) do
+    {ast, issues}
+  end
+
+  defp issue_for(issue_meta, line_no, values) do
+    values_string =
+      case values do
+        [value] -> "`#{inspect(value)}`"
+        values -> "one of `#{inspect(values)}`"
+      end
+
+    format_issue(
+      issue_meta,
+      message: "If you provide an 'always true' clause to `cond`, it should be #{values_string}.",
+      trigger: "always_matching_cond_clause_true",
+      line_no: line_no
+    )
+  end
+end

--- a/test/credo/check/readability/always_matching_cond_clause_test.exs
+++ b/test/credo/check/readability/always_matching_cond_clause_test.exs
@@ -1,0 +1,115 @@
+defmodule Credo.Check.Readability.AlwaysMatchingCondClauseTest do
+  use Credo.TestHelper
+
+  @described_check Credo.Check.Readability.AlwaysMatchingCondClause
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report expected code" do
+    """
+    defmodule CredoSampleModule do
+      use ExUnit.Case
+
+      def some_fun(x) do
+        cond do
+          x > 5 -> "yay"
+          x < 5 -> "nay"
+          true -> "meh"
+        end
+
+        cond do
+          x > 5 -> "yay"
+          x < 5 -> "nay"
+          :else -> "meh"
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
+  test "it should NOT report a violation when additional values are configured" do
+    """
+    defmodule CredoSampleModule do
+      use ExUnit.Case
+
+      def some_fun(x) do
+        cond do
+          x > 5 -> "yay"
+          x < 5 -> "nay"
+          :foo -> "meh"
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> refute_issues(@described_check, allowed_values: [:foo])
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report a violation" do
+    """
+    defmodule CredoSampleModule do
+      use ExUnit.Case
+
+      def some_fun(x) do
+        cond do
+          x > 5 -> "yay"
+          x < 5 -> "nay"
+          :foo -> "meh"
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report a violation if the default allowed values are overridden" do
+    """
+    defmodule CredoSampleModule do
+      use ExUnit.Case
+
+      def some_fun(x) do
+        cond do
+          x > 5 -> "yay"
+          x < 5 -> "nay"
+          :else -> "meh"
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check, allowed_values: [:foo])
+  end
+
+  test "it should report a violation for multiple violations" do
+    """
+    defmodule CredoSampleModule do
+      use ExUnit.Case
+
+      def some_fun do
+        cond do
+          x > 5 -> "yay"
+          x < 5 -> "nay"
+          :foo -> "meh"
+        end
+
+        cond do
+          x > 5 -> "yay"
+          x < 5 -> "nay"
+          :other -> "meh"
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issues(@described_check)
+  end
+end


### PR DESCRIPTION
There would technically be a false positive case for this, which is if the always matching cond was a tuple, like `{true, true}` but I don't see why anyone would do that 🤣 