### PR TITLE
Add SourceLevel to Automated Code Review section

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ Some IDEs and editors are able to run Credo in the background and mark issues in
 ### Automated Code Review
 
 * [Codacy](https://www.codacy.com/) - checks your code from style to security, duplication, complexity, and also integrates with coverage.
+* [SourceLevel](https://sourcelevel.io/) - tracks how your code changes over time and have this information accessible to your whole team.
 * [Stickler CI](https://stickler-ci.com/) - checks your code for style and best practices across your entire stack.
 
 ## Contributing


### PR DESCRIPTION
Add SourceLevel to `README` in `Automated Code Review section`, I've followed alphabetical sort order, if you prefer to add to the end of the list, please let me know :)

We're now supporting the latest patch version for each minor version >= 1.0, [see more details in Credo page in our docs](https://docs.sourcelevel.io/engines/credo/).

Feel free to also check out [engine source code](https://github.com/sourcelevel/engine-credo), that runs Credo.

Thank you for the great tool! :heart: 