### PR TITLE
Add name of check to message when printing issues

### DIFF
--- a/lib/credo/cli/command/suggest/output/default.ex
+++ b/lib/credo/cli/command/suggest/output/default.ex
@@ -173,7 +173,7 @@ defmodule Credo.CLI.Command.Suggest.Output.Default do
            priority: priority
          } = issue,
          source_file,
-         %Execution{format: _} = exec,
+         %Execution{format: _, verbose: verbose} = exec,
          term_width
        ) do
     outer_color = Output.check_color(issue)
@@ -186,6 +186,13 @@ defmodule Credo.CLI.Command.Suggest.Output.Default do
         :faint
       else
         :bright
+      end
+
+    message =
+      if verbose do
+        message <> " (" <> inspect(check) <> ")"
+      else
+        message
       end
 
     message


### PR DESCRIPTION
For a number of the checks, it is not clear which specific check you are dealing with when reading through the output in Credo. I have a few times had to copy the error message, then search for it in credo source to figure out which one it is. This PR simply notes the name of the check in parenthesis after the message.

Example:
<img width="1004" alt="Screen Shot 2020-07-31 at 12 47 37 PM" src="https://user-images.githubusercontent.com/8557871/89057679-10142980-d32c-11ea-9017-b108bf3f58e3.png">
