### PR TITLE
Check UnsafeToAtom along pipe chains

### DIFF
--- a/lib/credo/check/warning/unsafe_to_atom.ex
+++ b/lib/credo/check/warning/unsafe_to_atom.ex
@@ -48,8 +48,6 @@ defmodule Credo.Check.Warning.UnsafeToAtom do
   end
 
   defp traverse({:|>, _loc, _args} = ast, issues, _issue_meta) do
-    unpiped = Macro.unpipe(ast)
-
     case Macro.unpipe(ast) do
       [first | rest] ->
         unpiped =

--- a/lib/credo/check/warning/unsafe_to_atom.ex
+++ b/lib/credo/check/warning/unsafe_to_atom.ex
@@ -47,29 +47,16 @@ defmodule Credo.Check.Warning.UnsafeToAtom do
     {nil, issues}
   end
 
-  defp traverse({:|>, _loc, _args} = ast, issues, _issue_meta) do
-    case Macro.unpipe(ast) do
-      [first | rest] ->
-        unpiped =
-          Enum.map(rest, fn
-            # adds the "previous" argument so we can track the correct
-            # arity
-            {{{:., loc, call}, meta, args}, pos} ->
-              {{{:., loc, call}, meta, List.insert_at(args, pos, :previous)}, pos}
-
-            ast ->
-              ast
-          end)
-
-        {[first | unpiped], issues}
-
-      ast ->
-        {ast, issues}
-    end
+  defp traverse({:|>, loc, args}, issues, _issue_meta) do
+    {args, _} = Enum.reduce(args, {[], first?: true}, &mark_as_in_pipe/2)
+    ast = {:|>, loc, Enum.reverse(args)}
+    {ast, issues}
   end
 
   defp traverse({{:., _loc, call}, meta, args} = ast, issues, issue_meta) do
-    case get_forbidden_call(call, args) do
+    in_pipe? = Keyword.get(meta, :in_pipe?, false)
+
+    case get_forbidden_call(call, args, in_pipe?: in_pipe?) do
       {bad, suggestion} ->
         {ast, issues_for_call(bad, suggestion, meta, issue_meta, issues)}
 
@@ -82,31 +69,72 @@ defmodule Credo.Check.Warning.UnsafeToAtom do
     {ast, issues}
   end
 
-  defp get_forbidden_call([:erlang, :list_to_atom], [_]) do
+  defp mark_as_in_pipe({:|>, loc, args}, {acc, first?: first?}) do
+    {args, first?: first?} = Enum.reduce(args, {[], first?: first?}, &mark_as_in_pipe/2)
+    {[{:|>, loc, args} | acc], first?: first?}
+  end
+
+  defp mark_as_in_pipe({{:., call_meta, call}, meta, args}, {acc, first?: first?}) do
+    call_meta = Keyword.put(call_meta, :in_pipe?, not first?)
+    meta = Keyword.put(meta, :in_pipe?, not first?)
+    {[{{:., call_meta, call}, meta, args} | acc], first?: false}
+  end
+
+  defp mark_as_in_pipe({x, meta, args}, {acc, first?: first?}) do
+    {[{x, Keyword.put(meta, :in_pipe?, not first?), args} | acc], first?: false}
+  end
+
+  defp mark_as_in_pipe(ast, {acc, first?: first?}), do: {[ast | acc], first?: first?}
+
+  defp get_forbidden_call([:erlang, :list_to_atom], [_], in_pipe?: false) do
     {":erlang.list_to_atom/1", ":erlang.list_to_existing_atom/1"}
   end
 
-  defp get_forbidden_call([:erlang, :binary_to_atom], [_, _]) do
+  defp get_forbidden_call([:erlang, :list_to_atom], [], in_pipe?: true) do
+    {":erlang.list_to_atom/1", ":erlang.list_to_existing_atom/1"}
+  end
+
+  defp get_forbidden_call([:erlang, :binary_to_atom], [_, _], in_pipe?: false) do
     {":erlang.binary_to_atom/2", ":erlang.binary_to_existing_atom/2"}
   end
 
-  defp get_forbidden_call([{:__aliases__, _, [:String]}, :to_atom], [_]) do
+  defp get_forbidden_call([:erlang, :binary_to_atom], [_], in_pipe?: true) do
+    {":erlang.binary_to_atom/2", ":erlang.binary_to_existing_atom/2"}
+  end
+
+  defp get_forbidden_call([{:__aliases__, _, [:String]}, :to_atom], [_], in_pipe?: false) do
     {"String.to_atom/1", "String.to_existing_atom/1"}
   end
 
