### PR TITLE
Fix name parsing bug in Credo.Check.Consistency.UnusedVariableNames

### DIFF
--- a/lib/credo/check/consistency/unused_variable_names/collector.ex
+++ b/lib/credo/check/consistency/unused_variable_names/collector.ex
@@ -40,7 +40,7 @@ defmodule Credo.Check.Consistency.UnusedVariableNames.Collector do
 
   defp unused_variable_name?({:_, _, _}), do: true
 
-  defp unused_variable_name?({name, _, _}),
+  defp unused_variable_name?({name, _, _}) when is_atom(name),
     do: String.starts_with?(Atom.to_string(name), "_")
 
   defp unused_variable_name?(_), do: false

--- a/test/credo/check/consistency/unused_variable_names_test.exs
+++ b/test/credo/check/consistency/unused_variable_names_test.exs
@@ -9,6 +9,7 @@ defmodule Credo.Check.Consistency.UnusedVariableNamesTest do
       defmodule Credo.SampleOne do
         defmodule Foo do
           def bar(_, %{foo: foo} = _, _) do
+            version = Mix.Project.config()[:version]
           end
         end
       end


### PR DESCRIPTION
There was a bug in my `unused_variable_name?/1` helper function. I fixed it 😄 