### PR TITLE
Update example of checking properties of issue list to assert_issues

### DIFF
--- a/guides/custom_checks/testing_checks.md
+++ b/guides/custom_checks/testing_checks.md
@@ -108,7 +108,7 @@ list of `issues` found, which makes it convenient  to check for the issues prope
     """
     |> to_source_file()
     |> run_check(RejectModuleAttributes)
-    |> assert_issue(fn issues -> assert Enum.count(issues) == 3 end)
+    |> assert_issues(fn issues -> assert Enum.count(issues) == 3 end)
 
 ### Testing checks that analyse multiple source files
 


### PR DESCRIPTION
The documentation has an example of validating a property of a list of issues with `assert_issue`.

The anonymous function for `assert_issue` only receives a single issue, I think this example was supposed to use `assert_issues`, which takes a list of issues, instead.