### PR TITLE
Add note to end of execution noting `mix credo explain`

### DIFF
--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -10,6 +10,7 @@ defmodule Credo.CLI.Output.Summary do
     {:readability, "code readability issue", "code readability issues"},
     {:design, "software design suggestion", "software design suggestions"}
   ]
+  @get_more_details "For more information including configuration options on a specific issue, run `mix credo explain <location-of-issue>`"
   @cry_for_help "Please report incorrect results: https://github.com/rrrene/credo/issues"
 
   alias Credo.CLI.Output
@@ -34,6 +35,11 @@ defmodule Credo.CLI.Output.Summary do
     issues = Execution.get_issues(exec)
     source_file_count = exec |> Execution.get_source_files() |> Enum.count()
     checks_count = count_checks(exec)
+
+    if issues != [] do
+      UI.puts()
+      UI.puts([:reset, @get_more_details])
+    end
 
     UI.puts()
     UI.puts([:faint, @cry_for_help])


### PR DESCRIPTION
Adds note to end of execution noting the `mix credo explain` feature. Only appears when at least one issue is found. Fixes #751.

![Screen Shot 2020-04-16 at 12 07 12 PM](https://user-images.githubusercontent.com/8557871/79479672-1ed40c00-7fdb-11ea-8b39-1f83a31c08ee.png)
