### PR TITLE
Fix `Strings.replace_with_spaces` with charlist

### DIFF
--- a/lib/credo/code/strings.ex
+++ b/lib/credo/code/strings.ex
@@ -145,7 +145,7 @@ defmodule Credo.Code.Strings do
   defp parse_charlist(str, acc, replacement) when is_binary(str) do
     {h, t} = String.next_codepoint(str)
 
-    parse_comment(t, acc <> h, replacement)
+    parse_charlist(t, acc <> h, replacement)
   end
 
   #

--- a/test/credo/code/strings_test.exs
+++ b/test/credo/code/strings_test.exs
@@ -85,6 +85,7 @@ defmodule Credo.Code.StringsTest do
     x = ~S[text]
     x = ~S{text}
     x = ~S<text>
+    x = to_string('text') <> "text"
     ?" # <-- this is not a string
     """
 
@@ -104,6 +105,7 @@ defmodule Credo.Code.StringsTest do
     x = ~S[    ]
     x = ~S{    }
     x = ~S<    >
+    x = to_string('text') <> "    "
     ?" # <-- this is not a string
     """
 


### PR DESCRIPTION
There was a bug where a charlist before a string would cause the `replace_with_spaces` function to skip the rest of the line.

fixes #809