### PR TITLE
Fix type specification

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -36,7 +36,7 @@ defmodule Credo.Check do
 
   @callback explanation_for_params() :: Keyword.t()
 
-  @callback format_issue(issue_meta :: IssueMeta, opts :: Keyword.t()) :: Issue.t()
+  @callback format_issue(issue_meta :: Credo.IssueMeta.t(), opts :: Keyword.t()) :: Issue.t()
 
   @base_category_exit_status_map %{
     consistency: 1,

--- a/lib/credo/issue_meta.ex
+++ b/lib/credo/issue_meta.ex
@@ -5,7 +5,7 @@ defmodule Credo.IssueMeta do
   params (by default).
   """
 
-  @type t :: module
+  @type t :: {__MODULE__, Credo.SourceFile.t(), Keyword.t()}
 
   alias Credo.SourceFile
 


### PR DESCRIPTION
A wrong typespec causes dialyzer errors in a client project where custom credo checks are built.