### PR TITLE
fixed mix credo explain priority and arrow

### DIFF
--- a/lib/credo/priority.ex
+++ b/lib/credo/priority.ex
@@ -37,6 +37,17 @@ defmodule Credo.Priority do
     @priority_names_map[to_string(key)] || raise "Got an invalid priority: #{inspect(key)}"
   end
 
+  def to_atom(priority) when is_number(priority) do
+    cond do
+      priority in 20..999 -> :higher
+      priority in 10..19 -> :high
+      priority in 0..9 -> :normal
+      priority in -10..-1 -> :low
+      priority in -999..-11 -> :ignore
+      true -> nil
+    end
+  end
+
   def scope_priorities(%SourceFile{} = source_file) do
     line_count =
       source_file

--- a/lib/credo/priority.ex
+++ b/lib/credo/priority.ex
@@ -39,14 +39,15 @@ defmodule Credo.Priority do
 
   def to_atom(priority) when is_number(priority) do
     cond do
-      priority in 20..999 -> :higher
+      priority > 19 -> :higher
       priority in 10..19 -> :high
       priority in 0..9 -> :normal
       priority in -10..-1 -> :low
-      priority in -999..-11 -> :ignore
-      true -> nil
+      priority < -10 -> :ignore
     end
   end
+
+  def to_atom(_), do: nil
 
   def scope_priorities(%SourceFile{} = source_file) do
     line_count =

--- a/test/credo/cli/output/output_test.exs
+++ b/test/credo/cli/output/output_test.exs
@@ -1,0 +1,5 @@
+defmodule Credo.CLI.OutputTest do
+  use Credo.Test.Case
+
+  doctest Credo.CLI.Output
+end

--- a/test/credo/priority_test.exs
+++ b/test/credo/priority_test.exs
@@ -119,4 +119,22 @@ defmodule Credo.PriorityTest do
 
     assert expected == Priority.scope_priorities(source_file)
   end
+
+  describe "Credo.Priority.to_atom/1" do
+    test "it should convert integers edge cases to the correct priority" do
+      %{
+        -100 => :ignore,
+        -10 => :low,
+        -1 => :low,
+        0 => :normal,
+        9 => :normal,
+        10 => :high,
+        19 => :high,
+        20 => :higher
+      }
+      |> Enum.each(fn {i, priority} ->
+        assert Priority.to_atom(i) == priority
+      end)
+    end
+  end
 end


### PR DESCRIPTION
There is an issue with the priority mappings when running `mix explain rule`

## Before Fix
<img width="813" alt="before" src="https://user-images.githubusercontent.com/1206303/109347731-d4453200-7830-11eb-92c0-e96abb0d1612.png">

## After Fix
<img width="754" alt="after" src="https://user-images.githubusercontent.com/1206303/109347738-d6a78c00-7830-11eb-94da-b3a89b095d99.png">

I added doctests

```bash
spencercarlson$ mix test test/credo/cli/output/output_test.exs
Excluding tags: [to_be_implemented: true]

........

Finished in 0.04 seconds
8 doctests, 0 failures
```