### PR TITLE
Enable by default `UnnecessaryAliasExpansion`

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -110,8 +110,7 @@
         {Credo.Check.Readability.StringSigils, []},
         {Credo.Check.Readability.TrailingBlankLine, []},
         {Credo.Check.Readability.TrailingWhiteSpace, []},
-        # TODO: enable by default in Credo 1.1
-        {Credo.Check.Readability.UnnecessaryAliasExpansion, false},
+        {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
         {Credo.Check.Readability.VariableNames, []},
 
         #


### PR DESCRIPTION
The comment suggests that this should already be a default. Let's make it so.