### PR TITLE
Show alternative VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Some IDEs and editors are able to run Credo in the background and mark issues in
 * [IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir#credo) - Elixir plugin for JetBrains IDEs (IntelliJ IDEA, Rubymine, PHPStorm, PyCharm, etc)
 * [linter-elixir-credo](https://atom.io/packages/linter-elixir-credo) - Package for Atom editor (by @smeevil)
 * [Elixir Linter (Credo)]([https://](https://marketplace.visualstudio.com/items?itemName=pantajoe.vscode-elixir-credo)) - VSCode extension (by @pantajoe)
+* [ElixirLinter](https://marketplace.visualstudio.com/items?itemName=iampeterbanjo.elixirlinter) - VSCode plugin (by @iampeterbanjo, NO LONGER MAINTAINED)
 * [flycheck](https://www.flycheck.org/en/latest/languages.html#elixir) - Emacs syntax checking extension
 
 ### Automated Code Review

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Some IDEs and editors are able to run Credo in the background and mark issues in
 
 * [IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir#credo) - Elixir plugin for JetBrains IDEs (IntelliJ IDEA, Rubymine, PHPStorm, PyCharm, etc)
 * [linter-elixir-credo](https://atom.io/packages/linter-elixir-credo) - Package for Atom editor (by @smeevil)
-* [ElixirLinter](https://marketplace.visualstudio.com/items?itemName=iampeterbanjo.elixirlinter) - VSCode plugin (by @iampeterbanjo)
+* [Elixir Linter (Credo)]([https://](https://marketplace.visualstudio.com/items?itemName=pantajoe.vscode-elixir-credo)) - VSCode extension (by @pantajoe)
 * [flycheck](https://www.flycheck.org/en/latest/languages.html#elixir) - Emacs syntax checking extension
 
 ### Automated Code Review

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Some IDEs and editors are able to run Credo in the background and mark issues in
 
 * [IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir#credo) - Elixir plugin for JetBrains IDEs (IntelliJ IDEA, Rubymine, PHPStorm, PyCharm, etc)
 * [linter-elixir-credo](https://atom.io/packages/linter-elixir-credo) - Package for Atom editor (by @smeevil)
-* [Elixir Linter (Credo)]([https://](https://marketplace.visualstudio.com/items?itemName=pantajoe.vscode-elixir-credo)) - VSCode extension (by @pantajoe)
+* [Elixir Linter (Credo)](https://marketplace.visualstudio.com/items?itemName=pantajoe.vscode-elixir-credo) - VSCode extension (by @pantajoe)
 * [ElixirLinter](https://marketplace.visualstudio.com/items?itemName=iampeterbanjo.elixirlinter) - VSCode plugin (by @iampeterbanjo, NO LONGER MAINTAINED)
 * [flycheck](https://www.flycheck.org/en/latest/languages.html#elixir) - Emacs syntax checking extension
 


### PR DESCRIPTION
The great [VS Code extension](https://github.com/iampeterbanjo/vscode-elixir-linter) of @peterbanjo is no longer maintainted. 😢 
I went ahead and built a new extension 👋🏼 

This PR includes a new VS Code extension for Credo and notifies newcomers about the fact that the extension 'ElixirLinter' is no longer maintained.