### PR TITLE
Add Elixir 1.12.2 and Erlang 24.0 to the CI matrix

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -15,19 +15,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [20.3, 21.3, 22.2, 23]
-        elixir: [1.7.4, 1.8.2, 1.9.4, 1.10.4, 1.11.2]
+        otp: [20.3, 21.3, 22.3, 23.3, 24.0]
+        elixir: [1.7.4, 1.8.2, 1.9.4, 1.10.4, 1.11.4, 1.12.2]
         exclude:
-          - otp: 23
+          - otp: 24.0
             elixir: 1.7.4
-          - otp: 23
+          - otp: 24.0
             elixir: 1.8.2
-          - otp: 23
+          - otp: 24.0
             elixir: 1.9.4
+          - otp: 24.0
+            elixir: 1.10.4
+          - otp: 23.3
+            elixir: 1.7.4
+          - otp: 23.3
+            elixir: 1.8.2
+          - otp: 23.3
+            elixir: 1.9.4
+          - otp: 21.3
+            elixir: 1.12.2
           - otp: 20.3
             elixir: 1.10.4
           - otp: 20.3
-            elixir: 1.11.2
+            elixir: 1.11.4
+          - otp: 20.3
+            elixir: 1.12.2
     steps:
       - uses: actions/checkout@v2.3.1
         with:

--- a/.github/workflows/compatibility-canary-smoke-tests.yml
+++ b/.github/workflows/compatibility-canary-smoke-tests.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "[${{matrix.project.name}}]"
     strategy:
+      fail-fast: false
       matrix:
         project:
           # Community projects

--- a/.github/workflows/compatibility-canary-smoke-tests.yml
+++ b/.github/workflows/compatibility-canary-smoke-tests.yml
@@ -92,8 +92,8 @@ jobs:
       - uses: actions/checkout@v2.3.1
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 23
-          elixir-version: 1.11.2
+          otp-version: 24.0
+          elixir-version: 1.12.2
       - run: mix deps.get
       - run: mix deps.compile
       - run: mix compile

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -12,19 +12,31 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Elixir ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [20.3, 21.3, 22.2, 23]
-        elixir: [1.7.4, 1.8.2, 1.9.4, 1.10.4, 1.11.2]
+        otp: [20.3, 21.3, 22.3, 23.3, 24.0]
+        elixir: [1.7.4, 1.8.2, 1.9.4, 1.10.4, 1.11.4, 1.12.2]
         exclude:
-          - otp: 23
+          - otp: 24.0
             elixir: 1.7.4
-          - otp: 23
+          - otp: 24.0
             elixir: 1.8.2
-          - otp: 23
+          - otp: 24.0
             elixir: 1.9.4
+          - otp: 24.0
+            elixir: 1.10.4
+          - otp: 23.3
+            elixir: 1.7.4
+          - otp: 23.3
+            elixir: 1.8.2
+          - otp: 23.3
+            elixir: 1.9.4
+          - otp: 21.3
+            elixir: 1.12.2
           - otp: 20.3
             elixir: 1.10.4
           - otp: 20.3
-            elixir: 1.11.2
+            elixir: 1.11.4
+          - otp: 20.3
+            elixir: 1.12.2
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
         repo_branch: ["v1.10", "master"]
     steps:

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -11,6 +11,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Elixir ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
+      fail-fast: false
       matrix:
         otp: [20.3, 21.3, 22.3, 23.3, 24.0]
         elixir: [1.7.4, 1.8.2, 1.9.4, 1.10.4, 1.11.4, 1.12.2]

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Phoenix ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
+      fail-fast: false
       matrix:
         otp: [20.3, 21.3, 22.3, 23.3, 24.0]
         elixir: [1.7.4, 1.8.2, 1.9.4, 1.10.4, 1.11.4, 1.12.2]

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -11,19 +11,31 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] Phoenix ${{matrix.repo_branch}} source code analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [20.3, 21.3, 22.2, 23]
-        elixir: [1.7.4, 1.8.2, 1.9.4, 1.10.4, 1.11.2]
+        otp: [20.3, 21.3, 22.3, 23.3, 24.0]
+        elixir: [1.7.4, 1.8.2, 1.9.4, 1.10.4, 1.11.4, 1.12.2]
         exclude:
-          - otp: 23
+          - otp: 24.0
             elixir: 1.7.4
-          - otp: 23
+          - otp: 24.0
             elixir: 1.8.2
-          - otp: 23
+          - otp: 24.0
             elixir: 1.9.4
+          - otp: 24.0
+            elixir: 1.10.4
+          - otp: 23.3
+            elixir: 1.7.4
+          - otp: 23.3
+            elixir: 1.8.2
+          - otp: 23.3
+            elixir: 1.9.4
+          - otp: 21.3
+            elixir: 1.12.2
           - otp: 20.3
             elixir: 1.10.4
           - otp: 20.3
-            elixir: 1.11.2
+            elixir: 1.11.4
+          - otp: 20.3
+            elixir: 1.12.2
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
         repo_branch: ["v1.4", "master"]
     steps:

--- a/lib/credo/code/interpolation_helper.ex
+++ b/lib/credo/code/interpolation_helper.ex
@@ -156,8 +156,6 @@ defmodule Credo.Code.InterpolationHelper do
   defp find_interpolations({{_line_no, _col_start2, _}, _list} = token, source) do
     {line_no, col_start, line_no_end, col_end} = Token.position(token)
 
-    {line_no, col_start, line_no_end, col_end}
-
     col_end =
       if line_no_end > line_no && col_end == 1 do
         # This means we encountered :eol and jumped in the next line.


### PR DESCRIPTION
Also updated Erlang 22.2 -> 22.3, Elixir 1.11.2 -> 1.11.4 and made Erlang 23 explicitly 23.3.

Removed a unused term that was warning on Elixir 1.11.4 and OTP 24.

Disables fail-fast for the compatibility CI tests.

Update the canary smoke tests to use the latest OTP 24.0 and Elixir 1.12.2