### PR TITLE
Enable concurrent reads from ETS services, stop GenServer.call timeouts

### DIFF
--- a/lib/credo/service/ets_table_helper.ex
+++ b/lib/credo/service/ets_table_helper.ex
@@ -14,7 +14,13 @@ defmodule Credo.Service.ETSTableHelper do
       end
 
       def get(filename) do
-        GenServer.call(__MODULE__, {:get, filename})
+        case :ets.lookup(@table_name, filename) do
+          [{^filename, value}] ->
+            {:ok, value}
+
+          [] ->
+            :notfound
+        end
       end
 
       def put(filename, value) do
@@ -34,16 +40,6 @@ defmodule Credo.Service.ETSTableHelper do
     ets = :ets.new(table_name, [:named_table, read_concurrency: true])
 
     {:ok, ets}
-  end
-
-  def handle_call(table_name, {:get, filename}, _from, current_state) do
-    case :ets.lookup(table_name, filename) do
-      [{^filename, value}] ->
-        {:reply, {:ok, value}, current_state}
-
-      [] ->
-        {:reply, :notfound, current_state}
-    end
   end
 
   def handle_call(table_name, {:put, filename, value}, _from, current_state) do


### PR DESCRIPTION
Should close #752 

It seems like this sort of solution was intended in the first place: the ets tables are created with `[:named_table, read_concurrency: true]` as options, but the reads are currently serialized through a GenServer the same as the writes are. I can't think of a situation where this would break any credo logic, but at the same time, I don't know the codebase too well.

I checked on the CI mentioned in the original issue and both this PR and it does fix our issue.

The initial workaround of https://github.com/surgeventures/credo/commit/7a4c0abcb921fc3e3558c9d0a8afdbb5d33bc918 works as well, but just increasing GenServer.call timeouts doesn't seem like the right thing to do or like it's a robust solution.

I made the branch off of the `v1.2.2` tag so that we can use the fix instantly without moving on to the `v1.3` RC, but it should work on master all the same.