### PR TITLE
Add :exit_status to the list of valid options

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -175,6 +175,7 @@ defmodule Credo.Check do
     :base_priority,
     :category,
     :elixir_version,
+    :exit_status,
     :explanations,
     :param_defaults,
     :run_on_all,


### PR DESCRIPTION
There seems to be support for this option (it's even added by default in the generated custom check), but using Credo.Check will fail as it's not in the list op valid options.