### PR TITLE
Add check for capitalized start of the code comments

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -163,6 +163,7 @@
         {Credo.Check.Design.DuplicatedCode, false},
         {Credo.Check.Readability.AliasAs, false},
         {Credo.Check.Readability.BlockPipe, false},
+        {Credo.Check.Readability.CapitalizedComments, false},
         {Credo.Check.Readability.ImplTrue, false},
         {Credo.Check.Readability.MultiAlias, false},
         {Credo.Check.Readability.SinglePipe, false},

--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -31,7 +31,7 @@ defmodule Credo.Check do
       ```
 
   - `:param_defaults` Sets the default values for the check's params (e.g. `[param1: 42, param2: "offline"]`)
-  - `:run_on_all`     Sets whether the check runs on all source files at once or each source file separatly.
+  - `:run_on_all`     Sets whether the check runs on all source files at once or each source file separately.
   - `:tags`           Sets the tags for this check (list of atoms, e.g. `[:tag1, :tag2]`)
 
   Please also note that these options to `use Credo.Check` are just a convenience to implement the `Credo.Check`
@@ -141,7 +141,7 @@ defmodule Credo.Check do
   # @callback run(source_file :: Credo.SourceFile.t, params :: Keyword.t) :: list()
 
   @doc """
-  Returns wether or not this check runs on all source files.
+  Returns whether or not this check runs on all source files.
   """
   @callback run_on_all?() :: boolean
 

--- a/lib/credo/check/readability/capitalized_comments.ex
+++ b/lib/credo/check/readability/capitalized_comments.ex
@@ -1,0 +1,126 @@
+defmodule Credo.Check.Readability.CapitalizedComments do
+  @moduledoc false
+
+  use Credo.Check,
+    base_priority: :high,
+    category: :readability,
+    tags: [:controversial],
+    param_defaults: [
+      non_capitalized_sentence: ~r/\# [a-z]\S+ \S+/,
+      capitalized_sentence_without_end: ~r/\# [`|"|'|0-9|A-Z]+.*[^.?!]$/,
+      comment_sentence_without_end: ~r/\# \S+.*[^.?!]$/,
+      excluded_paths: [],
+      excluded_files: []
+    ],
+    explanations: [
+      check: """
+      Comments longer than a word need to be capitalized.
+
+      Rules for valid single line comment:
+      - Comment should start with ` or ' or " or 0-9 or A-Z
+      - Comment should end with . or ? or !
+
+      Rules for multi-line comments
+      - Comment should start with ` or ' or " or 0-9 or A-Z
+      - The following comment sentence can start with non-capitalized letters
+      - Comment sentence ending with . or ? or ! at end are considered as end of the multi-line comments.
+
+      Comments failing to follow these rules are considered as non-capitalized comments and marked as issues.
+
+      Valid comments examples:
+
+        # This is a valid single line comment.
+
+        # This is valid multi
+        # line comments.
+        # Yup and valid.
+
+        # `code` block.
+
+        # "Wow", this is also allowed.
+
+        # 'xox', also valid.
+
+        # 9 is also valid.
+
+        # Is this also valid?
+        # - yes!
+      """,
+      params: [
+        excluded_paths: "A list of paths to exclude",
+        excluded_files: "A list of files to exclude",
+        non_capitalized_sentence: "Regex to match non-capitalized sentence.",
+        capitalized_sentence_without_end: "Regex to match capitalized sentence without end.",
+        comment_sentence_without_end: "Regex to match any comment sentence without end."
+      ]
+    ]
+
+  @doc false
+  def run(source_file, params \\ []) do
+    excluded_paths = Params.get(params, :excluded_paths, __MODULE__)
+    excluded_files = Params.get(params, :excluded_files, __MODULE__)
+
+    if Enum.member?(excluded_files, source_file.filename) or
+         String.starts_with?(source_file.filename, excluded_paths) do
+      []
+    else
+      lines = SourceFile.lines(source_file)
+
+      issue_meta = IssueMeta.for(source_file, params)
+
+      {_, issues} = Enum.reduce(lines, {:single, []}, &process_line(&1, &2, issue_meta, params))
+
+      issues
+    end
+  end
+
+  defp process_line({line_no, line}, {comment_type, issues}, issue_meta, params) do
+    case comment_type do
+      :single -> process_single_comment(issues, issue_meta, line_no, line, params)
+      :multiline -> process_multiline_comment(issues, issue_meta, line_no, line, params)
+    end
+  end
+
+  defp process_single_comment(issues, issue_meta, line_no, line, params) do
+    cond do
+      run_regex(line, :capitalized_sentence_without_end, params) != nil ->
+        {:multiline, issues}
+
+      run_regex(line, :non_capitalized_sentence, params) != nil ->
+        [match | _] = run_regex(line, :non_capitalized_sentence, params)
+        {:single, add_to_issues(issues, issue_meta, line_no, match)}
+
+      true ->
+        {:single, issues}
+    end
+  end
+
+  defp process_multiline_comment(issues, _issue_meta, _line_no, line, params) do
+    case run_regex(line, :comment_sentence_without_end, params) do
+      nil -> {:single, issues}
+      _ -> {:multiline, issues}
+    end
+  end
+
+  defp add_to_issues(issues, issue_meta, line_no, match) do
+    match
+    |> build_message()
+    |> issue_for(issue_meta, line_no, match)
+    |> List.wrap()
+    |> Kernel.++(issues)
+  end
+
+  defp run_regex(line, regex_identifier, params) do
+    params
+    |> Params.get(regex_identifier, __MODULE__)
+    |> Regex.run(line)
+  end
+
+  defp build_message(match),
+    do:
+      "Non-capitalized beginning of comment found: \"#{match}\". Comments longer than one word must be capitalized"
+
+  defp issue_for(message, issue_meta, line_no, trigger) do
+    format_issue(issue_meta, message: message, line_no: line_no, trigger: trigger)
+  end
+end

