### PR TITLE
Fix outdented heredoc warnings

### DIFF
--- a/lib/credo/check/readability/space_after_commas.ex
+++ b/lib/credo/check/readability/space_after_commas.ex
@@ -46,7 +46,7 @@ defmodule Credo.Check.Readability.SpaceAfterCommas do
     source_file
     |> Sigils.replace_with_spaces(" ", " ", source_file.filename)
     |> Strings.replace_with_spaces(" ", " ", source_file.filename)
-    |> Heredocs.replace_with_spaces(" ", " ", source_file.filename)
+    |> Heredocs.replace_with_spaces(" ", " ", "", source_file.filename)
     |> Charlists.replace_with_spaces(" ", " ", source_file.filename)
     |> String.replace(~r/(\A|[^\?])#.+/, "\\1")
     |> Credo.Code.to_lines()

--- a/lib/credo/code/heredocs.ex
+++ b/lib/credo/code/heredocs.ex
@@ -253,6 +253,6 @@ defmodule Credo.Code.Heredocs do
       |> :binary.part(byte_index, length_after_byte_index)
       |> String.replace(~r/\n(.{#{no_of_chars_to_replace}})/, pad_string)
 
-    String.slice(acc, 0, byte_index) <> new_acc
+    :binary.part(acc, 0, byte_index) <> new_acc
   end
 end

--- a/lib/credo/code/heredocs.ex
+++ b/lib/credo/code/heredocs.ex
@@ -250,7 +250,7 @@ defmodule Credo.Code.Heredocs do
 
     new_acc =
       acc
-      |> String.slice(byte_index, length_after_byte_index)
+      |> :binary.part(byte_index, length_after_byte_index)
       |> String.replace(~r/\n(.{#{no_of_chars_to_replace}})/, pad_string)
 
     String.slice(acc, 0, byte_index) <> new_acc

--- a/test/credo/code/heredocs_test.exs
+++ b/test/credo/code/heredocs_test.exs
@@ -553,16 +553,16 @@ defmodule Credo.Code.HeredocsTest do
       end
 
       @doc """
-    ..........................
-    .."""
+      ........................
+      """
       @spec preload_all(t()) :: t()
       def preload_all(issue) do
         Repo.preload(issue, [:author, :assignee, :tags, :bug_creator])
       end
 
       @doc ~S"""
-    .............
-    .."""
+      ...........
+      """
       @spec build_query(Ecto.Query.t(), Map.t()) :: Ecto.Query.t()
       def build_query(base \\ __MODULE__, params) do
         params
@@ -604,8 +604,8 @@ defmodule Credo.Code.HeredocsTest do
       defp query_by(query, _, _), do: query
 
       @doc """
-    ...........
-    .."""
+      .........
+      """
       def changeset(issue, attrs \\ %{}) do
         permitted_attrs = ~w(
           code


### PR DESCRIPTION
`mix credo test.ex` produces outdented heredoc warnings.

test.ex:

```
defmodule Test do
  # ああああ

  @doc """
  a

  b
  """
end
```

result:

```
warning: outdented heredoc line. The contents inside the heredoc should be indented at the same level as the closing """. The following is forbidden:

    def text do
      """
    contents
      """
    end

Instead make sure the contents are indented as much as the heredoc closing:

    def text do
      """
      contents
      """
    end

The current heredoc line is indented too little
  test.ex:6
```

This PR will fix above problem. Other problems may also be fixed.