### PR TITLE
Remove old CodeHelper references which was removed in v1.0.0

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -80,7 +80,6 @@ defmodule Credo.Check do
       @before_compile Credo.Check
 
       alias Credo.Check
-      alias Credo.Check.CodeHelper
       alias Credo.Check.Params
       alias Credo.CLI.ExitStatus
       alias Credo.Issue

--- a/lib/credo/code.ex
+++ b/lib/credo/code.ex
@@ -7,9 +7,6 @@ defmodule Credo.Code do
   value of a module attribute inside a given module, we want to extract that
   function and put it in the `Credo.Code` namespace, so others can utilize them
   without reinventing the wheel.
-
-  The most often utilized functions are conveniently imported to
-  `Credo.Check.CodeHelper`.
   """
 
   alias Credo.Code.Charlists

--- a/test/credo/check/readability/alias_order_test.exs
+++ b/test/credo/check/readability/alias_order_test.exs
@@ -17,7 +17,6 @@ defmodule Credo.Check.Readability.AliasOrderTest do
       alias Credo.CLI.Sorter
 
       alias Credo.Check
-      alias Credo.Check.CodeHelper
       alias Credo.Check.Params
       alias Credo.CLI.ExitStatus
       alias Credo.Issue


### PR DESCRIPTION
The alias and the references to this module no longer make sense since the module was removed in v1.0.0