### PR TITLE
Add Emacs as a supported editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Some IDEs and editors are able to run Credo in the background and mark issues in
 * [IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir#credo) - Elixir plugin for JetBrains IDEs (IntelliJ IDEA, Rubymine, PHPStorm, PyCharm, etc)
 * [linter-elixir-credo](https://atom.io/packages/linter-elixir-credo) - Package for Atom editor (by @smeevil)
 * [ElixirLinter](https://marketplace.visualstudio.com/items?itemName=iampeterbanjo.elixirlinter) - VSCode plugin (by @iampeterbanjo)
+* [flycheck](https://www.flycheck.org/en/latest/languages.html#elixir) - Emacs syntax checking extension
 
 ### Automated Code Review
 


### PR DESCRIPTION
Emacs has support for credo with the flycheck plugin
https://www.flycheck.org/en/latest/languages.html#elixir