### PR TITLE
Revert #867 and #869

### DIFF
--- a/lib/credo/check/readability/predicate_function_names.ex
+++ b/lib/credo/check/readability/predicate_function_names.ex
@@ -77,7 +77,7 @@ defmodule Credo.Check.Readability.PredicateFunctionNames do
 
   defp issues_for_definition(op, body, issues, issue_meta) do
     case Enum.at(body, 0) do
-      {name, meta, _} ->
+      {name, meta, nil} ->
         issues_for_name(op, name, meta, issues, issue_meta)
 
       _ ->

--- a/lib/credo/check/refactor/cyclomatic_complexity.ex
+++ b/lib/credo/check/refactor/cyclomatic_complexity.ex
@@ -42,16 +42,15 @@ defmodule Credo.Check.Refactor.CyclomaticComplexity do
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
     max_complexity = Params.get(params, :max_complexity, __MODULE__)
-    ignore_guards = Params.get(params, :ignore_guards, __MODULE__)
 
     Credo.Code.prewalk(
       source_file,
-      &traverse(&1, &2, issue_meta, max_complexity, ignore_guards)
+      &traverse(&1, &2, issue_meta, max_complexity)
     )
   end
 
   # exception for `__using__` macros
-  defp traverse({:defmacro, _, [{:__using__, _, _}, _]} = ast, issues, _, _, _) do
+  defp traverse({:defmacro, _, [{:__using__, _, _}, _]} = ast, issues, _, _) do
     {ast, issues}
   end
 
@@ -59,24 +58,10 @@ defmodule Credo.Check.Refactor.CyclomaticComplexity do
   # NOTE: see above how we want to exclude certain front-loads
   for op <- @def_ops do
     defp traverse(
-           {unquote(op), meta, [{:when, _, [head | _guards]} | body] = _arguments},
-           issues,
-           issue_meta,
-           max_complexity,
-           true = _ignore_guards
-         ) do
-      ast = {unquote(op), meta, [head | body]}
-      traverse(ast, issues, issue_meta, max_complexity, false)
-    end
-  end
-
-  for op <- @def_ops do
-    defp traverse(
            {unquote(op), meta, arguments} = ast,
            issues,
            issue_meta,
-           max_complexity,
-           _ignore_guards
+           max_complexity
          )
          when is_list(arguments) do
       complexity =
@@ -106,7 +91,7 @@ defmodule Credo.Check.Refactor.CyclomaticComplexity do
     end
   end
 
-  defp traverse(ast, issues, _source_file, _max_complexity, _ignore_guards) do
+  defp traverse(ast, issues, _source_file, _max_complexity) do
     {ast, issues}
   end
 

--- a/test/credo/check/readability/predicate_function_names_test.exs
+++ b/test/credo/check/readability/predicate_function_names_test.exs
@@ -19,18 +19,6 @@ defmodule Credo.Check.Readability.PredicateFunctionNamesTest do
     |> refute_issues()
   end
 
-  test "it should NOT report expected code with arity on function" do
-    """
-    def valid?(a) do
-    end
-    defp has_attachment?(a) do
-    end
-    """
-    |> to_source_file
-    |> run_check(@described_check)
-    |> refute_issues()
-  end
-
   #
   # cases raising issues
   #
@@ -55,25 +43,5 @@ defmodule Credo.Check.Readability.PredicateFunctionNamesTest do
     |> to_source_file
     |> run_check(@described_check)
     |> assert_issues()
-  end
-
-  test "it should report a violation with arity" do
-    """
-    def is_valid?(a) do
-    end
-    """
-    |> to_source_file
-    |> run_check(@described_check)
-    |> assert_issue()
-  end
-
-  test "it should report a violation with arity /2" do
-    """
-    def is_valid(a) do
-    end
-    """
-    |> to_source_file
-    |> run_check(@described_check)
-    |> assert_issue()
   end
 end

--- a/test/credo/check/refactor/cyclomatic_complexity_test.exs
+++ b/test/credo/check/refactor/cyclomatic_complexity_test.exs
@@ -251,20 +251,4 @@ defmodule Credo.Check.Refactor.CyclomaticComplexityTest do
     |> assert_issue()
     |> assert_trigger(:foobar)
   end
-
-  test "it ignores cyclomatic complexity of guards when ignore_guards is true" do
-    """
-    defmodule CredoTest do
-    defp foobar(%{a: a, b: b, c: c, d: d, e: e, f: f,
-                  g: g, h: h, i: i, j: j}
-    ) when is_atom(a) and is_atom(b) and is_atom(c) and is_atom(d) and
-    is_atom(e) and is_atom(f) and is_atom(g) and is_atom(h) and is_atom(j) do
-      {a, b, c, d, e, f, g, h, i, j}
-    end
-    end
-    """
-    |> to_source_file
-    |> run_check(@described_check, max_complexity: 4, ignore_guards: true)
-    |> refute_issues()
-  end
 end


### PR DESCRIPTION
The contents of these PRs somehow broke the test suite, i.e.

    mix test

times out during random integration tests.

It is unclear at this point, what caused this:

1. Reverting only #867 *or* #869 did not fix it.
2. Reverting only the changes introduced in test/ or lib/ by those PRs did not fix it.