### PR TITLE
fix Elixir formatter asterisk spacing conflict

### DIFF
--- a/lib/credo/check/consistency/space_around_operators.ex
+++ b/lib/credo/check/consistency/space_around_operators.ex
@@ -112,7 +112,20 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators do
     !number_in_function_capture?(line, column)
   end
 
+  defp create_issue?(line, _column, trigger) when trigger == :* do
+    # The Elixir formatter always removes spaces around the asterisk in
+    # typespecs for binaries by default. Credo shouldn't conflict with the
+    # default Elixir formatter settings.
+    !typespec_binary_unit_operator_without_spaces?(line)
+  end
+
   defp create_issue?(_, _, _), do: true
+
+  defp typespec_binary_unit_operator_without_spaces?(line) do
+    # In code this construct can only appear inside a binary typespec. It could
+    # also appear verbatim in a string, but it's rather unlikely...
+    line =~ "_::_*"
+  end
 
   defp arrow_in_typespec?(line, column) do
     # -2 because we need to subtract the operator

--- a/test/credo/check/consistency/space_around_operators_test.exs
+++ b/test/credo/check/consistency/space_around_operators_test.exs
@@ -207,6 +207,14 @@ defmodule Credo.Check.Consistency.SpaceAroundOperatorsTest do
     """
   end
 
+  @with_spaces7 """
+  defmodule AlwaysNoSpacesInBinaryTypespecTest do
+    @callback foo() :: <<_::_*8>>
+
+    def foo, do: 1 + 1
+  end
+  """
+
   @with_and_without_spaces """
   defmodule OtherModule3 do
     defmacro foo do
@@ -360,6 +368,13 @@ defmodule Credo.Check.Consistency.SpaceAroundOperatorsTest do
       %{acc | "#{date_type}_dates": :foo}
       """
     ]
+    |> to_source_files()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should always allow no spaces in binary typespec" do
+    [@with_spaces7]
     |> to_source_files()
     |> run_check(@described_check)
     |> refute_issues()


### PR DESCRIPTION
The Elixir formatter always removes spaces around the asterisk in
typespecs for binaries by default. Credo shouldn't conflict with the
default Elixir formatter settings, but it raises an issue if the rest of
the file is using spaces around operators.

This PR adds handling of this corner case.