### PR TITLE
Add configuration option to SinglePipe, to ignore 0-arity functions

### DIFF
--- a/lib/credo/check/readability/single_pipe.ex
+++ b/lib/credo/check/readability/single_pipe.ex
@@ -2,6 +2,7 @@ defmodule Credo.Check.Readability.SinglePipe do
   use Credo.Check,
     base_priority: :high,
     tags: [:controversial],
+    param_defaults: [allow_0_arity_functions: false],
     explanations: [
       check: """
       Pipes (`|>`) should only be used when piping data through multiple calls.
@@ -28,33 +29,77 @@ defmodule Credo.Check.Readability.SinglePipe do
       Like all `Readability` issues, this one is not a technical concern.
       But you can improve the odds of others reading and liking your code by making
       it easier to follow.
-      """
+
+      Piping 0-arity functions might be considered a valid exception to this rule
+
+      This example ...
+
+        my_function()
+        |> my_other_function()
+
+      ...could be considered easier to read than ...
+
+        my_other_function(my_function())
+
+      Because of this, the check can optionally ignore such cases (see configuration options).
+      """,
+      params: [
+        allow_0_arity_functions: "Piping local or foreign 0-arity functions is allowed."
+      ]
     ]
+
 
   @doc false
   @impl true
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
 
+    allow_0_arity_functions = Params.get(params, :allow_0_arity_functions, __MODULE__)
+
+
+
     {_continue, issues} =
-      Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta), {true, []})
+      Credo.Code.prewalk(
+        source_file,
+        &traverse(&1, &2, issue_meta, allow_0_arity_functions),
+        {true, []}
+      )
 
     issues
   end
 
   # TODO: consider for experimental check front-loader (ast)
-  defp traverse({:|>, _, [{:|>, _, _} | _]} = ast, {_, issues}, _) do
+  defp traverse({:|>, _, [{:|>, _, _} | _]} = ast, {_, issues}, _, _) do
     {ast, {false, issues}}
   end
 
-  defp traverse({:|>, meta, _} = ast, {true, issues}, issue_meta) do
+  # single pipe, with zero arity functions not allowed
+  defp traverse({:|>, meta, _} = ast, {true, issues}, issue_meta, false) do
     {
       ast,
       {false, issues ++ [issue_for(issue_meta, meta[:line], "|>")]}
     }
   end
 
-  defp traverse(ast, {_, issues}, _issue_meta) do
+  # single pipe, left operand is 0-arity local function, zero arity functions allowed
+  defp traverse({:|>, _, [{{:., _, _}, _, []}, _]} = ast, {true, issues}, _, true) do
+    {ast, {false, issues}}
+  end
+
+  # single pipe, left operand is 0-arity foreign function, zero arity functions allowed
+  defp traverse({:|>, _, [{fun, _, []}, _]} = ast, {true, issues}, _, true) when is_atom(fun) do
+    {ast, {false, issues}}
+  end
+
+  # single-pipe, left operand is not a function
+  defp traverse({:|>, meta, _} = ast, {true, issues}, issue_meta, true) do
+    {
+      ast,
+      {false, issues ++ [issue_for(issue_meta, meta[:line], "|>")]}
+    }
+  end
+
+  defp traverse(ast, {_, issues}, _issue_meta, _allow_functions) do
     {ast, {true, issues}}
   end
 

--- a/lib/credo/check/readability/single_pipe.ex
+++ b/lib/credo/check/readability/single_pipe.ex
@@ -86,7 +86,9 @@ defmodule Credo.Check.Readability.SinglePipe do
     {ast, {false, issues}}
   end
 
-  # single pipe, left operand is 0-arity foreign function, zero arity functions allowed
+  # single pipe, zero arity functions allowed, covers 2 cases
+  # - left operand is 0-arity foreign function
+  # - left operand is anonymous function
   defp traverse({:|>, _, [{fun, _, []}, _]} = ast, {true, issues}, _, true) when is_atom(fun) do
     {ast, {false, issues}}
   end

--- a/test/credo/check/readability/single_pipe_test.exs
+++ b/test/credo/check/readability/single_pipe_test.exs
@@ -73,6 +73,12 @@ defmodule Credo.Check.Readability.SinglePipeTest do
           OtherModule.foo() |> bar()
           foo() |> OtherModule.bar()
           foo() |> bar()
+
+          foo_anonymous = fn ->
+            nil
+          end
+
+          foo_anonymous.() |> bar()
         end
 
         def foo(), do: nil
@@ -97,6 +103,12 @@ defmodule Credo.Check.Readability.SinglePipeTest do
         OtherModule.foo() |> bar()
         foo() |> OtherModule.bar()
         foo() |> bar()
+
+        foo_anonymous = fn ->
+          nil
+        end
+
+        foo_anonymous.() |> bar()
       end
 
       def foo(), do: nil

--- a/test/credo/check/readability/single_pipe_test.exs
+++ b/test/credo/check/readability/single_pipe_test.exs
@@ -59,4 +59,71 @@ defmodule Credo.Check.Readability.SinglePipeTest do
     |> run_check(@described_check)
     |> assert_issues()
   end
+
+  test "it should report a violation if piping a 0-arity function and such functions not allowed" do
+    """
+    defmodule CredoSampleModule do
+      defmodule OtherModule do
+        def foo, do: nil
+        def bar(nil), do: nil
+      end
+
+      defmodule CredoSampleModule do
+        def test do
+          OtherModule.foo() |> bar()
+          foo() |> OtherModule.bar()
+          foo() |> bar()
+        end
+
+        def foo(), do: nil
+        def bar(nil), do: nil
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issues()
+  end
+
+  test "it should NOT report violation when piping 0-arity function and such functions allowed" do
+    """
+    defmodule OtherModule do
+      def foo, do: nil
+      def bar(nil), do: nil
+    end
+
+    defmodule CredoSampleModule do
+      def test do
+        OtherModule.foo() |> bar()
+        foo() |> OtherModule.bar()
+        foo() |> bar()
+      end
+
+      def foo(), do: nil
+      def bar(nil), do: nil
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check, allow_0_arity_functions: true)
+    |> refute_issues()
+  end
+
+  test "it should report violation when piping non-function and 0-arity functions allowed" do
+    """
+    defmodule CredoSampleModule do
+      def test do
+        :foo |> bar()
+
+        foo = "foo"
+        bar |> foo()
+      end
+
+      def bar(_), do: nil
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check, allow_0_arity_functions: true)
+    |> assert_issues()
+  end
+
 end


### PR DESCRIPTION
This is based on proposal-65 at https://github.com/rrrene/credo-proposals/issues/65

First time contributor to the repository, and I'm not really sure on what the conventions are, so any criticism is more than welcome.