### PR TITLE
add min_priority after strict to avoid overwrites

### DIFF
--- a/lib/credo/config_builder.ex
+++ b/lib/credo/config_builder.ex
@@ -80,11 +80,11 @@ defmodule Credo.ConfigBuilder do
     |> add_switch_format(switches)
     |> add_switch_help(switches)
     |> add_switch_ignore(switches)
-    |> add_switch_min_priority(switches)
     |> add_switch_mute_exit_status(switches)
     |> add_switch_only(switches)
     |> add_switch_read_from_stdin(switches)
     |> add_switch_strict(switches)
+    |> add_switch_min_priority(switches)
     |> add_switch_verbose(switches)
     |> add_switch_version(switches)
   end


### PR DESCRIPTION
this commit changes the order of the `add_switch_` functions for `strict` and `min_priority`. 
As `add_switch_strict` overwrites in `Execution.set_strict`the min_priority value, it needs to be before the `add_switch_min_priorty`.
See https://github.com/rrrene/credo/blob/master/lib/credo/execution.ex#L298

the last time the order has been changed was with this commit:
https://github.com/rrrene/credo/commit/9d7b62e90b85fc07820ed0c81c371d9c48b0f1c1

Fixes https://github.com/rrrene/credo/issues/777