### PR TITLE
Add explicit default to Refactor.VariableRebinding check's allow_bang option

### DIFF
--- a/lib/credo/check/refactor/variable_rebinding.ex
+++ b/lib/credo/check/refactor/variable_rebinding.ex
@@ -1,6 +1,7 @@
 defmodule Credo.Check.Refactor.VariableRebinding do
   use Credo.Check,
     tags: [:controversial],
+    param_defaults: [allow_bang: false],
     explanations: [
       check: """
       You might want to refrain from rebinding variables.


### PR DESCRIPTION
This was incorrectly surfaced as a warning in an app I work on after upgrading to `v1.4.0`:

    $ mix credo
    ** (config) Credo.Check.Refactor.VariableRebinding: unknown param `allow_bang`.
