### PR TITLE
add recommended Elixir and Erlang/OTP combinations to CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -36,7 +36,6 @@ jobs:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
       - run: ./test/smoke_test.sh
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -51,7 +51,10 @@ jobs:
           otp-version: 23.0.2
           elixir-version: 1.10.3
       - run: mix deps.get
-      - run: mix compile --warnings-as-errors
+      - run: mix compile
+        env:
+          ELIXIRC_OPTS: "--warnings-as-errors"
+          ERLC_OPTS: "warnings_as_errors"
 
   check_formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -45,6 +45,8 @@ jobs:
       - run: ./test/smoke_test.sh
 
   compile_with_no_warnings:
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v2.3.1
 
       - uses: actions/setup-elixir@v1.3
@@ -57,6 +59,8 @@ jobs:
       - run: mix compile --warnings-as-errors
 
   check_formatting:
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v2.3.1
 
       - uses: actions/setup-elixir@v1.3

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -30,11 +30,11 @@ jobs:
           - otp: 23.0.2
             elixir: 1.10.3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.1
 
-      - uses: actions/setup-elixir@v1
+      - uses: actions/setup-elixir@v1.3
         with:
-          otp: ${{matrix.otp}}
+          otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
       - run: mix deps.get

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -37,8 +37,6 @@ jobs:
       - run: mix deps.compile
 
       - run: mix compile
-
-      - run: mix compile --warnings-as-errors
         env:
           MIX_ENV: test
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,29 +14,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [20.3, 21.3, 22.2]
-        elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.0]
+        include:
+          - otp: 18.3.4.11
+            elixir: 1.5.3
+          - otp: 19.3.6.13
+            elixir: 1.6.6
+          - otp: 19.3.6.13
+            elixir: 1.7.4
+          - otp: 20.3.8.26
+            elixir: 1.8.2
+          - otp: 20.3.8.26
+            elixir: 1.9.4
+          - otp: 21.3.8.16
+            elixir: 1.10.3
+          - otp: 23.0.2
+            elixir: 1.10.3
     steps:
       - uses: actions/checkout@v2
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
 
       - uses: actions/setup-elixir@v1
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
         with:
-          otp-version: ${{matrix.otp}}
+          otp: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
       - run: mix deps.get
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
 
       - run: mix deps.compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
 
       - run: mix compile --warnings-as-errors
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
 
       - run: mix test
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"
 
       - run: ./test/smoke_test.sh
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.0')"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -60,3 +60,13 @@ jobs:
       - run: mix deps.get
 
       - run: mix compile --warnings-as-errors
+
+  check_formatting:
+      - uses: actions/checkout@v2.3.1
+
+      - uses: actions/setup-elixir@v1.3
+        with:
+          otp-version: 23.0.2
+          elixir-version: 1.10.3
+
+      - run: mix format --check-formatted

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,11 @@
 name: "CI Tests"
-
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -44,7 +44,7 @@ jobs:
       - run: mix compile
         env:
           MIX_ENV: test
-
+      - run: mix test
       - run: ./test/smoke_test.sh
 
   compile_with_no_warnings:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -37,12 +37,14 @@ jobs:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
-      - run: mix deps.get
+      - run: mix deps.get --only test
 
       - run: mix deps.compile
 
       - run: mix compile --warnings-as-errors
 
       - run: mix test
+        env:
+          MIX_ENV: test
 
       - run: ./test/smoke_test.sh

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,9 +26,9 @@ jobs:
           - otp: 20.3.8.26
             elixir: 1.9.4
           - otp: 21.3.8.16
-            elixir: 1.10.3
+            elixir: 1.10.4
           - otp: 23.0.2
-            elixir: 1.10.3
+            elixir: 1.10.4
     steps:
       - uses: actions/checkout@v2.3.1
       - uses: actions/setup-elixir@v1.3
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/setup-elixir@v1.3
         with:
           otp-version: 23.0.2
-          elixir-version: 1.10.3
+          elixir-version: 1.10.4
       - run: mix deps.get
       - run: mix compile
         env:
@@ -60,5 +60,5 @@ jobs:
       - uses: actions/setup-elixir@v1.3
         with:
           otp-version: 23.0.2
-          elixir-version: 1.10.3
+          elixir-version: 1.10.4
       - run: mix format --check-formatted

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -31,16 +31,11 @@ jobs:
             elixir: 1.10.3
     steps:
       - uses: actions/checkout@v2.3.1
