### PR TITLE
Include line number in line ending check. Fixes #253.

### DIFF
--- a/lib/credo/check/consistency/line_endings.ex
+++ b/lib/credo/check/consistency/line_endings.ex
@@ -18,9 +18,11 @@ defmodule Credo.Check.Consistency.LineEndings do
   end
 
   defp issues_for(expected, source_file, params) do
+    first_line_with_issue = @collector.first_line_with_issue(expected, source_file)
+
     source_file
     |> IssueMeta.for(params)
-    |> format_issue(message: message_for(expected))
+    |> format_issue(message: message_for(expected), line_no: first_line_with_issue)
     |> List.wrap()
   end
 

--- a/lib/credo/check/consistency/line_endings/collector.ex
+++ b/lib/credo/check/consistency/line_endings/collector.ex
@@ -11,6 +11,14 @@ defmodule Credo.Check.Consistency.LineEndings.Collector do
     end)
   end
 
+  def first_line_with_issue(expected, source_file) do
+    {line_no, _} = source_file
+    |> SourceFile.lines()
+    |> Enum.find(&line_ending(&1) != expected)
+
+    line_no
+  end
+
   defp line_ending({_line_no, line}) do
     if String.ends_with?(line, "\r") do
       :windows


### PR DESCRIPTION
Include first offending line number in each file for the line ending check. Probably will always be line 1 but we should report it anyway for consistent reports. Fixes #253.