### PR TITLE
Trim string in TagHelper

### DIFF
--- a/lib/credo/check/design/tag_helper.ex
+++ b/lib/credo/check/design/tag_helper.ex
@@ -39,7 +39,8 @@ defmodule Credo.Check.Design.TagHelper do
   defp traverse({:@, _, [{name, meta, [string]} | _]} = ast, issues, regex)
        when name in @doc_attribute_names and is_binary(string) do
     if string =~ regex do
-      {nil, issues ++ [{meta[:line], string, string}]}
+      trimed = String.trim(string)
+      {nil, issues ++ [{meta[:line], trimed, trimed}]}
     else
       {ast, issues}
     end

--- a/lib/credo/check/design/tag_helper.ex
+++ b/lib/credo/check/design/tag_helper.ex
@@ -39,7 +39,7 @@ defmodule Credo.Check.Design.TagHelper do
   defp traverse({:@, _, [{name, meta, [string]} | _]} = ast, issues, regex)
        when name in @doc_attribute_names and is_binary(string) do
     if string =~ regex do
-      trimed = String.trim(string)
+      trimed = String.trim_trailing(string)
       {nil, issues ++ [{meta[:line], trimed, trimed}]}
     else
       {ast, issues}


### PR DESCRIPTION
Trims also tagged strings found in `docs`.