### PR TITLE
Enum.count/2 needs to execute condition, the alternatives do not apply

### DIFF
--- a/lib/credo/check/warning/expensive_empty_enum_check.ex
+++ b/lib/credo/check/warning/expensive_empty_enum_check.ex
@@ -62,13 +62,19 @@ defmodule Credo.Check.Warning.ExpensiveEmptyEnumCheck do
   end
 
   defp issues_for_call(meta, issues, issue_meta, ast) do
-    [issue_for(issue_meta, meta[:line], Macro.to_string(ast)) | issues]
+    [issue_for(issue_meta, meta[:line], Macro.to_string(ast), suggest(ast)) | issues]
   end
 
-  defp issue_for(issue_meta, line_no, trigger) do
+  defp suggest({_op, _, [0, {_pattern, _, args}]}), do: suggest_for_arity(Enum.count(args))
+  defp suggest({_op, _, [{_pattern, _, args}, 0]}), do: suggest_for_arity(Enum.count(args))
+
+  defp suggest_for_arity(2), do: "`not Enum.any?/2`"
+  defp suggest_for_arity(1), do: "Enum.empty?/1 or list == []"
+
+  defp issue_for(issue_meta, line_no, trigger, suggestion) do
     format_issue(
       issue_meta,
-      message: "#{trigger} is expensive. Prefer Enum.empty?/1 or list == [] or `not Enum.any?/2`",
+      message: "#{trigger} is expensive. Prefer #{suggestion}",
       trigger: trigger,
       line_no: line_no
     )

--- a/lib/credo/check/warning/expensive_empty_enum_check.ex
+++ b/lib/credo/check/warning/expensive_empty_enum_check.ex
@@ -15,6 +15,12 @@ defmodule Credo.Check.Warning.ExpensiveEmptyEnumCheck do
 
           list == []
 
+
+      For Enum.count/2: Checking if an enum doesn't contain specific elements should
+      be done by using
+
+          not Enum.any?(enum, condition)
+
       """
     ]
 
@@ -62,7 +68,7 @@ defmodule Credo.Check.Warning.ExpensiveEmptyEnumCheck do
   defp issue_for(issue_meta, line_no, trigger) do
     format_issue(
       issue_meta,
-      message: "#{trigger} is expensive. Prefer Enum.empty?/1 or list == []",
+      message: "#{trigger} is expensive. Prefer Enum.empty?/1 or list == [] or `not Enum.any?/2`",
       trigger: trigger,
       line_no: line_no
     )

--- a/test/credo/check/warning/expensive_empty_enum_check_test.exs
+++ b/test/credo/check/warning/expensive_empty_enum_check_test.exs
@@ -105,7 +105,7 @@ defmodule Credo.Check.Warning.ExpensiveEmptyEnumCheckTest do
     |> assert_issue()
   end
 
-  test "it should report when checking if Enum.count is 0" do
+  test "it should report when checking if Enum.count/1 is 0" do
     """
     defmodule CredoSampleModule do
       def some_function(enum) do
@@ -119,10 +119,10 @@ defmodule Credo.Check.Warning.ExpensiveEmptyEnumCheckTest do
     """
     |> to_source_file
     |> run_check(@described_check)
-    |> assert_issue()
+    |> assert_issue(fn issue -> assert issue.message =~ "Enum.empty" end)
   end
 
-  test "it should report when checking if Enum.count is 0 backwards" do
+  test "it should report when checking if Enum.count/1 is 0 backwards" do
     """
     defmodule CredoSampleModule do
       def some_function(enum) do
@@ -136,7 +136,41 @@ defmodule Credo.Check.Warning.ExpensiveEmptyEnumCheckTest do
     """
     |> to_source_file
     |> run_check(@described_check)
-    |> assert_issue()
+    |> assert_issue(fn issue -> assert issue.message =~ "Enum.empty" end)
+  end
+
+  test "it should report when checking if Enum.count/2 is 0" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(enum) do
+        if Enum.count(some_list, &is_nil/1) == 0 do
+          "empty"
+        else
+          "not empty"
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(fn issue -> assert issue.message =~ "Enum.any" end)
+  end
+
+  test "it should report when checking if Enum.count/2 is 0 backwards" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(enum) do
+        if 0 == Enum.count(enum, &is_nil/1) do
+          "empty"
+        else
+          "not empty"
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(fn issue -> assert issue.message =~ "Enum.any" end)
   end
 
   test "it should report when checking if length is 0 with triple-equals" do


### PR DESCRIPTION
I made the `Enum.count/1-2` pattern more strict so it only matches the `/1` and not the `/2`. For reference here is the documentation: https://hexdocs.pm/elixir/Enum.html#count/2. I took that example code in the tests :)

Adding this case was a breeze. Thanks for making it so easy 😄 