### PR TITLE
Ignore module attributes in UnsafeToAtom

### DIFF
--- a/lib/credo/check/warning/unsafe_to_atom.ex
+++ b/lib/credo/check/warning/unsafe_to_atom.ex
@@ -41,6 +41,10 @@ defmodule Credo.Check.Warning.UnsafeToAtom do
     Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
   end
 
+  defp traverse({:@, _, _}, issues, _) do
+    {nil, issues}
+  end
+
   defp traverse({{:., _loc, call}, meta, args} = ast, issues, issue_meta) do
     case get_forbidden_call(call, args) do
       {bad, suggestion} ->

--- a/test/credo/check/warning/unsafe_to_atom_test.exs
+++ b/test/credo/check/warning/unsafe_to_atom_test.exs
@@ -10,6 +10,9 @@ defmodule Credo.Check.Warning.UnsafeToAtomTest do
   test "it should NOT report expected code" do
     """
     defmodule CredoSampleModule do
+      @test_module_attribute String.to_atom("foo")
+      @test_module_attribute2 Jason.decode("", keys: :atoms)
+
       def convert_module(parameter) do
         Module.safe_concat(__MODULE__, parameter)
       end


### PR DESCRIPTION
Module attributes are determined at compile time, so are safe to use without fear of overloading the runtime atom table. This PR ignores module attributes for the UnsafeToAtom check.

Fixes #749