### PR TITLE
fix: fixes issue #696

### DIFF
--- a/lib/credo/check/readability/function_names.ex
+++ b/lib/credo/check/readability/function_names.ex
@@ -23,6 +23,9 @@ defmodule Credo.Check.Readability.FunctionNames do
   @all_sigil_chars ~w(a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y z Z)
   @all_sigil_atoms Enum.map(@all_sigil_chars, &:"sigil_#{&1}")
 
+  #all non-special-form operators
+  @all_nonspecial_operators ~W(! && ++ -- .. <> =~ @ |> || != !== * + - / <= == === > >= ||| &&& <<< >>> <<~ ~>> <~ ~> <~> <|> ^^^ ~~~)a
+
   use Credo.Check, base_priority: :high
 
   alias Credo.Code.Name
@@ -61,6 +64,12 @@ defmodule Credo.Check.Readability.FunctionNames do
   for op <- @def_ops do
     # Ignore variables named e.g. `defp`
     defp traverse({unquote(op), _meta, nil} = ast, issues, _issue_meta) do
+      {ast, issues}
+    end
+
+    # ignore non-special-form (overridable) operators
+    defp traverse({unquote(op), _meta, [{operator, _at_meta, _args} | _tail]} = ast, issues, _issue_meta)
+    when operator in @all_nonspecial_operators do
       {ast, issues}
     end
 

--- a/lib/credo/check/readability/module_attribute_names.ex
+++ b/lib/credo/check/readability/module_attribute_names.ex
@@ -29,6 +29,11 @@ defmodule Credo.Check.Readability.ModuleAttributeNames do
     Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
   end
 
+  # ignore non-alphanumeric @ ASTs, for when you're redefining the @ macro.
+  defp traverse({:@, _meta, [{:{}, _, _}]} = ast, issues, _) do
+    {ast, issues}
+  end
+
   defp traverse(
          {:@, _meta, [{name, meta, _arguments}]} = ast,
          issues,

--- a/test/credo/check/readability/function_names_test.exs
+++ b/test/credo/check/readability/function_names_test.exs
@@ -67,7 +67,6 @@ defmodule Credo.Check.Readability.FunctionNamesTest do
     |> refute_issues(@described_check)
   end
 
-  @tag :one
   test "it should NOT report expected code (for operators) /6" do
     """
     defmacro @expr2

--- a/test/credo/check/readability/function_names_test.exs
+++ b/test/credo/check/readability/function_names_test.exs
@@ -67,6 +67,22 @@ defmodule Credo.Check.Readability.FunctionNamesTest do
     |> refute_issues(@described_check)
   end
 
+  @tag :one
+  test "it should NOT report expected code (for operators) /6" do
+    """
+    defmacro @expr2
+    defmacro @expr do
+      # ...
+    end
+
+    def left ++ right do
+      # ++ code
+    end
+    """
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
   #
   # cases raising issues
   #

--- a/test/credo/check/readability/module_attribute_names_test.exs
+++ b/test/credo/check/readability/module_attribute_names_test.exs
@@ -31,6 +31,20 @@ defmodule Credo.Check.Readability.ModuleAttributeNamesTest do
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT fail when redefining the @ operator" do
+    """
+    defmodule CredoSampleModule do
+      defmacro @{_, _, _} do
+        quote do
+          # some_code_here
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
   #
   # cases raising issues
   #


### PR DESCRIPTION
sometimes it's useful (but, of course, potentially dangerous) to redefine an "@" parameter inside of a using statement.  This form currently gets trapped by credo.  I attempted a strategy of trapping on the outer context being a *defmacro* statement, but this strategy wound up being simpler.  In general, the "@" AST will not be followed by a bracket except in this singular situation.