### PR TITLE
Fix ExpensiveEmptyEnumCheck when length is a var

### DIFF
--- a/lib/credo/check/warning/expensive_empty_enum_check.ex
+++ b/lib/credo/check/warning/expensive_empty_enum_check.ex
@@ -31,7 +31,7 @@ defmodule Credo.Check.Warning.ExpensiveEmptyEnumCheck do
                               _,
                               _
                             }
-  @length_pattern quote do: {:length, _, _}
+  @length_pattern quote do: {:length, _, [_]}
   @comparisons [
     {@enum_count_pattern, 0},
     {0, @enum_count_pattern},

--- a/test/credo/check/warning/expensive_empty_enum_check_test.exs
+++ b/test/credo/check/warning/expensive_empty_enum_check_test.exs
@@ -155,4 +155,40 @@ defmodule Credo.Check.Warning.ExpensiveEmptyEnumCheckTest do
     |> run_check(@described_check)
     |> assert_issue()
   end
+
+  test "it should not report when checking if a variable called length is 0" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(enum) do
+        length = 0
+        if length == 0 do
+          "is 0"
+        else
+          "something else"
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should not report when checking if a variable called length is 0 backwards" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(enum) do
+        length = 0
+        if 0 == length do
+          "is 0"
+        else
+          "something else"
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
 end


### PR DESCRIPTION
Fix #824

In cases where a local variable called `length` was checked for zero value, credo incorrectly assumed this to be a call to Kernel.length/1 and showed a warning that this was an expensive operation.
This is fixed by making sure pattern match checks length's AST for a single parameter at the last item in the tuple, meeting Kernel.length/1's AST.

This also removes warnings from length function calls with more than a single parameter.
I'm not sure this is desired, but since a length/2+ function can be anything other than checking the size of an enumerable and the suggestion might not be valid, I think it is only fair we don't warn people creating and using a function like that.
Please LMK if you think I should add a test for this scenario or if we should keep warning for length/2+ as it feels it was in some sort of unchecked limbo.