### PR TITLE
Check for `===` as well as `==` in empty enum check

### DIFF
--- a/lib/credo/check/warning/expensive_empty_enum_check.ex
+++ b/lib/credo/check/warning/expensive_empty_enum_check.ex
@@ -37,10 +37,12 @@ defmodule Credo.Check.Warning.ExpensiveEmptyEnumCheck do
     {@length_pattern, 0},
     {0, @length_pattern}
   ]
+  @operators [:==, :===]
 
-  for {lhs, rhs} <- @comparisons do
+  for {lhs, rhs} <- @comparisons,
+      operator <- @operators do
     defp traverse(
-           {:==, meta, [unquote(lhs), unquote(rhs)]} = ast,
+           {unquote(operator), meta, [unquote(lhs), unquote(rhs)]} = ast,
            issues,
            issue_meta
          ) do

--- a/test/credo/check/warning/expensive_empty_enum_check_test.exs
+++ b/test/credo/check/warning/expensive_empty_enum_check_test.exs
@@ -138,4 +138,21 @@ defmodule Credo.Check.Warning.ExpensiveEmptyEnumCheckTest do
     |> run_check(@described_check)
     |> assert_issue()
   end
+
+  test "it should report when checking if length is 0 with triple-equals" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(some_list) do
+        if length(some_list) === 0 do
+          "empty"
+        else
+          "not empty"
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
 end


### PR DESCRIPTION
At the moment, credo warns on 
```elixir
length(some_list) == 0
```

After this change, it will also warn on
```elixir
length(some_list) === 0
```