### PR TITLE
exclude from CI matrix incompatible Elixir x Erlang/OTP version combinations

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -15,6 +15,9 @@ jobs:
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        exclude:
+          - otp: 22.2
+            elixir: 1.6.6
     steps:
       - uses: actions/checkout@v2
         if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        exclude:
+          - otp: 22.2
+            elixir: 1.6.6
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
         repo_branch: ["v1.10", "master"]
     steps:

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        exclude:
+          - otp: 22.2
+            elixir: 1.6.6
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
         repo_branch: ["v1.4", "master"]
     steps:


### PR DESCRIPTION
This pull request [exclude](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-excluding-configurations-from-a-matrix) from the CI matrix, Elixir x Erlang/OTP version combinations that are not compatible according to [Compatibility and Deprecations — Elixir v1.10.4](https://hexdocs.pm/elixir/compatibility-and-deprecations.html)  (e.g., Elixir 1.6 & Erlang/OTP 22).

This pull request is related to https://github.com/rrrene/credo/pull/785.