### PR TITLE
Add check for using apply

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -114,6 +114,7 @@
         {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
         {Credo.Check.Readability.VariableNames, []},
         {Credo.Check.Readability.WithSingleClause, []},
+        {Credo.Check.Readability.Apply, []},
 
         #
         ## Refactoring Opportunities

--- a/lib/credo/check/readability/apply.ex
+++ b/lib/credo/check/readability/apply.ex
@@ -1,0 +1,44 @@
+defmodule Credo.Check.Readability.Apply do
+  use Credo.Check,
+    base_priority: :low,
+    explanations: [
+      check: """
+      If the number of arguments and the function name are known at compile time,
+      prefer `module.function(arg_1, arg_2, ..., arg_n)` as it is clearer than
+      `apply(module, :function, [arg_1, arg_2, ..., arg_n])`.
+      """
+    ]
+
+  alias Credo.Code
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    source_file
+    |> Code.prewalk(&traverse(&1, &2, IssueMeta.for(source_file, params)))
+    |> Enum.reverse()
+  end
+
+  defp traverse(ast, issues, issue_meta) do
+    case issue(ast, issue_meta) do
+      nil -> {ast, issues}
+      issue -> {ast, [issue | issues]}
+    end
+  end
+
+  defp issue({:apply, meta, [_fun, args]}, issue_meta) when is_list(args),
+    do: issue_for(issue_meta, meta[:line])
+
+  defp issue({:apply, meta, [_module, _fun, args]}, issue_meta) when is_list(args),
+    do: issue_for(issue_meta, meta[:line])
+
+  defp issue(_ast, _issue_meta), do: nil
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue(
+      issue_meta,
+      message: "Avoid apply when the number of arguments is known",
+      line_no: line_no
+    )
+  end
+end

--- a/test/credo/check/readability/apply_test.exs
+++ b/test/credo/check/readability/apply_test.exs
@@ -1,0 +1,57 @@
+defmodule Credo.Check.Readability.ApplyTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Readability.Apply
+
+  test "it should NOT report violation for apply/2" do
+    """
+    defmodule Test do
+      def some_function(fun, args) do
+        apply(fun, args)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report violation for apply/3" do
+    """
+    defmodule Test do
+      def some_function(module, fun, args) do
+        apply(module, fun, args)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should report a violation for apply/2" do
+    """
+    defmodule Test do
+      def some_function(fun, arg1, arg2) do
+        apply(fun, [arg1, arg2])
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation for apply/3" do
+    """
+    defmodule Test do
+      def some_function(module, fun, arg1, arg2) do
+        apply(module, fun, [arg1, arg2])
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+end


### PR DESCRIPTION
Inspired by https://github.com/elixir-lang/elixir/pull/10748

> If the number of arguments is known at compile time, prefer
  `fun.(arg_1, arg_2, ..., arg_n)` as it is clearer than
  `apply(fun, [arg_1, arg_2, ..., arg_n])`.
