### PR TITLE
Correctly deduplicate multiclauses

### DIFF
--- a/test/credo/code/module_test.exs
+++ b/test/credo/code/module_test.exs
@@ -511,6 +511,30 @@ defmodule Credo.Code.ModuleTest do
                [{Test, [callback_fun: [line: 3, column: 3]]}]
     end
 
+    test "deduplicates multiclauses" do
+      assert analyze("""
+             def a(1), do: true
+             def a(2), do: false
+
+             @impl true
+             def b(1), do: true
+             def b(2), do: false
+
+             @doc false
+             def c(1), do: true
+             def c(2), do: false
+
+             defp d(1), do: true
+             defp d(2), do: false
+             """) == [
+               {Test,
+                public_fun: [line: 2, column: 3],
+                callback_fun: [line: 6, column: 3],
+                private_fun: [line: 10, column: 3],
+                private_fun: [line: 13, column: 3]}
+             ]
+    end
+
     test "handles multiple modules" do
       full_source =
         """


### PR DESCRIPTION
In the previous version, module part analysis would treat multiclauses as distinct functions. That cause problems with the `StrictModuleLayout`.

For example:

```elixir
@impl
def handle_call(...), do:
def handle_call(...), do:
```

The second clause would be incorrectly interpreted as a public function.