### PR TITLE
Fix logic issue with PipeChainStart, excluding :atoms, and nil. Fixes #712

### DIFF
--- a/lib/credo/check/refactor/pipe_chain_start.ex
+++ b/lib/credo/check/refactor/pipe_chain_start.ex
@@ -205,9 +205,10 @@ defmodule Credo.Check.Refactor.PipeChainStart do
     function_name = to_function_call_name(ast)
 
     found_argument_types =
-      arguments
-      |> List.first()
-      |> argument_type()
+      case arguments do
+        [nil | _] -> [:atom]
+        x -> x |> List.first() |> argument_type()
+      end
 
     Enum.member?(excluded_functions, function_name) ||
       Enum.any?(

--- a/test/credo/check/refactor/pipe_chain_start_test.exs
+++ b/test/credo/check/refactor/pipe_chain_start_test.exs
@@ -312,6 +312,22 @@ defmodule Credo.Check.Refactor.PipeChainStartTest do
     |> refute_issues(@described_check, excluded_argument_types: [:number])
   end
 
+  test "it should NOT report a violation for an excluded argument type /7" do
+    """
+    insert(:event) |> schedule_events()
+    """
+    |> to_source_file
+    |> refute_issues(@described_check, excluded_argument_types: [:atom])
+  end
+
+  test "it should NOT report a violation for an excluded argument type /8" do
+    """
+    foo(nil) |> bar()
+    """
+    |> to_source_file
+    |> refute_issues(@described_check, excluded_argument_types: [:atom])
+  end
+
   #
   # cases raising issues
   #


### PR DESCRIPTION
Fixed logic issue with PipeChainStart when excluding `:atom` and using a `nil`. See #712.