### PR TITLE
Add regex support and umbrella test path regex to excluded_paths for ModuleDependencies.

### DIFF
--- a/lib/credo/check/refactor/module_dependencies.ex
+++ b/lib/credo/check/refactor/module_dependencies.ex
@@ -14,7 +14,7 @@ defmodule Credo.Check.Refactor.ModuleDependencies do
       max_deps: "Maximum number of module dependencies.",
       dependency_namespaces: "List of dependency namespaces to include in this check",
       excluded_namespaces: "List of namespaces to exclude from this check",
-      excluded_paths: "List of paths to exclude from this check"
+      excluded_paths: "List of paths or regex to exclude from this check"
     ]
   ]
 
@@ -22,7 +22,7 @@ defmodule Credo.Check.Refactor.ModuleDependencies do
     max_deps: 10,
     dependency_namespaces: [],
     excluded_namespaces: [],
-    excluded_paths: ["test"]
+    excluded_paths: [~r"/test/", ~r"^test/"]
   ]
 
   use Credo.Check, base_priority: :normal
@@ -62,8 +62,11 @@ defmodule Credo.Check.Refactor.ModuleDependencies do
   defp ignore_path?(filename, excluded_paths) do
     directory = Path.dirname(filename)
 
-    Enum.any?(excluded_paths, &String.starts_with?(directory, &1))
+    Enum.any?(excluded_paths, &matches?(directory, &1))
   end
+
+  defp matches?(directory, %Regex{} = regex), do: Regex.match?(regex, directory)
+  defp matches?(directory, path) when is_binary(path), do: String.starts_with?(directory, path)
 
   defp traverse(
          {:defmodule, meta, [mod | _]} = ast,

--- a/test/credo/check/refactor/module_dependencies_test.exs
+++ b/test/credo/check/refactor/module_dependencies_test.exs
@@ -57,4 +57,52 @@ defmodule Credo.Check.Refactor.ModuleDependenciesTest do
     |> to_source_file
     |> assert_issue(@described_check)
   end
+
+  test "it should not report a violation on non-umbrella test path" do
+    """
+    defmodule CredoSampleModule do
+      def some_function() do
+        [
+          DateTime,
+          Kernel,
+          GenServer,
+          GenEvent,
+          File,
+          Time,
+          IO,
+          Logger,
+          URI,
+          Path,
+          String
+        ]
+      end
+    end
+    """
+    |> to_source_file("test/foo/my_test.exs")
+    |> refute_issues(@described_check)
+  end
+
+  test "it should not report a violation on umbrella test path" do
+    """
+    defmodule CredoSampleModule do
+      def some_function() do
+        [
+          DateTime,
+          Kernel,
+          GenServer,
+          GenEvent,
+          File,
+          Time,
+          IO,
+          Logger,
+          URI,
+          Path,
+          String
+        ]
+      end
+    end
+    """
+    |> to_source_file("apps/foo/test/foo/my_test.exs")
+    |> refute_issues(@described_check)
+  end
 end


### PR DESCRIPTION
Adds umbrella app test directories to default ignore in ModuleDependencies check when in umbrella app.

Fixes #705.