### PR TITLE
Add GitHub output format (for GitHub Actions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Some IDEs and editors are able to run Credo in the background and mark issues in
 * [flycheck](https://www.flycheck.org/en/latest/languages.html#elixir) - Emacs syntax checking extension
 * [kakoune](https://github.com/mawww/kakoune/wiki/Lint#elixir) - Config for linting support in Kakoune editor
 
+### Continuous Integration
+
+* [GitHub Actions](https://docs.github.com/actions) - runs workflows within GitHub repositories (run `mix credo --format github` to create checks)
+
 ### Automated Code Review
 
 * [Codacy](https://www.codacy.com/) - checks your code from style to security, duplication, complexity, and also integrates with coverage.

--- a/guides/commands/suggest_command.md
+++ b/guides/commands/suggest_command.md
@@ -129,7 +129,7 @@ $ mix credo --files-excluded ./test/**/*.exs
 
 ### `--format`
 
-Display the list in a specific format (json, flycheck, or oneline)
+Display the list in a specific format (json, flycheck, github, or oneline)
 
 ```bash
 $ mix credo --format json

--- a/guides/configuration/cli_switches.md
+++ b/guides/configuration/cli_switches.md
@@ -13,6 +13,7 @@ Here are a couple of common use case and their respective command line switches:
 Use `--format` to format the output in one of the following formats:
 
 - `--format flycheck` for [Flycheck](http://www.flycheck.org/) output
+- `--format github` for [GitHub Actions](https://docs.github.com/actions/reference/workflow-commands-for-github-actions) output
 - `--format json` for [JSON](https://www.json.org/) output
 
 Additionally, you can deactivate the output's coloring by using `--no-color`.
@@ -139,7 +140,7 @@ Suggest options:
       --enable-disabled-checks  Re-enable disabled checks that match the given strings
       --files-included          Only include these files (accepts globs, can be used multiple times)
       --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-      --format                  Display the list in a specific format (json,flycheck,oneline)
+      --format                  Display the list in a specific format (json,flycheck,github,oneline)
   -i, --ignore-checks           Ignore checks that match the given strings
       --ignore                  Alias for --ignore-checks
       --min-priority            Minimum priority to show issues (high,medium,normal,low,lower or number)

--- a/lib/credo/cli/command/list/list_output.ex
+++ b/lib/credo/cli/command/list/list_output.ex
@@ -4,6 +4,7 @@ defmodule Credo.CLI.Command.List.ListOutput do
   use Credo.CLI.Output.FormatDelegator,
     default: Credo.CLI.Command.List.Output.Default,
     flycheck: Credo.CLI.Command.List.Output.FlyCheck,
+    github: Credo.CLI.Command.List.Output.GitHub,
     oneline: Credo.CLI.Command.List.Output.Oneline,
     json: Credo.CLI.Command.List.Output.Json
 
@@ -41,7 +42,7 @@ defmodule Credo.CLI.Command.List.ListOutput do
             --enable-disabled-checks  Re-enable disabled checks that match the given strings
             --files-included          Only include these files (accepts globs, can be used multiple times)
             --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-            --format                  Display the list in a specific format (json,flycheck,oneline)
+            --format                  Display the list in a specific format (json,flycheck,github,oneline)
         -i, --ignore-checks           Ignore checks that match the given strings
             --ignore                  Alias for --ignore-checks
             --min-priority            Minimum priority to show issues (high,medium,normal,low,lower or number)

--- a/lib/credo/cli/command/list/output/github.ex
+++ b/lib/credo/cli/command/list/output/github.ex
@@ -1,0 +1,14 @@
+defmodule Credo.CLI.Command.List.Output.GitHub do
+  @moduledoc false
+
+  alias Credo.CLI.Output.Formatter.GitHub
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> GitHub.print_issues()
+  end
+end

--- a/lib/credo/cli/command/suggest/output/github.ex
+++ b/lib/credo/cli/command/suggest/output/github.ex
@@ -1,0 +1,14 @@
+defmodule Credo.CLI.Command.Suggest.Output.GitHub do
+  @moduledoc false
+
+  alias Credo.CLI.Output.Formatter.GitHub
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> GitHub.print_issues()
+  end
+end

--- a/lib/credo/cli/command/suggest/suggest_output.ex
+++ b/lib/credo/cli/command/suggest/suggest_output.ex
@@ -4,6 +4,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
   use Credo.CLI.Output.FormatDelegator,
     default: Credo.CLI.Command.Suggest.Output.Default,
     flycheck: Credo.CLI.Command.Suggest.Output.FlyCheck,
+    github: Credo.CLI.Command.Suggest.Output.GitHub,
     oneline: Credo.CLI.Command.Suggest.Output.Oneline,
     json: Credo.CLI.Command.Suggest.Output.Json
 
@@ -41,7 +42,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
             --enable-disabled-checks  Re-enable disabled checks that match the given strings
             --files-included          Only include these files (accepts globs, can be used multiple times)
             --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-            --format                  Display the list in a specific format (json,flycheck,oneline)
+            --format                  Display the list in a specific format (json,flycheck,github,oneline)
         -i, --ignore-checks           Ignore checks that match the given strings
             --ignore                  Alias for --ignore-checks
             --min-priority            Minimum priority to show issues (high,medium,normal,low,lower or number)

--- a/lib/credo/cli/output/format_delegator.ex
+++ b/lib/credo/cli/output/format_delegator.ex
@@ -8,6 +8,7 @@ defmodule Credo.CLI.Output.FormatDelegator do
       use Credo.CLI.Output.FormatDelegator,
         default: Credo.CLI.Command.Suggest.Output.Default,
         flycheck: Credo.CLI.Command.Suggest.Output.FlyCheck,
+        github: Credo.CLI.Command.Suggest.Output.GitHub,
         oneline: Credo.CLI.Command.Suggest.Output.Oneline,
         json: Credo.CLI.Command.Suggest.Output.Json
 

--- a/lib/credo/cli/output/formatter/github.ex
+++ b/lib/credo/cli/output/formatter/github.ex
@@ -1,0 +1,30 @@
+defmodule Credo.CLI.Output.Formatter.GitHub do
+  @moduledoc false
+
+  alias Credo.CLI.Output
+  alias Credo.CLI.Output.UI
+  alias Credo.Issue
+
+  def print_issues(issues) do
+    Enum.each(issues, fn issue ->
+      issue
+      |> to_github()
+      |> UI.puts()
+    end)
+  end
+
+  def to_github(
+        %Issue{
+          message: message,
+          filename: filename,
+          column: column,
+          line_no: line_no,
+          priority: priority
+        } = issue
+      ) do
+    tag = Output.check_tag(issue, false)
+    priority = priority |> Output.priority_arrow()
+
+    "::error file=#{filename},line=#{line_no},col=#{column}::#{tag} #{priority} #{message}"
+  end
+end

--- a/lib/credo/cli/output/formatter/github.ex
+++ b/lib/credo/cli/output/formatter/github.ex
@@ -1,16 +1,25 @@
 defmodule Credo.CLI.Output.Formatter.GitHub do
   @moduledoc false
 
+  alias Credo.CLI.Filename
   alias Credo.CLI.Output
   alias Credo.CLI.Output.UI
   alias Credo.Issue
 
   def print_issues(issues) do
-    Enum.each(issues, fn issue ->
-      issue
-      |> to_github()
-      |> UI.puts()
-    end)
+    issues
+    |> Enum.group_by(& &1.filename)
+    |> Enum.flat_map(&to_github_group/1)
+    |> Enum.each(&UI.puts/1)
+  end
+
+  def to_github_group({filename, issues}) do
+    count = length(issues)
+    count_issues = if count == 1, do: "1 issue", else: "#{count} issues"
+
+    ["::group::#{count_issues} in #{filename}"] ++
+      Enum.flat_map(issues, &to_github/1) ++
+      ["::endgroup::"]
   end
 
   def to_github(
@@ -18,13 +27,16 @@ defmodule Credo.CLI.Output.Formatter.GitHub do
           message: message,
           filename: filename,
           column: column,
-          line_no: line_no,
-          priority: priority
+          line_no: line_no
         } = issue
       ) do
-    tag = Output.check_tag(issue, false)
-    priority = priority |> Output.priority_arrow()
+    category = issue.category |> to_string() |> String.capitalize()
+    arrow = issue.priority |> Output.priority_arrow()
+    pos_suffix = Filename.pos_suffix(line_no, column)
 
-    "::error file=#{filename},line=#{line_no},col=#{column}::#{tag} #{priority} #{message}"
+    [
+      "::error file=#{filename},line=#{line_no},col=#{column}::#{message} [#{arrow} #{category}]",
+      "  at #{filename}#{pos_suffix}"
+    ]
   end
 end

--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -26,10 +26,6 @@ defmodule Credo.CLI.Output.Summary do
     nil
   end
 
-  def print(_source_files, %Execution{format: "github"}, _time_load, _time_run) do
-    nil
-  end
-
   def print(_source_files, %Execution{format: "oneline"}, _time_load, _time_run) do
     nil
   end

--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -26,6 +26,10 @@ defmodule Credo.CLI.Output.Summary do
     nil
   end
 
+  def print(_source_files, %Execution{format: "github"}, _time_load, _time_run) do
+    nil
+  end
+
   def print(_source_files, %Execution{format: "oneline"}, _time_load, _time_run) do
     nil
   end


### PR DESCRIPTION
This PR adds a new output `--format github` for adding checks in [GitHub Actions](https://docs.github.com/actions) (via [workflow commands](https://docs.github.com/actions/reference/workflow-commands-for-github-actions)).

The checks are annotated in the workflow logs, grouped by file, as well as inline in the "compare files" view.

Please let me know if this is interesting and whether it needs any changes 🙂 