### PR TITLE
[WIP] Enforce consistent module attribute ordering

### DIFF
--- a/lib/credo/check/consistency/collector.ex
+++ b/lib/credo/check/consistency/collector.ex
@@ -134,9 +134,9 @@ defmodule Credo.Check.Consistency.Collector do
         :ok
       end
 
-      def transform_fequencies(frequencies), do: frequencies
+      def transform_frequencies(frequencies), do: frequencies
 
-      defoverridable transform_fequencies: 1
+      defoverridable transform_frequencies: 1
     end
   end
 

--- a/lib/credo/check/consistency/module_attribute_order/collector.ex
+++ b/lib/credo/check/consistency/module_attribute_order/collector.ex
@@ -1,0 +1,61 @@
+defmodule Credo.Check.Consistency.ModuleAttributeOrder.Collector do
+  @moduledoc false
+
+  use Credo.Check.Consistency.Collector
+
+  alias Credo.Code
+
+  def collect_matches(source_file, _params) do
+    source_file
+    |> Code.prewalk(&traverse_file/2, [])
+    |> collapse()
+  end
+
+  def find_locations_not_matching(expected, source_file) do
+    source_file
+    |> Code.prewalk(&traverse_file/2, [])
+    |> collapse()
+
+    # |> drop_locations(expected)
+  end
+
+  defp traverse_file({:defmodule, _, [_name, [do: content]]} = ast, file_attributes) do
+    {_, module_attributes} = Macro.prewalk(content, [], &traverse_module/2)
+
+    {ast, [module_attributes | file_attributes]}
+  end
+
+  defp traverse_file(ast, file_attributes), do: {ast, file_attributes}
+
+  defp traverse_module({:defmodule, meta, [name, _]}, attributes) do
+    {{:defmodule, meta, [name, [do: :ok]]}, attributes}
+  end
+
+  defp traverse_module(ast, attributes) do
+    case match_attribute(ast) do
+      nil -> {ast, attributes}
+      attribute -> {ast, [attribute | attributes]}
+    end
+  end
+
+  for attribute <- [:moduledoc, :behaviour, :type, :callback, :macrocallback, :optional_callbacks] do
+    defp match_attribute({:@, _, [{unquote(attribute), _, _}]}), do: unquote(attribute)
+  end
+
+  for attribute <- [:use, :import, :alias, :require, :defstruct, :@] do
+    defp match_attribute({unquote(attribute), _, _}), do: unquote(attribute)
+  end
+
+  defp match_attribute(_), do: nil
+
+  defp collapse(file_attributes) do
+    Enum.reduce(file_attributes, %{}, fn attributes, map ->
+      attributes =
+        attributes
+        |> Enum.reverse()
+        |> Enum.uniq()
+
+      Map.update(map, attributes, 1, &(&1 + 1))
+    end)
+  end
+end

--- a/lib/credo/check/consistency/module_attribute_order/collector.ex
+++ b/lib/credo/check/consistency/module_attribute_order/collector.ex
@@ -11,6 +11,10 @@ defmodule Credo.Check.Consistency.ModuleAttributeOrder.Collector do
     |> collapse()
   end
 
+  defdelegate transform_frequencies(frequencies),
+    to: Credo.Check.Consistency.ModuleAttributeOrder.Merger,
+    as: :merge_frequencies
+
   def find_locations_not_matching(expected, source_file) do
     source_file
     |> Code.prewalk(&traverse_file/2, [])

--- a/lib/credo/check/consistency/module_attribute_order/collector.ex
+++ b/lib/credo/check/consistency/module_attribute_order/collector.ex
@@ -46,9 +46,11 @@ defmodule Credo.Check.Consistency.ModuleAttributeOrder.Collector do
     defp match_attribute({:@, _, [{unquote(attribute), _, _}]}), do: unquote(attribute)
   end
 
-  for attribute <- [:use, :import, :alias, :require, :defstruct, :@] do
+  for attribute <- [:use, :import, :alias, :require, :defstruct] do
     defp match_attribute({unquote(attribute), _, _}), do: unquote(attribute)
   end
+
+  defp match_attribute({:@, _, _}), do: :moduleattribute
 
   defp match_attribute(_), do: nil
 