--- a/lib/credo/check/readability/impl_true.ex
+++ b/lib/credo/check/readability/impl_true.ex
@@ -11,13 +11,13 @@ defmodule Credo.Check.Readability.ImplTrue do
       Instead of:
 
           @impl true
-          def my_funcion() do
+          def my_function() do
             ...
 
       use:
 
           @impl MyBehaviour
-          def my_funcion() do
+          def my_function() do
             ...
 
       """

--- a/lib/credo/code/module.ex
+++ b/lib/credo/code/module.ex
@@ -1,7 +1,7 @@
 defmodule Credo.Code.Module do
   @moduledoc """
   This module provides helper functions to analyse modules, return the defined
-  funcions or module attributes.
+  functions or module attributes.
   """
 
   alias Credo.Code

--- a/test/credo/check/readability/capitalized_comments_test.exs
+++ b/test/credo/check/readability/capitalized_comments_test.exs
@@ -1,0 +1,165 @@
+defmodule Credo.Check.Readability.CapitalizedCommentsTest do
+  use Credo.Test.Case
+
+  alias Credo.Check.Readability.CapitalizedComments
+
+  describe "valid single line comment" do
+    test "when comments starts with \` or \' or \" or 0-9 or A-Z and ends with \. or \? or \!" do
+      """
+      # This is an valid comment.
+
+      # `code` block!
+
+      # "wow", this is also valid.
+
+      # 'also', this is valid?
+
+      # 9 is also valid.
+
+      # * starting with other symbol is valid.
+
+      # - this is also valid.
+
+      # valid_single_word_comment
+
+      ############################
+      ## This is a valid comment #
+      ############################
+      """
+      |> to_source_file()
+      |> run_check(CapitalizedComments)
+      |> refute_issues()
+    end
+  end
+
+  describe "valid multi-line comments" do
+    test "when comments starts with \` or \' or \" or 0-9 or A-Z and last comment line ends with \. or \? or \!" do
+      """
+      # This is an valid comment
+      # so, no issues.
+
+      # `code` block!
+      # New comment follows.
+
+      # "wow", this is also valid:
+      # def code(x) do
+      #   IO.inspect x
+      # end
+
+      # 'also', this is valid?
+      # - yes
+      # - and yes
+
+      # 9 is also valid,
+      # but you need to be more
+      # clear what 9 means.
+      """
+      |> to_source_file()
+      |> run_check(CapitalizedComments)
+      |> refute_issues()
+    end
+  end
+
+  describe "invalid single line comment" do
+    test "non-capitalized start" do
+      """
+      # invalid comment.
+
+      # this is also invalid single comment
+      """
+      |> to_source_file()
+      |> run_check(CapitalizedComments)
+      |> assert_issues(fn [issue_1, issue_2] ->
+        assert "# invalid comment." == issue_2.trigger
+        assert "# this is" == issue_1.trigger
+      end)
+    end
+  end
+
+  describe "invalid multi-line comments" do
+    test "non-capitalized multi-comment start" do
+      """
+      # this comment is invalid,
+      # so it should be captured.
+      """
+      |> to_source_file()
+      |> run_check(CapitalizedComments)
+      |> assert_issues(fn [issue_1, issue_2] ->
+        assert "# this comment" == issue_2.trigger
+        assert "# so it" == issue_1.trigger
+      end)
+    end
+
+    test "new non-capitalized single comment start after multi-comment end" do
+      """
+      # This comment is invalid
+      # but now it has ended.
+      # so this comment is invalid
+
+      # This comment is invalid
+      # but now it has ended with?
+      # also, this comment is invalid
+
+      # This comment is invalid
+      # but now it has ended with!
+      # same, this comment is invalid
+      """
+      |> to_source_file()
+      |> run_check(CapitalizedComments)
+      |> assert_issues(fn [issue_1, issue_2, issue_3] ->
+        assert "# so this" == issue_3.trigger
+        assert "# also, this" == issue_2.trigger
+        assert "# same, this" == issue_1.trigger
+      end)
+    end
+  end
+
+  describe "configurable params" do
+    test "excluded_files" do
+      """
+        # file with invalid comment
+      """
+      |> to_source_file("sample.ex")
+      |> run_check(CapitalizedComments, excluded_files: ["sample.ex"])
+      |> refute_issues()
+    end
+
+    test "excluded_paths" do
+      """
+        # file with invalid comment
+      """
+      |> to_source_file("hello/sample.ex")
+      |> run_check(CapitalizedComments, excluded_paths: ["hello/"])
+      |> refute_issues()
+    end
+
+    test "non_capitalized_sentence" do
+      """
+        # Let us make this valid in regex
+      """
+      |> to_source_file("hello/sample.ex")
+      |> run_check(CapitalizedComments, non_capitalized_sentence: ~r/\# [A-Z] .*/)
+      |> refute_issues()
+    end
+
+    test "capitalized_sentence_without_end" do
+      """
+        # let us make this valid in regex
+      """
+      |> to_source_file("hello/sample.ex")
+      |> run_check(CapitalizedComments, capitalized_sentence_without_end: ~r/\# [a-z]*.*/)
+      |> refute_issues()
+    end
+
+    test "comment_sentence_without_end" do
+      """
+        # Let us make this valid in regex
+        # and this will pass.
+        # for sure
+      """
+      |> to_source_file("hello/sample.ex")
+      |> run_check(CapitalizedComments, comment_sentence_without_end: ~r/\# [a-z]*.*\.$/)
+      |> refute_issues()
+    end
+  end
+end


### PR DESCRIPTION
A controversial check which enforces comments longer than a word needs to be capitalized.

This works for both single-line and multi-line comments.

**A single-line comment should:**
```
      - start with ` or  '  or " or 0-9 or A-Z
      - end with . or ? or ! 
```

 Examples for valid case:
```elixir
      # This is a valid comment.

      # `code` block!

      # "wow", this is also valid.

      # 'also', this is valid?

      # 9 is also valid.

      # * starting with other symbol is valid.

      # - this is also valid.

      # valid_single_word_comment

      ############################
      ## This is a valid comment #
      ############################
```

**A multi-line comment should:**
```
      - Comment should start with ` or ' or " or 0-9 or A-Z
      - The following comment sentence can start with non-capitalized letters
      - Comment sentence ending with . or ? or ! at the end is considered as the end of the multi-line comments.
```
Examples for valid cases:
```
      # This is a valid comment
      # so, no issues.

      # `code` block!
      # New comment follows.

      # "yes", this is also valid:
      # def code(x) do
      #   IO.inspect x
      # end

      # 'also', this is valid?
      # - yes
      # - and yes

      # 9 is also valid,
      # but you need to be more
      # clear what 9 means.
```

I'm using this check with quite a big codebase; it seems stable and no issues. There could be some missed cases which I might not have seen, so far, it does well.