### PR TITLE
Improve default includes for umbrella apps. Fixes #559.

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -21,7 +21,16 @@
         # You can give explicit globs or simply directories.
         # In the latter case `**/*.{ex,exs}` will be used.
         #
-        included: ["lib/", "src/", "test/", "web/", "apps/"],
+        included: [
+          "lib/",
+          "src/",
+          "test/",
+          "web/",
+          "apps/*/lib/",
+          "apps/*/src/",
+          "apps/*/test/",
+          "apps/*/web/"
+        ],
         excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
       },
       #


### PR DESCRIPTION
This improves the default includes for umbrella apps. For monolith apps, we were targeting lib, src, test, and web, and excluding folders like assets, but umbrellas were targeted with `apps/` which included all the folders like assets in those sub-apps. The new version targets the lib, src, test, and web folders inside `apps/*/`. Fixes #599.

Old config:
```
Analysis took 121.5 seconds (5.8s to load, 115.6s running 61 checks)
```
New config:
```
Analysis took 113.7 seconds (1.1s to load, 112.6s running 61 checks)
```