### PR TITLE
Fix TrailingWhiteSpace check on Windows

### DIFF
--- a/lib/credo/check/readability/trailing_white_space.ex
+++ b/lib/credo/check/readability/trailing_white_space.ex
@@ -45,7 +45,7 @@ defmodule Credo.Check.Readability.TrailingWhiteSpace do
 
   defp traverse_line([{line_no, line} | tail], issues, issue_meta) do
     issues =
-      case Regex.run(~r/\s+$/, line, return: :index) do
+      case Regex.run(~r/\h+$/, line, return: :index) do
         [{column, line_length}] ->
           [issue_for(issue_meta, line_no, column + 1, line_length) | issues]
 

--- a/test/credo/check/readability/trailing_white_space_test.exs
+++ b/test/credo/check/readability/trailing_white_space_test.exs
@@ -30,6 +30,15 @@ defmodule Credo.Check.Readability.TrailingWhiteSpaceTest do
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report \r line endings" do
+    """
+    defmodule CredoSampleModule do\r
+    end\r
+    """
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
   #
   # cases raising issues
   #


### PR DESCRIPTION
Fixes the TrailingWhiteSpace check on windows style line endings. 
The current regex `~r/\s+$/` was catching `\r` line endings when it shouldn't catch. 
That commit replace the `\s` with `\h` which is a horizontal whitespace and it's also compliant with PCRE  (Perl Compatible Regular Expressions) that is used by elixir and erlang. 

Fixes #698 