### PR TITLE
add Elixir 1.5.3, supported according to mix.exs, to CI version matrix

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -15,6 +15,11 @@ jobs:
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.5.3, 1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        exclude:
+          - otp: 21.3
+            elixir: 1.5.3
+          - otp: 22.2
+            elixir: 1.5.3
     steps:
       - uses: actions/checkout@v2
         if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         otp: [20.3, 21.3, 22.2]
-        elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        elixir: [1.5.3, 1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
     steps:
       - uses: actions/checkout@v2
         if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         otp: [20.3, 21.3, 22.2]
-        elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        elixir: [1.5.3, 1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
         repo_branch: ["v1.10", "master"]
     steps:

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -13,6 +13,11 @@ jobs:
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.5.3, 1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        exclude:
+          - otp: 21.3
+            elixir: 1.5.3
+          - otp: 22.2
+            elixir: 1.5.3
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
         repo_branch: ["v1.10", "master"]
     steps:

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -12,6 +12,11 @@ jobs:
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.5.3, 1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        exclude:
+          - otp: 21.3
+            elixir: 1.5.3
+          - otp: 22.2
+            elixir: 1.5.3
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
         repo_branch: ["v1.4", "master"]
     steps:

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         otp: [20.3, 21.3, 22.2]
-        elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        elixir: [1.5.3, 1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
         repo_branch: ["v1.4", "master"]
     steps:


### PR DESCRIPTION
Add Elixir version 1.5.3, which according to `mix.exs` is supported by credo, to the CI Elixir x Erlang/OTP version matrix.

Warning: there are some combinations (none added by this pull request) that are not compatible according to [Compatibility and Deprecations — Elixir v1.10.4](https://hexdocs.pm/elixir/compatibility-and-deprecations.html)  (e.g., Elixir 1.5 & Erlang/OTP 22), but @rrrene [disapproved](https://github.com/rrrene/credo/pull/785#issuecomment-659462251) the [non-cartesian-product approach](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations) to Elixir × Erlang/OTP version matrix, so I am waiting for him to suggest a workaround more to his liking. Maybe using the cartesian approach + [exclusion](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-excluding-configurations-from-a-matrix) for filtering?

This pull request was extracted (deformed) from https://github.com/rrrene/credo/pull/785.