### PR TITLE
refactor the exclusion of specific Elixir x Erlang/OTP version combinations from the CI matrix

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -15,27 +15,23 @@ jobs:
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        exclude:
+          - otp: 20.3
+            elixir: 1.10.4
     steps:
       - uses: actions/checkout@v2
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - uses: actions/setup-elixir@v1
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
       - run: mix deps.get
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mix deps.compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mix compile --warnings-as-errors
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mix test
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: ./test/smoke_test.sh
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -13,31 +13,26 @@ jobs:
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        exclude:
+          - otp: 20.3
+            elixir: 1.10.4
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
         repo_branch: ["v1.10", "master"]
     steps:
       - uses: actions/checkout@v2
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
       - uses: actions/setup-elixir@v1
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
       - run: mix deps.get
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mix deps.compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mix compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mkdir -p tmp
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: git clone ${{matrix.repo_url}} tmp/${{matrix.repo_branch}} --depth=1 --branch ${{matrix.repo_branch}}
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mix credo tmp/${{matrix.repo_branch}} --strict --mute-exit-status
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -12,34 +12,29 @@ jobs:
       matrix:
         otp: [20.3, 21.3, 22.2]
         elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4, 1.10.4]
+        exclude:
+          - otp: 20.3
+            elixir: 1.10.4
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
         repo_branch: ["v1.4", "master"]
     steps:
       - uses: actions/checkout@v2
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
       - uses: actions/setup-elixir@v1
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
       - run: mix deps.get
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mix deps.compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mix compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mkdir -p tmp
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: git clone ${{matrix.repo_url}} tmp/${{matrix.repo_branch}} --depth=1 --branch ${{matrix.repo_branch}}
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mix credo tmp/${{matrix.repo_branch}} --strict --mute-exit-status
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
   test_on_new_project:
     runs-on: ubuntu-latest
@@ -50,21 +45,15 @@ jobs:
         elixir: [1.6.6, 1.7.2, 1.8.2, 1.9.4]
     steps:
       - uses: actions/checkout@v2
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
       - uses: actions/setup-elixir@v1
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
       - run: mix deps.get
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mix deps.compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: mix compile
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"
 
       - run: ./test/test_phoenix_compatibility.sh
-        if: "!(matrix.otp == '20.3' && matrix.elixir == '1.10.4')"


### PR DESCRIPTION
This pull request refactor the exclusion of specific Elixir x Erlang/OTP version combinations from the CI matrix making it _way_ more DRY by making use of [exclude](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-excluding-configurations-from-a-matrix) option.

This pull request is related to https://github.com/rrrene/credo/pull/785.