### PR TITLE
Add SkipTestWithoutComment check to warn if no comment precedes `@tag :skip` in a test

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -83,6 +83,7 @@
         #
         {Credo.Check.Design.AliasUsage,
          [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+        {Credo.Check.Design.SkipTestWithoutComment, []},
         # You can also customize the exit_status of each check.
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).

--- a/lib/credo/check/design/skip_test_without_comment.ex
+++ b/lib/credo/check/design/skip_test_without_comment.ex
@@ -1,0 +1,68 @@
+defmodule Credo.Check.Design.SkipTestWithoutComment do
+  use Credo.Check,
+    base_priority: :normal,
+    explanations: [
+      check: """
+      Skipped tests should have a comment documenting why the test is skipped. Tests are often skipped using `@tag :skip` when some issue
+      arises that renders the test temporarily broken or unable to run. This temporary skip often becomes permanent because the reason
+      for the test being skipped is not documented. A comment should exist on the line prior to the skip tag describing why the test is
+      skipped, making future removal of the tag more likely. For example:
+
+          # Our credentials expired, working on getting new ones
+          @tag :skip
+          test "vendor api returns data" do
+            ...
+
+      """
+    ]
+
+  alias Credo.Code.Heredocs
+
+  @doc false
+  @impl true
+  def run(%SourceFile{filename: filename} = source_file, params) do
+    if is_nil(filename) or !String.ends_with?(filename, "_test.exs") do
+      []
+    else
+      issue_meta = IssueMeta.for(source_file, params)
+
+      source_file
+      |> Heredocs.replace_with_spaces()
+      |> String.split("\n")
+      |> Enum.with_index(1)
+      |> Enum.map(&transform_line/1)
+      |> check_lines([], issue_meta)
+    end
+  end
+
+  @tag_skip_regex ~r/^\s*\@tag :skip($|[ \t]+.*$)/
+  @comment_regex ~r/^\s*\#.*$/
+
+  def transform_line({line, line_number}) do
+    cond do
+      line =~ @tag_skip_regex -> {:tag_skip, line_number}
+      line =~ @comment_regex -> {:comment, line_number}
+      true -> {nil, line_number}
+    end
+  end
+
+  def check_lines([{:tag_skip, line_number} | rest], issues, issue_meta) do
+    check_lines(rest, [issue_for(issue_meta, line_number) | issues], issue_meta)
+  end
+
+  def check_lines([{:comment, _}, {:tag_skip, _} | rest], issues, issue_meta) do
+    check_lines(rest, issues, issue_meta)
+  end
+
+  def check_lines([_hd | tl], issues, issue_meta), do: check_lines(tl, issues, issue_meta)
+  def check_lines([], issues, _issue_meta), do: issues
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue(
+      issue_meta,
+      message: "@tag :skip should have a comment preceding it explaining the :skip",
+      trigger: "@tag :skip",
+      line_no: line_no
+    )
+  end
+end

--- a/test/credo/check/design/skip_without_comment_test.exs
+++ b/test/credo/check/design/skip_without_comment_test.exs
@@ -1,0 +1,57 @@
+defmodule Credo.Check.Design.SkipTestWithoutCommentTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Design.SkipTestWithoutComment
+
+  test "it should NOT report when comment preceeds the tag" do
+    """
+    defmodule CredoSampleModuleTest do
+      alias ExUnit.Case
+
+      # Some comment
+      @tag :skip
+      test "foo" do
+        :ok
+      end
+
+    end
+    """
+    |> to_source_file("foo_test.exs")
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report non-test files" do
+    """
+    defmodule CredoSampleModuleTest do
+      alias ExUnit.Case
+
+      @tag :skip
+      test "foo" do
+        :ok
+      end
+
+    end
+    """
+    |> to_source_file("foo.ex")
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should report a violation" do
+    """
+    defmodule CredoSampleModuleTest do
+      alias ExUnit.Case
+
+      @tag :skip
+      test "foo" do
+        :ok
+      end
+
+    end
+    """
+    |> to_source_file("foo_test.exs")
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+end


### PR DESCRIPTION
"temporarily" skipped tests can become permanent fixtures in a codebase because the reason for the skip can be forgotten. Ideally skips should not be long-lived, so if you do have to skip a test, you should document why it is being skipped so the skip can be cleared as soon as possible. This check warns if there is not a comment on the line preceding the skip.