### PR TITLE
Spawning external executables

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -148,6 +148,7 @@
         {Credo.Check.Warning.UnusedRegexOperation, []},
         {Credo.Check.Warning.UnusedStringOperation, []},
         {Credo.Check.Warning.UnusedTupleOperation, []},
+        {Credo.Check.Warning.UnsafeExec, []},
 
         #
         # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
@@ -172,7 +173,8 @@
         {Credo.Check.Refactor.PipeChainStart, false},
         {Credo.Check.Refactor.VariableRebinding, false},
         {Credo.Check.Warning.MapGetUnsafePass, false},
-        {Credo.Check.Warning.UnsafeToAtom, false}
+        {Credo.Check.Warning.UnsafeToAtom, false},
+        {Credo.Check.Warning.LeakyEnvironment, false}
 
         #
         # Custom checks can be created using `mix credo.gen.check`.

--- a/lib/credo/check/warning/leaky_environment.ex
+++ b/lib/credo/check/warning/leaky_environment.ex
@@ -1,0 +1,76 @@
+defmodule Credo.Check.Warning.LeakyEnvironment do
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    explanations: [
+      check: """
+      OS child processes inherit the environment of their parent process. This
+      includes sensitive configuration parameters, such as credentials. To
+      minimize the risk of such values leaking, clear or overwrite them when
+      spawning executables.
+
+      The `System.cmd/2,3` function allows environment variables be cleared by
+      setting their value to `nil`:
+
+          System.cmd("env", [], env: %{"DB_PASSWORD" => nil})
+
+      """
+    ]
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse({{:., _loc, call}, meta, args} = ast, issues, issue_meta) do
+    case get_forbidden_call(call, args) do
+      nil ->
+        {ast, issues}
+
+      bad ->
+        {ast, issues_for_call(bad, meta, issue_meta, issues)}
+    end
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp get_forbidden_call([{:__aliases__, _, [:System]}, :cmd], [_, _]) do
+    "System.cmd/2"
+  end
+
+  defp get_forbidden_call([{:__aliases__, _, [:System]}, :cmd], [_, _, opts])
+       when is_list(opts) do
+    if Keyword.has_key?(opts, :env) do
+      nil
+    else
+      "System.cmd/3"
+    end
+  end
+
+  defp get_forbidden_call([:erlang, :open_port], [_, opts])
+       when is_list(opts) do
+    if Keyword.has_key?(opts, :env) do
+      nil
+    else
+      ":erlang.open_port/2"
+    end
+  end
+
+  defp get_forbidden_call(_, _) do
+    nil
+  end
+
+  defp issues_for_call(call, meta, issue_meta, issues) do
+    options = [
+      message: "When using #{call}, clear or overwrite sensitive environment variables",
+      trigger: call,
+      line_no: meta[:line]
+    ]
+
+    [format_issue(issue_meta, options) | issues]
+  end
+end

--- a/lib/credo/check/warning/unsafe_exec.ex
+++ b/lib/credo/check/warning/unsafe_exec.ex
@@ -1,0 +1,73 @@
+defmodule Credo.Check.Warning.UnsafeExec do
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    explanations: [
+      check: """
+      Spawning external commands can lead to command injection vulnerabilities.
+      Use a safe API where arguments are passed as an explicit list, rather
+      than unsafe APIs that run a shell to parse the arguments from a single
+      string.
+
+      Safe APIs include:
+
+        * `System.cmd/2,3`
+        * `:erlang.open_port/2`, passing `{:spawn_executable, file_name}` as the
+          first parameter, and any arguments using the `:args` option
+
+      Unsafe APIs include:
+
+        * `:os.cmd/1,2`
+        * `:erlang.open_port/2`, passing `{:spawn, command}` as the first
+          parameter
+
+      """
+    ]
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse({{:., _loc, call}, meta, args} = ast, issues, issue_meta) do
+    case get_forbidden_call(call, args) do
+      {bad, suggestion} ->
+        {ast, issues_for_call(bad, suggestion, meta, issue_meta, issues)}
+
+      nil ->
+        {ast, issues}
+    end
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp get_forbidden_call([:os, :cmd], [_]) do
+    {":os.cmd/1", "System.cmd/2,3"}
+  end
+
+  defp get_forbidden_call([:os, :cmd], [_, _]) do
+    {":os.cmd/2", "System.cmd/2,3"}
+  end
+
+  defp get_forbidden_call([:erlang, :open_port], [{:spawn, _}, _]) do
+    {":erlang.open_port/2 with `:spawn`", ":erlang.open_port/2 with `:spawn_executable`"}
+  end
+
+  defp get_forbidden_call(_, _) do
+    nil
+  end
+
+  defp issues_for_call(call, suggestion, meta, issue_meta, issues) do
+    options = [
+      message: "Prefer #{suggestion} over #{call} to prevent command injection",
+      trigger: call,
+      line_no: meta[:line]
+    ]
+
+    [format_issue(issue_meta, options) | issues]
+  end
+end

--- a/test/credo/check/warning/leaky_environment_test.exs
+++ b/test/credo/check/warning/leaky_environment_test.exs
@@ -1,0 +1,69 @@
+defmodule Credo.Check.Warning.LeakyEnvironmentTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Warning.LeakyEnvironment
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report expected code" do
+    """
+    defmodule CredoSampleModule do
+      def run_with_system_cmd3(executable, arguments) do
+        System.cmd(executable, arguments, env: %{"DB_PASSWORD" => nil})
+      end
+
+      def run_with_erlang_open_port(executable, arguments) do
+        :erlang.open_port({:spawn_executable, executable}, args: arguments, env: [{'DB_PASSWORD', false}])
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report a violation" do
+    """
+    defmodule CredoSampleModule do
+      def run_with_system_cmd2(executable, arguments) do
+        System.cmd(executable, arguments)
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /2" do
+    """
+    defmodule CredoSampleModule do
+      def run_with_system_cmd3(executable, arguments) do
+        System.cmd(executable, arguments, cd: "/tmp")
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /3" do
+    """
+    defmodule CredoSampleModule do
+      def run_with_erlang_open_port(executable, arguments) do
+        :erlang.open_port({:spawn_executable, executable}, args: arguments)
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+end

--- a/test/credo/check/warning/unsafe_exec_test.exs
+++ b/test/credo/check/warning/unsafe_exec_test.exs
@@ -1,0 +1,73 @@
+defmodule Credo.Check.Warning.UnsafeExecTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Warning.UnsafeExec
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report expected code" do
+    """
+    defmodule CredoSampleModule do
+      def run_with_system_cmd2(executable, arguments) do
+        System.cmd(executable, arguments)
+      end
+
+      def run_with_system_cmd3(executable, arguments) do
+        System.cmd(executable, arguments, [])
+      end
+
+      def run_with_erlang_open_port(executable, arguments) do
+        :erlang.open_port({:spawn_executable, executable}, args: arguments)
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report a violation" do
+    """
+    defmodule CredoSampleModule do
+      def run_with_os_cmd(command_line) do
+        :os.cmd(command_line)
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /2" do
+    """
+    defmodule CredoSampleModule do
+      def run_with_os_cmd(command_line) do
+        :os.cmd(command_line, [])
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /3" do
+    """
+    defmodule CredoSampleModule do
+      def run_with_erlang_open_port(command_line) do
+        :erlang.open_port({:spawn, command_line}, [])
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+end


### PR DESCRIPTION
Based on the [Spawning external executables](https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/external_executables) chapter of the [EEF Security WG Secure Coding and Deployment Hardening Guidelines](https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/).