--- a/lib/credo/check/consistency/module_attribute_order/merger.ex
+++ b/lib/credo/check/consistency/module_attribute_order/merger.ex
@@ -1,0 +1,140 @@
+defmodule Credo.Check.Consistency.ModuleAttributeOrder.Merger do
+  def merge_frequencies(%{} = frequencies) do
+    frequencies
+    |> Enum.sort_by(fn {attributes, frequency} -> {frequency, length(attributes)} end, &>=/2)
+    |> merge_frequencies()
+    |> Map.new()
+  end
+
+  def merge_frequencies(frequencies) when is_list(frequencies) do
+    do_merge_frequencies(frequencies, [])
+  end
+
+  defp do_merge_frequencies([], merged), do: merged
+  defp do_merge_frequencies([occurrence], merged), do: [occurrence | merged]
+
+  defp do_merge_frequencies([occurrence | rest], merged) do
+    {merged_occurrence, unmergable} =
+      merge_occurrence(occurrence,
+        with: rest,
+        already_merged: merged
+      )
+
+    do_merge_frequencies(unmergable, [merged_occurrence | merged])
+  end
+
+  defp merge_occurrence(to_merge, with: maybe_mergable, already_merged: already_merged) do
+    reference = already_merged ++ maybe_mergable
+
+    {merged, unmergable} =
+      Enum.reduce(
+        maybe_mergable,
+        {to_merge, []},
+        fn to_merge, {merged, unmergable} ->
+          case try_to_merge_occurrences(merged, to_merge, reference: reference) do
+            {:ok, merged} ->
+              {merged, unmergable}
+
+            :error ->
+              {merged, [to_merge | unmergable]}
+          end
+        end
+      )
+
+    {merged, Enum.reverse(unmergable)}
+  end
+
+  defp try_to_merge_occurrences(merged, to_merge, reference: reference) do
+    try_to_merge_occurrences(merged, to_merge, order: [], reference: reference)
+  end
+
+  defp try_to_merge_occurrences(merged, to_merge, order: order, reference: reference) do
+    {:ok, merge_occurrences!(merged, to_merge, order)}
+  catch
+    :conflict ->
+      :error
+
+    {:unclear, unclear} ->
+      order =
+        case determine_order_from(unclear, reference) do
+          {ordered, [] = _unclear} ->
+            ordered
+
+            # TODO: Fallback to styleguide
+        end
+
+      try_to_merge_occurrences(merged, to_merge, order: order, reference: reference)
+  end
+
+  defp merge_occurrences!(
+         {attributes, frequency},
+         {attributes_to_merge, frequency_to_merge},
+         order
+       ) do
+    {
+      merge_attributes!(attributes, attributes_to_merge, order),
+      frequency + frequency_to_merge
+    }
+  end
+
+  defp merge_attributes!(attributes, attributes, _order), do: attributes
+  defp merge_attributes!([], attributes, _order), do: attributes
+  defp merge_attributes!(attributes, [], _order), do: attributes
+
+  defp merge_attributes!([attribute | rest], [attribute | other_rest], order) do
+    [attribute | merge_attributes!(rest, other_rest, order)]
+  end
+
+  defp merge_attributes!([attribute | rest], [other_attribute | other_rest], order) do
+    case {attribute in other_rest, other_attribute in rest} do
+      {true, false} ->
+        [other_attribute | merge_attributes!([attribute | rest], other_rest, order)]
+
+      {false, true} ->
+        [attribute | merge_attributes!(rest, [other_attribute | other_rest], order)]
+
+      {true, true} ->
+        throw(:conflict)
+
+      {false, false} ->
+        order
+        |> Enum.filter(&(&1 in [attribute, other_attribute]))
+        |> case do
+          [_, _] = order ->
+            order ++ merge_attributes!(rest, other_rest, order)
+
+          _not_contained_in_order ->
+            throw({:unclear, [attribute, other_attribute] ++ order})
+        end
+    end
+  end
+
+  defp determine_order_from({_ordered, []} = ordered, _attributes), do: ordered
+
+  defp determine_order_from(unclear, attributes) when is_list(unclear) do
+    determine_order_from({[], unclear}, attributes)
+  end
+
+  defp determine_order_from(ordered_and_unclear, [{_attributes, _frequency} | _] = occurrences) do
+    determine_order_from(
+      ordered_and_unclear,
+      Enum.map(occurrences, fn {attributes, _} -> attributes end)
+    )
+  end
+
+  defp determine_order_from(ordered_and_unclear, [attributes | _] = all_attributes)
+       when is_list(attributes) do
+    Enum.reduce(all_attributes, ordered_and_unclear, fn attributes, ordered_and_unclear ->
+      determine_order_from(ordered_and_unclear, attributes)
+    end)
+  end
+
+  defp determine_order_from({ordered, unclear}, attributes) do
+    new_ordered =
+      unclear
+      |> Enum.filter(&(&1 in attributes))
+      |> Enum.sort_by(&Enum.find_index(attributes, fn attribute -> attribute == &1 end))
+
+    {ordered ++ new_ordered, unclear -- new_ordered}
+  end
+end

