### PR TITLE
Fix Git check for systems without git

### DIFF
--- a/lib/credo/cli/command/diff/diff_command.ex
+++ b/lib/credo/cli/command/diff/diff_command.ex
@@ -60,6 +60,8 @@ defmodule Credo.CLI.Command.Diff.DiffCommand do
       {_output, 0} -> true
       {_output, _} -> false
     end
+  rescue
+    _ -> false
   end
 
   defp git_ref_exists?(git_ref) do


### PR DESCRIPTION
This PR fixes `git_present?` for systems that don't have git.

On a system without git available, the previous implementation raises an ErlangError:
```
** (ErlangError) Erlang error: :enoent
    (elixir 1.11.2) lib/system.ex:815: System.cmd("git", ["--help"], [])
```
This is solved by rescuing the error.