### PR TITLE
adds in missing < operator from this check

### DIFF
--- a/lib/credo/check/readability/function_names.ex
+++ b/lib/credo/check/readability/function_names.ex
@@ -28,7 +28,7 @@ defmodule Credo.Check.Readability.FunctionNames do
   @all_sigil_atoms Enum.map(@all_sigil_chars, &:"sigil_#{&1}")
 
   # all non-special-form operators
-  @all_nonspecial_operators ~W(! && ++ -- .. <> =~ @ |> || != !== * + - / <= == === > >= ||| &&& <<< >>> <<~ ~>> <~ ~> <~> <|> ^^^ ~~~)a
+  @all_nonspecial_operators ~W(! && ++ -- .. <> =~ @ |> || != !== * + - / < <= == === > >= ||| &&& <<< >>> <<~ ~>> <~ ~> <~> <|> ^^^ ~~~)a
 
   @doc false
   @impl true


### PR DESCRIPTION
`<` was missing from the non-special-form-operators list.