### PR TITLE
Exit with error status when load config fail

### DIFF
--- a/guides/introduction/exit_statuses.md
+++ b/guides/introduction/exit_statuses.md
@@ -17,11 +17,14 @@ This way you can reason about the encountered issues right from the exit status.
 
 Default values for the checks are based on their category:
 
-    consistency:  1
-    design:       2
-    readability:  4
-    refactor:     8
-    warning:     16
+    consistency:         1
+    design:              2
+    readability:         4
+    refactor:            8
+    warning:             16
+    <custom category>:   32
+    <custom category>:   64
+    runtime errors:      128 (and above)
 
 Let's see what this means using an example:
 

--- a/lib/credo/execution/task/convert_cli_options_to_config.ex
+++ b/lib/credo/execution/task/convert_cli_options_to_config.ex
@@ -15,6 +15,7 @@ defmodule Credo.Execution.Task.ConvertCLIOptionsToConfig do
   def halt_on_error({:error, error}, exec) do
     exec
     |> Execution.put_assign("#{__MODULE__}.error", error)
+    |> Execution.put_assign("credo.exit_status", 128)
     |> Execution.halt()
   end
 


### PR DESCRIPTION
As reported in #831 when `Credo` fails to load the config file the exit status is `0` (success). This behavior generates a false positive on CI pipelines.

This PR adds a status code `128` when config load fails.

Obs. I didn't find an appropriate test file to add a spec for this new behavior.