### PR TITLE
Fix nil in Credo.Check.Consistency.UnusedVariableNames.Collector

### DIFF
--- a/lib/credo/check/consistency/unused_variable_names/collector.ex
+++ b/lib/credo/check/consistency/unused_variable_names/collector.ex
@@ -34,6 +34,8 @@ defmodule Credo.Check.Consistency.UnusedVariableNames.Collector do
 
   defp traverse(_callback, ast, acc), do: {ast, acc}
 
+  defp reduce_unused_variables(ast, _callback, acc) when is_nil(ast), do: acc
+
   defp reduce_unused_variables(ast, callback, acc) do
     Enum.reduce(ast, acc, &if(unused_variable_name?(&1), do: callback.(&1, &2), else: &2))
   end


### PR DESCRIPTION
Relates to  #717 
Signed-off-by: Roman Sotnikov <roman.sotnikov@gmail.com>

After fix:

```bash
  Consistency                                                                   
┃ 
┃ [C] ↗ Unused variables should be named consistently. It seems your strategy is 
┃       to name them anonymously (ie. `_`) but `_assoc` does not follow that 
┃       convention.
┃       lib/opm_web/services/audit/audit.ex:103:21 #(OpmWeb.Service.Audit.handle_assoc)
┃ [C] ↗ Unused variables should be named consistently. It seems your strategy is 
┃       to name them anonymously (ie. `_`) but `_field` does not follow that 
┃       convention.
┃       lib/opm_web/services/audit/audit.ex:103:29 #(OpmWeb.Service.Audit.handle_assoc)
┃ [C] ↗ Unused variables should be named consistently. It seems your strategy is 
┃       to name them anonymously (ie. `_`) but `_changeset` does not follow that 
┃       convention.
┃       lib/opm_web/services/audit/audit.ex:103:37 #(OpmWeb.Service.Audit.handle_assoc)
┃ [C] ↗ Unused variables should be named consistently. It seems your strategy is 
┃       to name them anonymously (ie. `_`) but `_model` does not follow that 
┃       convention.
┃       lib/opm_web/services/audit/audit.ex:103:49 #(OpmWeb.Service.Audit.handle_assoc)
┃ [C] ↗ Unused variables should be named consistently. It seems your strategy is 
┃       to name them anonymously (ie. `_`) but `_originator` does not follow 
┃       that convention.
┃       lib/opm_web/services/audit/audit.ex:103:57 #(OpmWeb.Service.Audit.handle_assoc)
┃  ...  (179 more, use `-a` to show them)

Please report incorrect results: https://github.com/rrrene/credo/issues

```