--- a/lib/credo/check/consistency/module_attribute_order/merger.ex
+++ b/lib/credo/check/consistency/module_attribute_order/merger.ex
@@ -78,6 +78,8 @@ defmodule Credo.Check.Consistency.ModuleAttributeOrder.Merger do
             ordered
 
           {_ordered, _unclear} ->
+            warn_styleguide_fallback(unclear)
+
             Enum.filter(@styleguide_order, &(&1 in unclear))
         end
 
@@ -154,5 +156,15 @@ defmodule Credo.Check.Consistency.ModuleAttributeOrder.Merger do
       |> Enum.sort_by(&Enum.find_index(attributes, fn attribute -> attribute == &1 end))
 
     {ordered ++ new_ordered, unclear -- new_ordered}
+  end
+
+  defp warn_styleguide_fallback(unclear) do
+    unclear = Enum.map_join(unclear, " and ", &"`#{&1}`")
+
+    IO.warn(
+      "the ModuleAttributeOrder check didn't find enough code examples " <>
+        "to determine the preferred order of #{unclear}, " <>
+        "it will fallback to the community styleguide ordering."
+    )
   end
 end

--- a/lib/credo/check/consistency/module_attribute_order/merger.ex
+++ b/lib/credo/check/consistency/module_attribute_order/merger.ex
@@ -1,4 +1,21 @@
 defmodule Credo.Check.Consistency.ModuleAttributeOrder.Merger do
+  # From: https://github.com/christopheradams/elixir_style_guide#module-attribute-ordering
+  # Used as fallback if the codebase has insufficient examples
+  @styleguide_order [
+    :moduledoc,
+    :behaviour,
+    :use,
+    :import,
+    :alias,
+    :require,
+    :module_attribute,
+    :defstruct,
+    :type,
+    :callback,
+    :macrocallback,
+    :optional_callbacks
+  ]
+
   def merge_frequencies(%{} = frequencies) do
     frequencies
     |> Enum.sort_by(fn {attributes, frequency} -> {frequency, length(attributes)} end, &>=/2)
@@ -60,7 +77,8 @@ defmodule Credo.Check.Consistency.ModuleAttributeOrder.Merger do
           {ordered, [] = _unclear} ->
             ordered
 
-            # TODO: Fallback to styleguide
+          {_ordered, _unclear} ->
+            Enum.filter(@styleguide_order, &(&1 in unclear))
         end
 
       try_to_merge_occurrences(merged, to_merge, order: order, reference: reference)

--- a/test/credo/check/consistency/module_attribute_order/collector_test.exs
+++ b/test/credo/check/consistency/module_attribute_order/collector_test.exs
@@ -278,5 +278,69 @@ defmodule Credo.Check.Consistency.ModuleAttributeOrder.CollectorTest do
                ] => 1
              }
     end
+
+    test "it should merge frequencies for matches where the order is unclear by looking at the previously processed things" do
+      frequencies = %{
+        [
+          :moduledoc,
+          :type,
+          :require,
+          :alias
+        ] => 30,
+        [
+          :moduledoc,
+          :use,
+          :alias,
+          :type
+        ] => 23,
+        [
+          :use,
+          :alias,
+          :require
+        ] => 20
+      }
+
+      assert Collector.transform_frequencies(frequencies) == %{
+               [
+                 :moduledoc,
+                 :use,
+                 :alias,
+                 :type,
+                 :require
+               ] => 23 + 20,
+               [
+                 :moduledoc,
+                 :type,
+                 :require,
+                 :alias
+               ] => 30
+             }
+    end
+
+    test "it should merge frequencies for matches where the order is unclear according to the styleguide if no other reference is available" do
+      frequencies = %{
+        [
+          :moduledoc,
+          :use,
+          :alias,
+          :type
+        ] => 23,
+        [
+          :use,
+          :alias,
+          :require
+        ] => 20
+      }
+
+      assert Collector.transform_frequencies(frequencies) == %{
+               [
+                 :moduledoc,
+                 :use,
+                 :alias,
+                 :require,
+                 :type
+               ] => 23 + 20
+             }
+    end
   end
 end

