### PR TITLE
Make Credo.Check.Readability.MultiAlias check work with submodule expansion

### DIFF
--- a/lib/credo/check/readability/multi_alias.ex
+++ b/lib/credo/check/readability/multi_alias.ex
@@ -36,7 +36,9 @@ defmodule Credo.Check.Readability.MultiAlias do
          issues,
          issue_meta
        ) do
-    {:__aliases__, _, [module | []]} = multi_alias
+    {:__aliases__, _, module} = multi_alias
+    module = Enum.join(module, ".")
+
     new_issue = issue_for(issue_meta, Keyword.get(opts, :line), base_alias, module)
 
     {ast, [new_issue | issues]}

--- a/test/credo/check/readability/multi_alias_test.exs
+++ b/test/credo/check/readability/multi_alias_test.exs
@@ -41,4 +41,16 @@ defmodule Credo.Check.Readability.MultiAliasTest do
     |> to_source_file
     |> assert_issue(@described_check)
   end
+
+  test "it should report a violation for multiple nested expansions" do
+    """
+    defmodule CredoSampleModule do
+      alias App.{Module1.Submodule1, Module2}
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check, fn issue ->
+      assert issue.trigger == "Module1.Submodule1"
+    end)
+  end
 end


### PR DESCRIPTION
The `Credo.Check.Readability.MultiAlias` check was raising an error when trying to parse this code because of the `Bar.Baz` part.

```elixir
alias Foo.{Bar.Baz, Quux}
```

I fixed it and added a test.