### PR TITLE
Fix issue with interpolation of strings vs charlists. Fixes #729.

### DIFF
--- a/lib/credo/code/interpolation_helper.ex
+++ b/lib/credo/code/interpolation_helper.ex
@@ -55,9 +55,11 @@ defmodule Credo.Code.InterpolationHelper do
 
   defp replace_line(line, col_start, col_end, char) do
     length = max(col_end - col_start, 0)
-
-    String.slice(line, 0, col_start - 1) <>
-      String.duplicate(char, length) <> String.slice(line, (col_end - 1)..-1)
+    line = String.to_charlist(line)
+    part1 = Enum.slice(line, 0, col_start - 1)
+    part2 = String.to_charlist(String.duplicate(char, length))
+    part3 = Enum.slice(line, (col_end - 1)..-1)
+    List.to_string(part1 ++ part2 ++ part3)
   end
 
   @doc false

--- a/test/credo/code/interpolation_helper_test.exs
+++ b/test/credo/code/interpolation_helper_test.exs
@@ -479,4 +479,16 @@ defmodule Credo.Code.InterpolationHelperTest do
 
     assert expected == InterpolationHelper.replace_interpolations(source, "$")
   end
+
+  test "it should replace issue #729 correctly" do
+    source = ~S"""
+    "🇿🇼 #{String.upcase(env)}"
+    """
+
+    expected = ~S"""
+    "🇿🇼 $$$$$$$$$$$$$$$$$$$$$"
+    """
+
+    assert expected == InterpolationHelper.replace_interpolations(source, "$")
+  end
 end


### PR DESCRIPTION
This PR fixes #729. This was a fun one to track down. When we pass code into `:elixir_tokenizer` to identify the token locations, we first convert the string to a charlist:
https://github.com/rrrene/credo/blob/d77eab696f7a7e485ba6ef3c1a7cc41ccd834fba/lib/credo/code.ex#L132-L134
This results in column numbers consistent with the charlist indexes of the characters. For the unicode character in question (🇿🇼), it translates to two values:
```elixir
iex(1)> String.to_charlist("🇿🇼")
[127487, 127484]
```
This means that when the `:elixir_tokenizer` identifies the `#` token in this string:

```elixir
    source = ~S"""
    "🇿🇼 #{String.upcase(env)}"
    """
```
it identifies it at the 5th column in the output, which is correct because it is the 5th item in the charlist:
```elixir
   {:bin_string, {1, 1, nil},
    [
      "🇿🇼 ",
      {{1, 5, nil}, {1, 25, nil},
```

The problem is that our code to split and replace that interpolation uses `String.slice`, which uses the `String` indexes, not `charlist` indexes, so when it grabs the 5th character, it is off by one and starts the replacement at the `{` instead of the `#`. The resulting code has an unexpected/unparsable `#`:
```elixir
     Assertion with == failed
     code:  assert expected == InterpolationHelper.replace_interpolations(source, " ")
     left:  "\"🇿🇼                      \"\n"
     right: "\"🇿🇼 #                     \n"
```

The fix was simply to convert the strings to charlists and use `Enum.slice` instead of `String.slice` to replace the values, as the numbers we are working with are the charlist indexes, not the string indexes.