### PR TITLE
Add new check for bad ecto migration timestamps

### DIFF
--- a/lib/credo/check/warning/bad_migration_timestamp.ex
+++ b/lib/credo/check/warning/bad_migration_timestamp.ex
@@ -1,0 +1,50 @@
+defmodule Credo.Check.Warning.BadMigrationTimestamp do
+  use Credo.Check,
+    base_priority: :high,
+    param_defaults: [included: ["priv/repo/migrations/*.exs"]],
+    explanations: [
+      check: """
+      If a migration file name is hand edited it is possible to have an aberrant timestamp
+      which will always be applied last no matter how many later migrations are added
+
+      This check ensures that migration files do not have such timestamps.
+      """
+    ]
+
+  @test_files_containing_timestamp ~r/(?<timestamp>\d{14}\d*).*.exs$/
+
+  alias Credo.SourceFile
+
+  @doc false
+  def run(%SourceFile{filename: filename} = source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    if map = Regex.named_captures(@test_files_containing_timestamp, filename) do
+      timestamp = map["timestamp"]
+      {ts_year, ""} = timestamp |> binary_part(0, 4) |> Integer.parse()
+      {ts_month, ""} = timestamp |> binary_part(4, 2) |> Integer.parse()
+      ts_length = String.length(timestamp)
+      %{year: year, month: month} = Date.utc_today
+
+      # to account for timezone/dateline differences, we should tolerate 1 "year" or 1 "month" of difference
+      # but more than that must be an error...  could do more fine grained checking, but coarse
+      # check seems good enough for detecting most user errors.
+      if ts_length > 14 or ts_year > year + 1 or (ts_year == year and ts_month > month + 1) do
+        issue_meta
+        |> issue_for()
+        |> List.wrap()
+      else
+        []
+      end
+    else
+      []
+    end
+  end
+
+  defp issue_for(issue_meta) do
+    format_issue(
+      issue_meta,
+      message: "Migration timestamps should be in past"
+    )
+  end
+end

--- a/test/credo/check/warning/bad_migration_timestamp_test.exs
+++ b/test/credo/check/warning/bad_migration_timestamp_test.exs
@@ -1,0 +1,68 @@
+defmodule Credo.Check.Warning.BadMigrationTimestampTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Warning.BadMigrationTimestamp
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report files that start with timestamp in past" do
+    """
+    defmodule Credo.Check.Warning.BadMigrationTimestampTest do
+      use Ecto.Migration
+      def change do
+        fake_migration
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20210331180839_test_case.exs")
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report non migration files" do
+    """
+    defmodule Credo.Check.Warning.BadMigrationTimestampTest do
+      def test do
+        "test"
+      end
+    end
+    """
+    |> to_source_file("random_path/some_file.ex")
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report files that have too long a timestamp" do
+    """
+    defmodule Credo.Check.Warning.BadMigrationTimestampTest do
+      use Ecto.Migration
+      def change do
+        fake_migration
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/202103311808399_test_case.exs")
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report files that have a timestamp in the future" do
+    """
+    defmodule Credo.Check.Warning.BadMigrationTimestampTest do
+      use Ecto.Migration
+      def change do
+        fake_migration
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/22210331180839_test_case.exs")
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+end


### PR DESCRIPTION
Hopefully this is a welcome PR and not out of scope since it's targeting an issue from a specific hex library?  Just thought it would be useful as I'm guilty of occasionally hand editing these files and have been bit by this once or twice!  Thanks, let me know if I can do anything further to help/improve!