### PR TITLE
Fix spec check

### DIFF
--- a/lib/credo/check/readability/specs.ex
+++ b/lib/credo/check/readability/specs.ex
@@ -44,7 +44,7 @@ defmodule Credo.Check.Readability.Specs do
     {ast, [{name, length(args)} | specs]}
   end
 
-  defp find_specs({:impl, _, [true]} = ast, specs) do
+  defp find_specs({:impl, _, [impl]} = ast, specs) when impl != false do
     {ast, [:impl | specs]}
   end
 

--- a/test/credo/check/readability/specs_test.exs
+++ b/test/credo/check/readability/specs_test.exs
@@ -101,4 +101,26 @@ defmodule Credo.Check.Readability.SpecsTest do
     |> to_source_file()
     |> refute_issues(@described_check)
   end
+
+  test "it should NOT report functions with `@impl SomeMod`" do
+    """
+    defmodule CredoTypespecTest do
+      @impl SomeMod
+      def foo(a), do: a
+    end
+    """
+    |> to_source_file()
+    |> refute_issues(@described_check)
+  end
+
+  test "it should report functions with `@impl false`" do
+    """
+    defmodule CredoTypespecTest do
+      @impl false
+      def foo(a), do: a
+    end
+    """
+    |> to_source_file()
+    |> assert_issue(@described_check)
+  end
 end


### PR DESCRIPTION
If a callback fun was marked with `@impl BehaviourMod`, `Credo.Check.Readability.Specs` check treated that fun as public.