### PR TITLE
Properly handle lack of parens in spec check

### DIFF
--- a/lib/credo/check/readability/specs.ex
+++ b/lib/credo/check/readability/specs.ex
@@ -44,7 +44,8 @@ defmodule Credo.Check.Readability.Specs do
   end
 
   defp find_specs({:spec, _, [{_, _, [{name, _, args} | _]}]} = ast, specs)
-       when is_list(args) do
+       when is_list(args) or is_nil(args) do
+    args = with nil <- args, do: []
     {ast, [{name, length(args)} | specs]}
   end
 
@@ -84,7 +85,9 @@ defmodule Credo.Check.Readability.Specs do
          specs,
          issue_meta
        )
-       when is_list(args) do
+       when is_list(args) or is_nil(args) do
+    args = with nil <- args, do: []
+
     if {name, length(args)} in specs do
       {ast, issues}
     else

--- a/test/credo/check/readability/specs_test.exs
+++ b/test/credo/check/readability/specs_test.exs
@@ -133,4 +133,27 @@ defmodule Credo.Check.Readability.SpecsTest do
     |> run_check(@described_check)
     |> assert_issue()
   end
+
+  test "it should report function with arity zero and no parentheses" do
+    """
+    defmodule CredoTypespecTest do
+      def foo, do: :ok
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should NOT report function with arity zero and a spec with no parentheses" do
+    """
+    defmodule CredoTypespecTest do
+      @spec foo :: :ok
+      def foo, do: :ok
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
 end


### PR DESCRIPTION
Fixes a bug in `Credo.Check.Readability.Specs`, where a parensless definition (i.e. `def foo do ... end`) was not accounted for.