### PR TITLE
Fixes the link for testing_checks HTML file

### DIFF
--- a/guides/custom_checks/adding_checks.md
+++ b/guides/custom_checks/adding_checks.md
@@ -278,4 +278,4 @@ defmodule MyProject.Checks.RejectModuleAttributes do
 end
 ```
 
-Next, let's see how we can [write tests for our custom check!](testing.html)
+Next, let's see how we can [write tests for our custom check!](testing_checks.html)


### PR DESCRIPTION
Fixes the link from https://hexdocs.pm/credo/testing.html to https://hexdocs.pm/credo/testing_checks.html in https://hexdocs.pm/credo/adding_checks.html page.