--- a/test/credo/check/consistency/module_attribute_order/collector_test.exs
+++ b/test/credo/check/consistency/module_attribute_order/collector_test.exs
@@ -1,0 +1,200 @@
+defmodule Credo.Check.Consistency.ModuleAttributeOrder.CollectorTest do
+  use Credo.TestHelper
+
+  alias Credo.Check.Consistency.ModuleAttributeOrder.Collector
+
+  @all_relevant_attributes """
+  defmodule Credo.Sample1 do
+    @moduledoc false
+
+    @behaviour SomeBehaviour
+
+    use SomeModule
+
+    import AnotherModule
+
+    alias AThirdModule
+    alias YetAnotherModule
+
+    require Logger
+
+    defstruct [:some, :fields]
+
+    @some_attribute :with_some_value
+
+    @type my_type :: any()
+    @type another_type :: any()
+
+    @callback a_callback() :: any()
+
+    @macrocallback a_macro_callback(keyword()) :: no_return
+
+    @optional_callbacks a_callback: 0
+
+    @impl true
+    def some_function, do: :ok
+  end
+  """
+
+  @some_attributes """
+  defmodule Credo.Sample2 do
+    @moduledoc false
+
+    use SomeModule
+
+    alias AThirdModule
+    alias YetAnotherModule
+
+    require Logger
+
+    @some_attribute :with_some_value
+
+    @type my_type :: any()
+    @type another_type :: any()
+
+    @impl true
+    def some_function, do: :ok
+  end
+  """
+
+  @interspersed_attributes """
+  defmodule Credo.Sample2 do
+    @moduledoc false
+
+    use SomeModule
+
+    import AnotherModule
+
+    require Logger
+
+    @some_attribute :with_some_value
+
+    alias YetAnother.GreatModule
+
+    require Stuff
+
+    @type my_type :: any()
+    @type another_type :: any()
+
+    alias MyNested.Awesomeness
+
+    @impl true
+    def some_function, do: :ok
+  end
+  """
+
+  @multi_module_attributes """
+  defmodule Credo.Sample2 do
+    @moduledoc false
+
+    use SomeModule
+
+    alias AThirdModule
+    alias YetAnotherModule
+
+    require Logger
+
+    @some_attribute :with_some_value
+
+    @type my_type :: any()
+    @type another_type :: any()
+
+    defmodule Nested do
+      @moduledoc false
+
+      use OtherModule
+
+      alias Stuff
+      alias MoreStuff
+
+      def my_function, do: :ok
+    end
+  end
+  """
+
+  describe ".collect_matches/2" do
+    test "it should report all relevant attributes in the used order" do
+      result =
+        @all_relevant_attributes
+        |> to_source_file()
+        |> Collector.collect_matches([])
+
+      assert result == %{
+               [
+                 :moduledoc,
+                 :behaviour,
+                 :use,
+                 :import,
+                 :alias,
+                 :require,
+                 :defstruct,
+                 :@,
+                 :type,
+                 :callback,
+                 :macrocallback,
+                 :optional_callbacks
+               ] => 1
+             }
+    end
+
+    test "it should report the relevant used attributes but not all in the used order" do
+      result =
+        @some_attributes
+        |> to_source_file()
+        |> Collector.collect_matches([])
+
+      assert result == %{
+               [
+                 :moduledoc,
+                 :use,
+                 :alias,
+                 :require,
+                 :@,
+                 :type
+               ] => 1
+             }
+    end
+
+    test "it should report the relevant used attributes in the order they first appeared" do
+      result =
+        @interspersed_attributes
+        |> to_source_file()
+        |> Collector.collect_matches([])
+
+      assert result == %{
+               [
+                 :moduledoc,
+                 :use,
+                 :import,
+                 :require,
+                 :@,
+                 :alias,
+                 :type
+               ] => 1
+             }
+    end
+
+    test "it should report the used attributes per module and respect nested modules" do
+      result =
+        @multi_module_attributes
+        |> to_source_file()
+        |> Collector.collect_matches([])
+
+      assert result == %{
+               [
+                 :moduledoc,
+                 :use,
+                 :alias,
+                 :require,
+                 :@,
+                 :type
+               ] => 1,
+               [
+                 :moduledoc,
+                 :use,
+                 :alias
+               ] => 1
+             }
+    end
+  end
+end

--- a/test/credo/check/consistency/module_attribute_order/collector_test.exs
+++ b/test/credo/check/consistency/module_attribute_order/collector_test.exs
@@ -128,7 +128,7 @@ defmodule Credo.Check.Consistency.ModuleAttributeOrder.CollectorTest do
                  :alias,
                  :require,
                  :defstruct,
-                 :@,
+                 :moduleattribute,
                  :type,
                  :callback,
                  :macrocallback,
@@ -149,7 +149,7 @@ defmodule Credo.Check.Consistency.ModuleAttributeOrder.CollectorTest do
                  :use,
                  :alias,
                  :require,
