### PR TITLE
use created expanded filename path

### DIFF
--- a/lib/credo/config_builder.ex
+++ b/lib/credo/config_builder.ex
@@ -28,7 +28,7 @@ defmodule Credo.ConfigBuilder do
     if is_binary(config_filename) do
       filename = Path.expand(config_filename)
 
-      ConfigFile.read_from_file_path(exec, dir, config_filename, config_name)
+      ConfigFile.read_from_file_path(exec, dir, filename, config_name)
     else
       ConfigFile.read_or_default(exec, dir, config_name)
     end


### PR DESCRIPTION
 - private fn get_config_file/2 in Credo.ConfigBuilder created the
   var `filename` for the expanded path of `config_file` but was not
   used and resulted in a warning.