### PR TITLE
Fix crash in AliasAs check when __MODULE__ is aliased. Fixes #710.

### DIFF
--- a/lib/credo/check/readability/alias_as.ex
+++ b/lib/credo/check/readability/alias_as.ex
@@ -34,6 +34,9 @@ defmodule Credo.Check.Readability.AliasAs do
   defp add_issue(issues, nil), do: issues
   defp add_issue(issues, issue), do: [issue | issues]
 
+  defp issue({:alias, _, [{:__MODULE__, _, nil}, [as: {_, meta, _}]]}, issue_meta),
+    do: issue_for(issue_meta, meta[:line], inspect(:__MODULE__))
+
   defp issue({:alias, _, [{_, _, original}, [as: {_, meta, _}]]}, issue_meta),
     do: issue_for(issue_meta, meta[:line], inspect(Module.concat(original)))
 

--- a/test/credo/check/readability/alias_as_test.exs
+++ b/test/credo/check/readability/alias_as_test.exs
@@ -44,4 +44,15 @@ defmodule Credo.Check.Readability.AliasAsTest do
     assert issue2.trigger == "App.Module3"
     assert issue3.trigger == "App.Module4"
   end
+
+  test "it should not raise on alias __MODULE__, as: Foo" do
+    _ =
+      """
+      defmodule Test do
+        alias __MODULE__, as: Foo
+      end
+      """
+      |> to_source_file
+      |> assert_issue(@described_check)
+  end
 end


### PR DESCRIPTION
Fix crash in AliasAs check when `__MODULE__` is aliased. Fixes #710.