-                 :@,
+                 :moduleattribute,
                  :type
                ] => 1
              }
@@ -167,7 +167,7 @@ defmodule Credo.Check.Consistency.ModuleAttributeOrder.CollectorTest do
                  :use,
                  :import,
                  :require,
-                 :@,
+                 :moduleattribute,
                  :alias,
                  :type
                ] => 1
@@ -186,7 +186,7 @@ defmodule Credo.Check.Consistency.ModuleAttributeOrder.CollectorTest do
                  :use,
                  :alias,
                  :require,
-                 :@,
+                 :moduleattribute,
                  :type
                ] => 1,
                [

--- a/test/credo/check/consistency/module_attribute_order/collector_test.exs
+++ b/test/credo/check/consistency/module_attribute_order/collector_test.exs
@@ -197,4 +197,86 @@ defmodule Credo.Check.Consistency.ModuleAttributeOrder.CollectorTest do
              }
     end
   end
+
+  describe ".transform_frequencies/1" do
+    test "it should merge frequencies for matches where some attributes are simply unused" do
+      frequencies = %{
+        [
+          :moduledoc,
+          :use,
+          :alias,
+          :type
+        ] => 23,
+        [
+          :use,
+          :alias,
+          :require,
+          :type
+        ] => 20,
+        [
+          :moduledoc,
+          :require,
+          :alias
+        ] => 1
+      }
+
+      assert Collector.transform_frequencies(frequencies) == %{
+               [
+                 :moduledoc,
+                 :use,
+                 :alias,
+                 :require,
+                 :type
+               ] => 23 + 20,
+               [
+                 :moduledoc,
+                 :require,
+                 :alias
+               ] => 1
+             }
+    end
+
+    test "it should merge frequencies for matches where the order is unclear by looking at the rest" do
+      frequencies = %{
+        [
+          :moduledoc,
+          :use,
+          :alias,
+          :type
+        ] => 23,
+        [
+          :use,
+          :alias,
+          :require
+        ] => 20,
+        [
+          :alias,
+          :require,
+          :type,
+          :callback
+        ] => 10,
+        [
+          :moduledoc,
+          :require,
+          :alias
+        ] => 1
+      }
+
+      assert Collector.transform_frequencies(frequencies) == %{
+               [
+                 :moduledoc,
+                 :use,
+                 :alias,
+                 :require,
+                 :type,
+                 :callback
+               ] => 23 + 20 + 10,
+               [
+                 :moduledoc,
+                 :require,
+                 :alias
+               ] => 1
+             }
+    end
+  end
 end


### PR DESCRIPTION
*This PR is a work-in-progress (it does not work yet) and an evolution of #588.*

Instead of strictly enforcing the styleguide it instead captures the ordering of the module attributes in the whole project, and enforces consistency across the codebase.

Due to the nature of the check it does this a bit different than all other consistency checks. The other consistency checks act on a line-by-line basis but this check looks at the **whole** module.

It's also special in the way that not all modules necessarily use all module attributes but can still be considered valid. For example:

```elixir
defmodule Module1 do
  @moduledoc false
  
  use AnotherModule
  
  alias SomeThing
  
  require Logger
end
```

Has the module attribute order `[:moduledoc, :use, :alias, :require]`, while this module:

```elixir
defmodule Module2 do
  use AnotherModule

  import MoreFunctions
  
  alias Stuff
  alias MoreStuff
end
```

Has the order `[:use, :import, :alias]`.

These two orders do not contradict but rather compliment each other. The correct general order can be inferred: `[:moduledoc, :use, :import, :alias, :require]`

As such the check introduces a new optional `transform_frequencies/1` callback for `Consistency` checks. This callback is used in the check to merge orders as seen above, which is a surprisingly hard problem. All of this "merging" happens in the `Merge` module which has been extracted to ease readability (although the code itself is not really readable.

---

In some cases the check can not determine the preferred order, take the example from above but now imagine `Module2` to have a `@type` at the end:

```elixir
defmodule Module2 do
  use AnotherModule

  import MoreFunctions
  
  alias Stuff
  alias MoreStuff

  @type my_type :: any()
end
```

In this case the two orders look like this:

```
Module1: [:moduledoc, :use,          :alias, :require]
Module2: [            :use, :import, :alias, :type]
```

As visible it's impossible to determine the correct order from just looking at these two modules. Instead this is handled by checking the order of attributes of **all** other modules in the order of frequency in the hope that one contains both attributes (`type` and `require`) to determine the correct order.

If this fails too the check falls back to the [order listed in the community styleguide](https://github.com/christopheradams/elixir_style_guide#module-attribute-ordering) and prints a warning.