### PR TITLE
Add check for specs containing structs to cut down on compile-time dependencies

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -141,6 +141,7 @@
         {Credo.Check.Warning.OperationOnSameValues, []},
         {Credo.Check.Warning.OperationWithConstantResult, []},
         {Credo.Check.Warning.RaiseInsideRescue, []},
+        {Credo.Check.Warning.SpecWithStruct, []},
         {Credo.Check.Warning.UnusedEnumOperation, []},
         {Credo.Check.Warning.UnusedFileOperation, []},
         {Credo.Check.Warning.UnusedKeywordOperation, []},

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Some IDEs and editors are able to run Credo in the background and mark issues in
 * [IntelliJ Elixir](https://github.com/KronicDeth/intellij-elixir#credo) - Elixir plugin for JetBrains IDEs (IntelliJ IDEA, Rubymine, PHPStorm, PyCharm, etc)
 * [linter-elixir-credo](https://atom.io/packages/linter-elixir-credo) - Package for Atom editor (by @smeevil)
 * [Elixir Linter (Credo)](https://marketplace.visualstudio.com/items?itemName=pantajoe.vscode-elixir-credo) - VSCode extension (by @pantajoe)
-* [ElixirLinter](https://marketplace.visualstudio.com/items?itemName=iampeterbanjo.elixirlinter) - VSCode plugin (by @iampeterbanjo, NO LONGER MAINTAINED)
 * [flycheck](https://www.flycheck.org/en/latest/languages.html#elixir) - Emacs syntax checking extension
 
 ### Automated Code Review

--- a/lib/credo/check/warning/spec_with_struct.ex
+++ b/lib/credo/check/warning/spec_with_struct.ex
@@ -12,10 +12,10 @@ defmodule Credo.Check.Warning.SpecWithStruct do
       Example:
 
           # preferred
-          @spec a_function(%MyModule{}) :: any
+          @spec a_function(MyModule.t()) :: any
 
           # NOT preferred
-          @spec a_function(MyModule.t()) :: any
+          @spec a_function(%MyModule{}) :: any
       """
     ]
 

--- a/lib/credo/check/warning/spec_with_struct.ex
+++ b/lib/credo/check/warning/spec_with_struct.ex
@@ -9,10 +9,12 @@ defmodule Credo.Check.Warning.SpecWithStruct do
 
       It is preferable to define and use `MyModule.t()` instead of `%MyModule{}` in specs.
 
-      Avoid:
+      Example:
+
+          # preferred
           @spec a_function(%MyModule{}) :: any
 
-      Prefer:
+          # NOT preferred
           @spec a_function(MyModule.t()) :: any
       """
     ]
@@ -24,7 +26,9 @@ defmodule Credo.Check.Warning.SpecWithStruct do
     Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
   end
 
-  defp traverse({:spec, meta, args}, issues, issue_meta) do
+  # `::` and `when` are used in specs
+  defp traverse({:spec, meta, [{atom, _, _} | _] = args}, issues, issue_meta)
+       when atom in ~w(:: when)a do
     case Macro.prewalk(args, nil, &find_structs/2) do
       {ast, nil} ->
         {ast, issues}

--- a/lib/credo/check/warning/spec_with_struct.ex
+++ b/lib/credo/check/warning/spec_with_struct.ex
@@ -1,0 +1,54 @@
+defmodule Credo.Check.Warning.SpecWithStruct do
+  use Credo.Check,
+    base_priority: :normal,
+    category: :warning,
+    explanations: [
+      check: """
+      Structs create compile-time dependencies between modules.  Using a struct in a spec
+      will cause the module to be recompiled whenever the struct's module changes.
+
+      It is preferable to define and use `MyModule.t()` instead of `%MyModule{}` in specs.
+
+      Avoid:
+          @spec a_function(%MyModule{}) :: any
+
+      Prefer:
+          @spec a_function(MyModule.t()) :: any
+      """
+    ]
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse({:spec, meta, args}, issues, issue_meta) do
+    case Macro.prewalk(args, nil, &find_structs/2) do
+      {ast, nil} ->
+        {ast, issues}
+
+      {ast, struct} ->
+        options = [
+          message: "Struct %#{struct}{} found in @spec",
+          trigger: struct,
+          line_no: meta[:line]
+        ]
+
+        {ast, [format_issue(issue_meta, options) | issues]}
+    end
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp find_structs({:%, _, [{:__aliases__, _, modules} | _]} = ast, _acc) do
+    {ast, Enum.join(modules, ".")}
+  end
+
+  defp find_structs(ast, acc) do
+    {ast, acc}
+  end
+end

--- a/test/credo/check/warning/spec_with_struct_test.exs
+++ b/test/credo/check/warning/spec_with_struct_test.exs
@@ -106,7 +106,7 @@ defmodule Credo.Check.Warning.SpecWithStructTest do
     |> assert_issue()
   end
 
-  test "it should report multiple issues" do
+  test "it should report multiple issues in separate specs" do
     [
       """
       defmodule Offender do
@@ -117,6 +117,24 @@ defmodule Credo.Check.Warning.SpecWithStructTest do
 
         @spec g(a_struct :: %AStruct{}) :: any
         def g(_) do
+          "oops"
+        end
+      end
+      """,
+      @my_struct_module,
+      @a_struct_module
+    ]
+    |> to_source_files()
+    |> run_check(@described_check)
+    |> assert_issues()
+  end
+
+  test "it should report multiple issues in a single spec" do
+    [
+      """
+      defmodule Offender do
+        @spec f(a_struct :: %AStruct{}, my_struct :: %MyApp.MyStruct{}) :: any
+        def f(_, _) do
           "oops"
         end
       end

--- a/test/credo/check/warning/spec_with_struct_test.exs
+++ b/test/credo/check/warning/spec_with_struct_test.exs
@@ -1,0 +1,154 @@
+defmodule Credo.Check.Warning.SpecWithStructTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Warning.SpecWithStruct
+
+  @my_struct_module """
+  defmodule MyApp.MyStruct do
+    @type t :: %__MODULE__{id: integer, name: String.t()}
+    defstruct [:id, name]
+  end
+  """
+
+  @a_struct_module """
+  defmodule AStruct do
+    @type t :: %__MODULE__{a: any}
+    defstruct [:a]
+  end
+  """
+
+  test "it should report an issue if a struct is used as a parameter in a spec" do
+    [
+      """
+      defmodule Offender do
+        @spec f(any, %MyApp.MyStruct{}, any) :: any
+        def f(_, _, _) do
+          "oops"
+        end
+      end
+      """,
+      @my_struct_module
+    ]
+    |> to_source_files()
+    |> run_check(@described_check)
+    |> assert_issue(fn issue ->
+      assert %{line_no: 2, message: "Struct %MyApp.MyStruct{} found in @spec"} = issue
+    end)
+  end
+
+  test "it should report an issue if a struct is used as a return value in a spec" do
+    [
+      """
+      defmodule Offender do
+        @spec f() :: %AStruct{}
+        def f do
+          "oops"
+        end
+      end
+      """,
+      @a_struct_module
+    ]
+    |> to_source_files()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report an issue if a struct is part of a union in a spec" do
+    [
+      """
+      defmodule Offender do
+        alias MyApp.MyStruct, as: MS
+        @spec f(String.t() | %MS{} | integer) :: any
+        def f(_) do
+          "oops"
+        end
+      end
+      """,
+      @my_struct_module
+    ]
+    |> to_source_files()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report an issue if a struct is used as an argument in a spec" do
+    [
+      """
+      defmodule Offender do
+        alias MyApp.MyStruct
+        @spec f(arg) :: any when arg: %MyStruct{}
+        def f(_) do
+          "oops"
+        end
+      end
+      """,
+      @my_struct_module
+    ]
+    |> to_source_files()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report an issue if a struct has an argument name in a spec" do
+    [
+      """
+      defmodule Offender do
+        @spec f(my_struct :: %MyApp.MyStruct{}) :: any
+        def f(_) do
+          "oops"
+        end
+      end
+      """,
+      @my_struct_module
+    ]
+    |> to_source_files()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report multiple issues" do
+    [
+      """
+      defmodule Offender do
+        @spec f(my_struct :: %MyApp.MyStruct{}) :: any
+        def f(_) do
+          "oops"
+        end
+
+        @spec g(a_struct :: %AStruct{}) :: any
+        def g(_) do
+          "oops"
+        end
+      end
+      """,
+      @my_struct_module,
+      @a_struct_module
+    ]
+    |> to_source_files()
+    |> run_check(@described_check)
+    |> assert_issues()
+  end
+
+  test "it should NOT report an issue if t() is used in a spec" do
+    [
+      """
+      defmodule CorrectUsage do
+        @spec f(MyApp.MyStruct.t()) :: any
+        def f(_) do
+          "yay"
+        end
+
+        @spec g(any, AStruct.t()) :: MyApp.MyStruct.t()
+        def g(_, _) do
+          "yay"
+        end
+      end
+      """,
+      @my_struct_module,
+      @a_struct_module
+    ]
+    |> to_source_files()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+end

--- a/test/credo/check/warning/spec_with_struct_test.exs
+++ b/test/credo/check/warning/spec_with_struct_test.exs
@@ -6,7 +6,7 @@ defmodule Credo.Check.Warning.SpecWithStructTest do
   @my_struct_module """
   defmodule MyApp.MyStruct do
     @type t :: %__MODULE__{id: integer, name: String.t()}
-    defstruct [:id, name]
+    defstruct [:id, :name]
   end
   """
 
@@ -145,6 +145,40 @@ defmodule Credo.Check.Warning.SpecWithStructTest do
       end
       """,
       @my_struct_module,
+      @a_struct_module
+    ]
+    |> to_source_files()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report an issue for functions, macros, or variables named spec" do
+    [
+      """
+      defmodule IgnoredFunction do
+        def spec(%AStruct{}) do
+          "okay"
+        end
+
+        def spec(arg) when arg == %AStruct{} do
+          arg
+        end
+      end
+      """,
+      """
+      defmodule IgnoredMacro do
+        defmacro spec(arg) do
+          arg
+        end
+      end
+      """,
+      """
+      defmodule IgnoredVariable do
+        def spec(id) do
+          spec = %AStruct{id: id}
+        end
+      end
+      """,
       @a_struct_module
     ]
     |> to_source_files()


### PR DESCRIPTION
I was recently working on a project that would recompile ~70 files each time it was recompiled.  I did some digging and figured out that it was a result of using structs eg `%SomeStruct{}` in specs. Switching them out to `SomeStruct.t()` (and making that type) cut down on the modules that would be recompiled each time. Structs create compile-time dependencies and this will warn about structs being used in specs.

I'm happy to turn this off by default or tag it as experimental :)

Thanks for the wonderful library!