### PR TITLE
fix credo diff cli

### DIFF
--- a/lib/credo/cli/command/diff/diff_command.ex
+++ b/lib/credo/cli/command/diff/diff_command.ex
@@ -95,11 +95,12 @@ defmodule Credo.CLI.Command.Diff.DiffCommand do
       now = DateTime.utc_now() |> to_string |> String.replace(~r/\D/, "")
       dirname = "credo-diff-#{now}"
       tmp_dirname = Path.join(System.tmp_dir!(), dirname)
+      if !File.exists?(tmp_dirname), do: File.mkdir!(tmp_dirname)
 
-      {_output, 0} =
+      {_output, _value} =
         System.cmd("git", ["clone", ".", tmp_dirname], cd: path, stderr_to_stdout: true)
 
-      {_output, 0} =
+      {_output, _value} =
         System.cmd("git", ["checkout", git_ref], cd: tmp_dirname, stderr_to_stdout: true)
 
       tmp_dirname


### PR DESCRIPTION
When it runs the `mix credo diff` CLI it returns a different value instead of 0.

So it keeps the tuple for the pattern matching, but it changes the zero value for
an unused variable like `_value`.

And after that, the CLI continues with weird behavior, because it tells could
not cd to find the path `/tmp/credo-diff-#{now}`, and to guarantee it will create
the path put an if conditions where checks the path it exists if not create a new owns.

I use:
```
erlang 23.1.1
elixir 1.11.1-otp-23
```

I testing with this project [ex_mon](https://github.com/herminiotorres/curso-elixir/tree/main/web/ex_mon)
the output:
```
mix credo diff
** (MatchError) no match of right hand side value: {"fatal: repository '.' does not exist\n", 128}
    lib/credo/cli/command/diff/diff_command.ex:99: Credo.CLI.Command.Diff.DiffCommand.GetGitDiff.run_git_clone_and_checkout/2
    lib/credo/cli/command/diff/diff_command.ex:61: Credo.CLI.Command.Diff.DiffCommand.GetGitDiff.run_credo_and_store_resulting_execution/1
    lib/credo/execution/task.ex:55: Credo.Execution.Task.do_run/3
    (elixir 1.11.1) lib/enum.ex:2181: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/credo/execution/task.ex:55: Credo.Execution.Task.do_run/3
    (elixir 1.11.1) lib/enum.ex:2181: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/credo.ex:30: Credo.run/1
    lib/credo/cli.ex:41: Credo.CLI.run_to_halt/1
```

After I change the value on tuple, and run again:

```
mix credo diff main
path: "curso-elixir/web/ex_mon"
git_ref: "main"
spawn: Could not cd to /tmp/credo-diff-20201029203508617407
Diffing 36 source files in working dir with main ...

Please report incorrect results: https://github.com/rrrene/credo/issues

Analysis took 0.07 seconds (0.02s to load, 0.05s running 52 checks on 36 files)

Changes between main and working dir:

+  added no issues,
✔  fixed no issues, and
~  kept 15 code readability issues.

Use `mix credo explain` to explain issues, `mix credo diff --help` for options.
```

When I guarantee to create the path:
```
mix credo diff d319c59
previous_dirname: "/tmp/credo-diff-20201029205339135573"
Diffing 36 source files in working dir with d319c59 ...

    Code Readability                                                                                                     
  ┃ 
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/trainer/pokemon/create.ex:1:11 #(ExMon.Trainer.Pokemon.Create)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/trainer.ex:1:11 #(ExMon.Trainer)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon_web/telemetry.ex:1:11 #(ExMonWeb.Telemetry)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/trainer/update.ex:1:11 #(ExMon.Trainer.Update)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/trainer/pokemon/update.ex:1:11 #(ExMon.Trainer.Pokemon.Update)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/trainer/pokemon/get.ex:1:11 #(ExMon.Trainer.Pokemon.Get)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/trainer/pokemon/delete.ex:1:11 #(ExMon.Trainer.Pokemon.Delete)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/trainer/pokemon.ex:1:11 #(ExMon.Trainer.Pokemon)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/trainer/get.ex:1:11 #(ExMon.Trainer.Get)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/trainer/delete.ex:1:11 #(ExMon.Trainer.Delete)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/trainer/create.ex:1:11 #(ExMon.Trainer.Create)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/pokemon/get.ex:1:11 #(ExMon.Pokemon.Get)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/pokemon.ex:1:11 #(ExMon.Pokemon)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon/poke_api/client.ex:1:11 #(ExMon.PokeAPI.Client)
+ ┃ [R] → Modules should have a @moduledoc tag.
+ ┃       lib/ex_mon.ex:1:11 #(ExMon)

Please report incorrect results: https://github.com/rrrene/credo/issues

Analysis took 0.1 seconds (0.02s to load, 0.09s running 52 checks on 36 files)

Changes between d319c59 and working dir:

+  added 15 new code readability issues,
✔  fixed no issues, and
~  kept no issues.

Use `mix credo explain` to explain issues, `mix credo diff --help` for options.
```