-
       - uses: actions/setup-elixir@v1.3
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-
       - run: mix deps.get --only test
-
-      - run: mix deps.compile
-
       - run: mix compile
         env:
           MIX_ENV: test
@@ -51,24 +46,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.1
-
       - uses: actions/setup-elixir@v1.3
         with:
           otp-version: 23.0.2
           elixir-version: 1.10.3
-
       - run: mix deps.get
-
       - run: mix compile --warnings-as-errors
 
   check_formatting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.1
-
       - uses: actions/setup-elixir@v1.3
         with:
           otp-version: 23.0.2
           elixir-version: 1.10.3
-
       - run: mix format --check-formatted

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,11 +1,6 @@
 name: "CI Tests"
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -35,10 +35,8 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-      - run: mix deps.get --only test
+      - run: mix deps.get
       - run: mix compile
-        env:
-          MIX_ENV: test
       - run: mix test
       - run: ./test/smoke_test.sh
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -41,10 +41,22 @@ jobs:
 
       - run: mix deps.compile
 
-      - run: mix compile --warnings-as-errors
+      - run: mix compile
 
-      - run: mix test
+      - run: mix compile --warnings-as-errors
         env:
           MIX_ENV: test
 
       - run: ./test/smoke_test.sh
+
+  compile_with_no_warnings:
+      - uses: actions/checkout@v2.3.1
+
+      - uses: actions/setup-elixir@v1.3
+        with:
+          otp-version: 23.0.2
+          elixir-version: 1.10.3
+
+      - run: mix deps.get
+
+      - run: mix compile --warnings-as-errors

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -15,11 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - otp: 18.3.4.11
+          - otp: 20.3.8.26
             elixir: 1.5.3
-          - otp: 19.3.6.13
+          - otp: 20.3.8.26
             elixir: 1.6.6
-          - otp: 19.3.6.13
+          - otp: 20.3.8.26
             elixir: 1.7.4
           - otp: 20.3.8.26
             elixir: 1.8.2

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "[${{matrix.otp}}/${{matrix.elixir}}] CI Tests on Credo [OTP/Elixir]"
     strategy:
+      fail-fast: false
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.0]

--- a/mix.exs
+++ b/mix.exs
@@ -119,7 +119,7 @@ defmodule Credo.Mixfile do
     [
       {:bunt, "~> 0.2.0"},
       {:jason, "~> 1.0"},
-      {:ex_doc, "~> 0.21", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.21", only: [:dev, :test], runtime: false},
       {:inch_ex, "~> 0.1", only: [:dev, :test], runtime: false}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -119,7 +119,7 @@ defmodule Credo.Mixfile do
     [
       {:bunt, "~> 0.2.0"},
       {:jason, "~> 1.0"},
-      {:ex_doc, "~> 0.21", only: [:dev, :test], runtime: false},
+      {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:inch_ex, "~> 0.1", only: [:dev, :test], runtime: false}
     ]
   end

--- a/test/smoke_test.sh
+++ b/test/smoke_test.sh
@@ -4,8 +4,6 @@ set -e
 
 GENEREATE_CREDO_CHECK="lib/my_first_credo_check.ex"
 
-mix compile --force --warnings-as-errors
-
 mix credo --mute-exit-status
 mix credo --strict --mute-exit-status
 mix credo --strict --enable-disabled-checks . --mute-exit-status


### PR DESCRIPTION
### Main course

Make sure all recommended Elixir and Erlang/OTP combinations are run on CI

Quoting @josevalim:
> I would still advise folks to go with:
> * For each Elixir version, add a run with earliest supported Erlang/OTP
> * For the last Elixir version, also test the latest supported Erlang/OTP

Please refer to the original discussion on https://github.com/dashbitco/broadway/pull/188 for the full rationale.

### Side dish

This pull request also
- updates [actions/setup-elixir](https://github.com/actions/setup-elixir) and [actions/checkout](https://github.com/actions/checkout) to their latest versions
- restricts compilation with `--warnings-as-errors` to the latest Elixir version, on a separate CI job, following [suggestion](https://github.com/whatyouhide/stream_data/pull/142#discussion_r444396899) by @whatyouhide 
- add CI job to check formatting (`mix format --check-formatted`) on the latest Elixir version