### PR TITLE
Fix bug with `nil` parse_timeout

### DIFF
--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -34,6 +34,13 @@ defmodule Credo.Sources do
   end
 
   def find(%Credo.Execution{files: files, parse_timeout: parse_timeout}) do
+    parse_timeout =
+      if is_nil(parse_timeout) do
+        :infinity
+      else
+        parse_timeout
+      end
+
     MapSet.new()
     |> include(files.included)
     |> exclude(files.excluded)


### PR DESCRIPTION
There was a bug in here when using plugins that the `parse_timeout` was
`nil`, and then when I tried to use it with `--config-name` it crashed.
Here's what that crash looked like:

```
mix credo --files-included lib/sketchql/subscriptions/sync_schedules.ex --files-included lib/sketchql/subscriptions/stripe/api/client.ex --config-name new_files
** (FunctionClauseError) no function clause matching in Task.yield_many/2

    The following arguments were given to Task.yield_many/2:

        # 1
        [%Task{owner: #PID<0.93.0>, pid: #PID<0.116.0>, ref: #Reference<0.323361820.2247360518.21450>}, %Task{owner: #PID<0.93.0>, pid: #PID<0.117.0>, ref: #Reference<0.323361820.2247360518.21451>}]

        # 2
        nil

    Attempted function clauses (showing 1 out of 1):

        def yield_many(tasks, timeout) when timeout == :infinity or is_integer(timeout) and timeout >= 0

    (elixir) lib/task.ex:759: Task.yield_many/2
    lib/credo/sources.ex:129: Credo.Sources.read_files/2
    lib/credo/cli/task/load_and_validate_source_files.ex:13: anonymous fn/1 in Credo.CLI.Task.LoadAndValidateSourceFiles.call/2
    (stdlib) timer.erl:166: :timer.tc/1
    lib/credo/cli/task/load_and_validate_source_files.ex:11: Credo.CLI.Task.LoadAndValidateSourceFiles.call/2
    lib/credo/execution/task.ex:55: Credo.Execution.Task.do_run/3
    (elixir) lib/enum.ex:1948: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/credo/execution/task.ex:55: Credo.Execution.Task.do_run/3
```

This fixes the issue at hand, but doesn't figure out why that is `nil`
in the first place.