### PR TITLE
Removed commented out IO.inspect

### DIFF
--- a/lib/credo/code/interpolation_helper.ex
+++ b/lib/credo/code/interpolation_helper.ex
@@ -169,7 +169,6 @@ defmodule Credo.Code.InterpolationHelper do
     {line_no, col_start, line_no_end, col_end} = Token.position(token)
 
     {line_no, col_start, line_no_end, col_end}
-    # |> IO.inspect()
 
     col_end =
       if line_no_end > line_no && col_end == 1 do
@@ -207,6 +206,7 @@ defmodule Credo.Code.InterpolationHelper do
     {line_no, col_start, line_no_end, col_end} = Token.position(token)
 
     {line_no, col_start, line_no_end, col_end}
+
     # |> IO.inspect()
 
     col_end =


### PR DESCRIPTION
`mix format` wanted to add a newline above the commented out IO.inspect, so I removed it instead.

This brings master in line with `mix format`.