### PR TITLE
disable fail-fast strategy to Erlang/OTP x Elixir version matrix

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "[${{matrix.otp}}/${{matrix.elixir}}] CI Tests on Credo [OTP/Elixir]"
     strategy:
+      fail-fast: false
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -10,6 +10,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Elixir ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
+      fail-fast: false
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Phoenix ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
+      fail-fast: false
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]


### PR DESCRIPTION
The change in this pull request, which was extracted from https://github.com/rrrene/credo/pull/785, prevents that all in-progress jobs are cancelled if any matrix job fails. The rationale is to save developers time, at the potential expense of computation power, by maximizing the amount of information extracted at once.

Particularly useful for a project that, such as this, often have a broken master:
![image](https://user-images.githubusercontent.com/456804/87738332-86088480-c7b3-11ea-9b10-da9c80489eff.png)

References:
- [Workflow syntax for GitHub Actions - GitHub Docs - jobs.<job_id>.strategy.fail-fast](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)
- [How to avoid broken master with Pipelines for Merged Results and Merge Trains | GitLab](https://about.gitlab.com/releases/2019/09/11/how-to-avoid-broken-master-with-pipelines-for-merge-requests/)