### PR TITLE
Cleaned up dialyzer issues. Unused/unreachable code and incorrect types.

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -24,8 +24,6 @@ defmodule Credo.Check do
   It has to return a list of found issues.
   """
 
-  @type t :: module
-
   @doc """
   Returns the base priority for the check.
   """
@@ -36,7 +34,7 @@ defmodule Credo.Check do
   """
   @callback category() :: atom
 
-  # @callback run(source_file :: Credo.SourceFile.t, params :: Keyword.t) :: List.t
+  # @callback run(source_file :: Credo.SourceFile.t, params :: Keyword.t) :: list()
 
   @callback run_on_all?() :: boolean
 
@@ -44,7 +42,8 @@ defmodule Credo.Check do
 
   @callback explanation_for_params() :: Keyword.t()
 
-  @callback format_issue(issue_meta :: Credo.IssueMeta.t(), opts :: Keyword.t()) :: Issue.t()
+  @callback format_issue(issue_meta :: Credo.IssueMeta.t(), opts :: Keyword.t()) ::
+              Credo.Issue.t()
 
   @base_category_exit_status_map %{
     consistency: 1,

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -43,7 +43,6 @@ defmodule Credo.Check.Readability.LargeNumbers do
     acc =
       case number_token(head, min_number) do
         nil -> acc
-        false -> acc
         token -> acc ++ [token]
       end
 

--- a/lib/credo/check/readability/parentheses_in_condition.ex
+++ b/lib/credo/check/readability/parentheses_in_condition.ex
@@ -40,7 +40,6 @@ defmodule Credo.Check.Readability.ParenthesesInCondition do
   defp collect_parenthetical_tokens([head | t], acc, prev_head) do
     acc =
       case check_for_opening_paren(head, t, prev_head) do
-        nil -> acc
         false -> acc
         token -> acc ++ [token]
       end

--- a/lib/credo/cli/command.ex
+++ b/lib/credo/cli/command.ex
@@ -54,5 +54,5 @@ defmodule Credo.CLI.Command do
   end
 
   @doc "Runs the Command."
-  @callback call(exec :: Credo.Execution.t(), opts :: List.t()) :: Credo.Execution.t()
+  @callback call(exec :: Credo.Execution.t(), opts :: list()) :: Credo.Execution.t()
 end

--- a/lib/credo/execution.ex
+++ b/lib/credo/execution.ex
@@ -85,7 +85,7 @@ defmodule Credo.Execution do
             results: %{},
             config_comment_map: %{}
 
-  @type t :: module
+  @type t :: %__MODULE__{}
 
   @execution_pipeline [
     __pre__: [

--- a/lib/credo/execution/task.ex
+++ b/lib/credo/execution/task.ex
@@ -92,28 +92,12 @@ defmodule Credo.Execution.Task do
     exec
   end
 
-  defp log(:call_start, {:task_group, _exec, task_group, _opts}) do
-    Logger.info("Calling #{task_group} ...")
-  end
-
   defp log(:call_start, {:task, _exec, task, _opts}) do
     Logger.info("Calling #{task} ...")
   end
 
-  defp log(:call_start, context_tuple) do
-    Logger.info("Calling #{inspect(context_tuple)} ...")
-  end
-
-  defp log(:call_end, {:task_group, _exec, task_group, _opts}, time) do
-    Logger.info("Finished #{task_group} in #{format_time(time)} ...")
-  end
-
   defp log(:call_end, {:task, _exec, task, _opts}, time) do
     Logger.info("Finished #{task} in #{format_time(time)} ...")
-  end
-
-  defp log(:call_end, context_tuple, time) do
-    Logger.info("Finished #{inspect(context_tuple)} in #{format_time(time)} ...")
   end
 
   defp format_time(time) do

--- a/lib/credo/execution/task/validate_options.ex
+++ b/lib/credo/execution/task/validate_options.ex
@@ -16,6 +16,7 @@ defmodule Credo.Execution.Task.ValidateOptions do
     end
   end
 
+  @spec error(Credo.Execution.t(), keyword()) :: no_return
   def error(exec, _opts) do
     UI.use_colors(exec)
 

--- a/lib/credo/issue.ex
+++ b/lib/credo/issue.ex
@@ -3,7 +3,7 @@ defmodule Credo.Issue do
   `Issue` structs represent all issues found during the code analysis.
   """
 
-  @type t :: module
+  @type t :: %__MODULE__{}
 
   defstruct check: nil,
             category: nil,


### PR DESCRIPTION
Brings dialyzer warnings from 34 down to 1 (which will remain as long as Elixir 1.5 is supported)