### PR TITLE
Add a check for IO.puts

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -182,6 +182,7 @@
           {Credo.Check.Refactor.AppendSingleItem, []},
           {Credo.Check.Refactor.DoubleBooleanNegation, []},
           {Credo.Check.Refactor.FilterReject, []},
+          {Credo.Check.Refactor.IoPuts, []},
           {Credo.Check.Refactor.MapMap, []},
           {Credo.Check.Refactor.ModuleDependencies, []},
           {Credo.Check.Refactor.NegatedIsNil, []},

--- a/lib/credo/check/refactor/io_puts.ex
+++ b/lib/credo/check/refactor/io_puts.ex
@@ -1,0 +1,47 @@
+defmodule Credo.Check.Refactor.IoPuts do
+  use Credo.Check,
+    base_priority: :high,
+    explanations: [
+      check: """
+      While calls to IO.puts might appear in some parts of production code,
+      most calls to this function are added during debugging sessions.
+
+      Consider using Logger statements instead, to benefit from its many features.
+      """
+    ]
+
+  @call_string "IO.puts"
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse(
+         {{:., _, [{:__aliases__, _, [:IO]}, :puts]}, meta, _arguments} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issues_for_call(meta, issues, issue_meta) do
+    [issue_for(issue_meta, meta[:line], @call_string) | issues]
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue(
+      issue_meta,
+      message: "There should be no calls to IO.puts/1.",
+      trigger: trigger,
+      line_no: line_no
+    )
+  end
+end

--- a/test/credo/check/refactor/io_puts_test.exs
+++ b/test/credo/check/refactor/io_puts_test.exs
@@ -1,0 +1,66 @@
+defmodule Credo.Check.Refactor.IoPutsTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Refactor.IoPuts
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report expected code" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report a violation" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        IO.puts parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /2" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        parameter1 + parameter2
+        |> IO.puts
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /3" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(a, b, c) do
+        map([a,b,c], &IO.puts(&1))
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+end


### PR DESCRIPTION
I was surprised to see that there was a check for `IO.inspect` and not for `IO.puts`, so I added one. It's almost an exact copy of the `IO.inspect` code.

Btw, thanks for your hard work on Credo! Saved me a bunch of time over the years.
