### PR TITLE
Fix CI by switching to erlef/setup-elixir action

### DIFF
--- a/.github/workflows/bugfix-reproducer.yml
+++ b/.github/workflows/bugfix-reproducer.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.1
 
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2.3.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/compatibility-canary-smoke-tests.yml
+++ b/.github/workflows/compatibility-canary-smoke-tests.yml
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.1
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: 23
           elixir-version: 1.11.2

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -29,7 +29,7 @@ jobs:
         repo_branch: ["v1.10", "master"]
     steps:
       - uses: actions/checkout@v2.3.1
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -28,7 +28,7 @@ jobs:
         repo_branch: ["v1.4", "master"]
     steps:
       - uses: actions/checkout@v2.3.1
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
@@ -57,7 +57,7 @@ jobs:
             elixir: 1.10.4
     steps:
       - uses: actions/checkout@v2.3.1
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}


### PR DESCRIPTION
We had a similar issue with our CI. Some interaction between Ubuntu 20.04 and the crypto library caused all our builds to fail.

The easiest solution is to switch to the action's new home. It's been adopted by the The Erlang Ecosystem Foundation recently.

This is me just blindly shooting as an attempt to do a quick fix, so feel free to close if it doesn't work.