-  defp get_forbidden_call([{:__aliases__, _, [:List]}, :to_atom], [_]) do
+  defp get_forbidden_call([{:__aliases__, _, [:String]}, :to_atom], [], in_pipe?: true) do
+    {"String.to_atom/1", "String.to_existing_atom/1"}
+  end
+
+  defp get_forbidden_call([{:__aliases__, _, [:List]}, :to_atom], [_], in_pipe?: false) do
     {"List.to_atom/1", "List.to_existing_atom/1"}
   end
 
-  defp get_forbidden_call([{:__aliases__, _, [:Module]}, :concat], [_]) do
+  defp get_forbidden_call([{:__aliases__, _, [:List]}, :to_atom], [], in_pipe?: true) do
+    {"List.to_atom/1", "List.to_existing_atom/1"}
+  end
+
+  defp get_forbidden_call([{:__aliases__, _, [:Module]}, :concat], [_], in_pipe?: false) do
     {"Module.concat/1", "Module.safe_concat/1"}
   end
 
-  defp get_forbidden_call([{:__aliases__, _, [:Module]}, :concat], [_, _]) do
+  defp get_forbidden_call([{:__aliases__, _, [:Module]}, :concat], [], in_pipe?: true) do
+    {"Module.concat/1", "Module.safe_concat/1"}
+  end
+
+  defp get_forbidden_call([{:__aliases__, _, [:Module]}, :concat], [_, _], in_pipe?: false) do
     {"Module.concat/2", "Module.safe_concat/2"}
   end
 
-  defp get_forbidden_call([{:__aliases__, _, [:Jason]}, decode], args)
+  defp get_forbidden_call([{:__aliases__, _, [:Module]}, :concat], [_], in_pipe?: true) do
+    {"Module.concat/2", "Module.safe_concat/2"}
+  end
+
+  defp get_forbidden_call([{:__aliases__, _, [:Jason]}, decode], args, _in_pipe?)
        when decode in [:decode, :decode!] do
     args
     |> Enum.any?(fn arg -> Keyword.keyword?(arg) and Keyword.get(arg, :keys) == :atoms end)
@@ -117,7 +145,7 @@ defmodule Credo.Check.Warning.UnsafeToAtom do
     end
   end
 
-  defp get_forbidden_call(_, _) do
+  defp get_forbidden_call(_, _, _) do
     nil
   end
 

--- a/test/credo/check/warning/unsafe_to_atom_test.exs
+++ b/test/credo/check/warning/unsafe_to_atom_test.exs
@@ -60,6 +60,34 @@ defmodule Credo.Check.Warning.UnsafeToAtomTest do
     |> assert_issue()
   end
 
+  test "it should report a violation (piped)" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter) do
+        parameter
+        |> String.to_atom()
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation (start of pipe)" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter) do
+        String.to_atom(parameter)
+        |> IO.inspect()
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
   test "it should report a violation /2" do
     """
     defmodule CredoSampleModule do
@@ -73,11 +101,67 @@ defmodule Credo.Check.Warning.UnsafeToAtomTest do
     |> assert_issue()
   end
 
+  test "it should report a violation /2 (piped)" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter) do
+        parameter
+        |> List.to_atom()
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /2 (start of pipe)" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter) do
+        List.to_atom(parameter)
+        |> IO.inspect()
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
   test "it should report a violation /3" do
     """
     defmodule CredoSampleModule do
       def some_function(parameter) do
         Module.concat(__MODULE__, parameter)
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /3 (piped)" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter) do
+        __MODULE__
+        |> Module.concat(parameter)
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /3 (start of pipe)" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter) do
+        Module.concat(__MODULE__, parameter)
+        |> IO.inspect
       end
     end
     """
@@ -112,11 +196,67 @@ defmodule Credo.Check.Warning.UnsafeToAtomTest do
     |> assert_issue()
   end
 
+  test "it should report a violation /5 (piped)" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter) do
+        parameter
+        |> :erlang.list_to_atom()
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /5 (start of pipe)" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter) do
+        :erlang.list_to_atom(parameter)
+        |> IO.inspect()
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
   test "it should report a violation /6" do
     """
     defmodule CredoSampleModule do
       def some_function(parameter) do
         :erlang.binary_to_atom(parameter, :utf8)
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /6 (piped)" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter) do
+        parameter
+        |> :erlang.binary_to_atom(:utf8)
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /6 (start of pipe)" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter) do
+        :erlang.binary_to_atom(parameter, :utf8)
+        |> IO.inspect()
       end
     end
     """


### PR DESCRIPTION
Currently, if a call to `String.to_atom/1`, `List.to_atom/1`,
`Module.concat/{1,2}`, `:erlang.list_to_atom/1` and
`:erlang.binary_to_atom/2` is in a pipe (`|>`) chain, it is not
detected by the `UnsafeToAtom` check.

This change alters the prewalk check to unpipe those chains and insert
a phantom argument in the chain to make the arity "correct" and allow
detection.