### PR TITLE
Improve strict module layout

### DIFF
--- a/lib/credo/check/readability/strict_module_layout.ex
+++ b/lib/credo/check/readability/strict_module_layout.ex
@@ -61,6 +61,10 @@ defmodule Credo.Check.Readability.StrictModuleLayout do
         Defaults to an empty list.
         """
       ]
+    ],
+    param_defaults: [
+      order: ~w/shortdoc moduledoc behaviour use import alias require/a,
+      ignore: []
     ]
 
   alias Credo.Code

--- a/lib/credo/code/module.ex
+++ b/lib/credo/code/module.ex
@@ -31,6 +31,7 @@ defmodule Credo.Code.Module do
           | :public_guard
           | :private_guard
           | :callback_fun
+          | :callback_macro
           | :module
 
   @type location :: [line: pos_integer, column: pos_integer]
@@ -404,7 +405,7 @@ defmodule Credo.Code.Module do
   defp code_type(:defp, _), do: :private_fun
 
   defp code_type(:defmacro, nil), do: :public_macro
-  defp code_type(:defmacro, :impl), do: :impl
+  defp code_type(:defmacro, :impl), do: :callback_macro
   defp code_type(macro, _) when macro in ~w/defmacro defmacrop/a, do: :private_macro
 
   defp code_type(:defguard, nil), do: :public_guard

--- a/test/credo/check/readability/strict_module_layout_test.exs
+++ b/test/credo/check/readability/strict_module_layout_test.exs
@@ -207,4 +207,37 @@ defmodule Credo.Check.Readability.StrictModuleLayoutTest do
       assert issue2.line_no == 4
     end
   end
+
+  describe "ignored parts" do
+    test "no errors are reported on ignored parts" do
+      """
+      defmodule Test do
+        alias Foo
+        import Bar
+        use Baz
+        require Qux
+      end
+      """
+      |> to_source_file
+      |> run_check(@described_check, ignore: ~w/use import/a)
+      |> refute_issues
+    end
+
+    test "reports errors on non-ignored parts" do
+      [issue] =
+        """
+        defmodule Test do
+          require Qux
+          import Bar
+          use Baz
+          alias Foo
+        end
+        """
+        |> to_source_file
+        |> run_check(@described_check, ignore: ~w/use import/a)
+        |> assert_issue
+
+      assert issue.message == "alias must appear before require"
+    end
+  end
 end

--- a/test/credo/check/readability/strict_module_layout_test.exs
+++ b/test/credo/check/readability/strict_module_layout_test.exs
@@ -146,6 +146,32 @@ defmodule Credo.Check.Readability.StrictModuleLayoutTest do
 
       assert issue.message == "alias must appear before require"
     end
+
+    test "callback functions and macros are handled by the `:callback_impl` option" do
+      assert [issue1, issue2] =
+               """
+               defmodule Test do
+                 @impl true
+                 def foo
+
+                 def baz, do: :ok
+
+                 @impl true
+                 defmacro bar
+
+                 def qux, do: :ok
+               end
+               """
+               |> to_source_file
+               |> run_check(@described_check, order: ~w/public_fun callback_impl/a)
+               |> assert_issues
+
+      assert issue1.message == "public function must appear before callback implementation"
+      assert issue1.scope == "Test.baz"
+
+      assert issue2.message == "public function must appear before callback implementation"
+      assert issue2.scope == "Test.qux"
+    end
   end
 
   describe "custom order" do

--- a/test/credo/check/readability/strict_module_layout_test.exs
+++ b/test/credo/check/readability/strict_module_layout_test.exs
@@ -206,6 +206,23 @@ defmodule Credo.Check.Readability.StrictModuleLayoutTest do
       assert issue2.message == "public function must appear before private function"
       assert issue2.line_no == 4
     end
+
+    test "treats `:callback_fun` as `:callback_impl` for backward compatibility" do
+      [issue] =
+        """
+        defmodule Test do
+          @impl Foo
+          def foo, do: :ok
+
+          def bar, do: :ok
+        end
+        """
+        |> to_source_file
+        |> run_check(@described_check, order: ~w/public_fun callback_fun/a)
+        |> assert_issue
+
+      assert issue.message == "public function must appear before callback implementation"
+    end
   end
 
   describe "ignored parts" do

--- a/test/credo/code/module_test.exs
+++ b/test/credo/code/module_test.exs
@@ -488,6 +488,11 @@ defmodule Credo.Code.ModuleTest do
                [{Test, [private_macro: [line: 3, column: 3]]}]
     end
 
+    test "interprets defmacro marked with @impl as callback macro" do
+      assert analyze(~s/@impl true\ndefmacro x, do: true/) ==
+               [{Test, [callback_macro: [line: 3, column: 3]]}]
+    end
+
     test "recognizes def" do
       assert analyze(~s/def x, do: true/) == [{Test, [public_fun: [line: 2, column: 3]]}]
     end


### PR DESCRIPTION
This PR brings in a few minor changes/additions to the `StrictModuleLayout` check. These additions are motivated by the real usage in the project of my client (which is where the original implementation of this check was done).

Note that these changes weren't discussed in any issue so far. However, to better understand the issues, I experimented with a fix, and so I ended up with the solution here, and then I figured I may as well submit it :-) That said, I'm not insisting on these changes, and so if you have some other ideas feel free to propose them.

Anyway, here are the changes:

1. Callback macros and callback functions are bundled under the same key `callback_impl`. In other words, with this change we can't enforce that e.g. callback macros must preceed callback functions. The reason is because a single module could implement multiple behaviours, and then such order becomes counterproductive, because we typically want to group callbacks by the module (e.g. first all callbacks of `Foo`, then all callbacks of `Bar`).
2. Added the `:ignore` option which allows us to ignore some module parts (i.e. allow some parts to appear anywhere in the module). For my client's projects, the concrete example would be private macros.