### PR TITLE
Improve performance

### DIFF
--- a/lib/credo/priority.ex
+++ b/lib/credo/priority.ex
@@ -71,6 +71,7 @@ defmodule Credo.Priority do
 
   defp make_base_map(priority_list, %SourceFile{} = source_file) do
     ast = SourceFile.ast(source_file)
+    scope_info_list = Scope.scope_info_list(ast)
 
     priority_list
     |> Enum.with_index()
@@ -80,7 +81,7 @@ defmodule Credo.Priority do
           nil
 
         _ ->
-          {_, scope_name} = Scope.name(ast, line: index + 1)
+          {_, scope_name} = Scope.name_from_scope_info_list(scope_info_list, index + 1)
           {scope_name, Enum.sum(list)}
       end
     end)


### PR DESCRIPTION
On a larger test file from a real world project (3600 LOC) this reduces the credo check time from what seems like an infinity (I didn't have the patience to let it finish) to 4.7 seconds.

I feel there's some more room for improvements, but this is already a solid gain, while the change is simple enough, so I'm submitting it now. 

Time-permitting I might analyze perf further, but I can't commit. I advise opening up an ongoing issue for this, and establishing some benchmarks, especially for situations when the input file is large, and when there are a lot of issues.

My impression (based on a very shallow walk through a small part of the code) is that credo might not handle such scenarios quite well. I've see some `++` appends performed during traversals, and random-access writes performed on lists, which might significantly affect performance with larger inputs.