### PR TITLE
Add new check for one-arity functions in pipes

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -115,6 +115,7 @@
           {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
           {Credo.Check.Readability.VariableNames, []},
           {Credo.Check.Readability.WithSingleClause, []},
+          {Credo.Check.Readability.OneArityFunctionInPipe, []},
 
           #
           ## Refactoring Opportunities

--- a/.credo.exs
+++ b/.credo.exs
@@ -115,7 +115,6 @@
           {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
           {Credo.Check.Readability.VariableNames, []},
           {Credo.Check.Readability.WithSingleClause, []},
-          {Credo.Check.Readability.OneArityFunctionInPipe, []},
 
           #
           ## Refactoring Opportunities
@@ -176,6 +175,7 @@
           {Credo.Check.Readability.ImplTrue, []},
           {Credo.Check.Readability.MultiAlias, []},
           {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.OneArityFunctionInPipe, []},
           {Credo.Check.Readability.SeparateAliasRequire, []},
           {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
           {Credo.Check.Readability.SinglePipe, []},

--- a/lib/credo/check/readability/one_arity_function_in_pipe.ex
+++ b/lib/credo/check/readability/one_arity_function_in_pipe.ex
@@ -19,20 +19,19 @@ defmodule Credo.Check.Readability.OneArityFunctionInPipe do
     Credo.Code.prewalk(source_file, &traverse(&1, &2, IssueMeta.for(source_file, params)))
   end
 
-  defp traverse(ast, issues, issue_meta) do
-    case issue(ast, issue_meta) do
-      nil -> {ast, issues}
-      issue -> {ast, [issue | issues]}
-    end
+  defp traverse({:|>, _, [_, {name, meta, nil}]} = ast, issues, issue_meta) when is_atom(name) do
+    {ast, [issue(issue_meta, meta[:line]) | issues]}
   end
 
-  defp issue({:|>, _meta, [_left, {name, meta, nil}]}, issue_meta) when is_atom(name) do
+  defp traverse(ast, issues, _) do
+    {ast, issues}
+  end
+
+  defp issue(meta, line) do
     format_issue(
-      issue_meta,
+      meta,
       message: "One arity functions should have parentheses in pipes",
-      line_no: meta[:line]
+      line_no: line
     )
   end
-
-  defp issue(_ast, _issue_meta), do: nil
 end

--- a/lib/credo/check/readability/one_arity_function_in_pipe.ex
+++ b/lib/credo/check/readability/one_arity_function_in_pipe.ex
@@ -1,0 +1,39 @@
+defmodule Credo.Check.Readability.OneArityFunctionInPipe do
+  use Credo.Check,
+    base_priority: :low,
+    explanations: [
+      check: """
+      Use parentheses for one-arity functions when using the pipe operator (|>).
+
+          # not preferred
+          some_string |> String.downcase |> String.trim
+
+          # preferred
+          some_string |> String.downcase() |> String.trim()
+      ```
+      """
+    ]
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, IssueMeta.for(source_file, params)))
+  end
+
+  defp traverse(ast, issues, issue_meta) do
+    case issue(ast, issue_meta) do
+      nil -> {ast, issues}
+      issue -> {ast, [issue | issues]}
+    end
+  end
+
+  defp issue({:|>, _meta, [_left, {name, meta, nil}]}, issue_meta) when is_atom(name) do
+    format_issue(
+      issue_meta,
+      message: "One arity functions should have parentheses in pipes",
+      line_no: meta[:line]
+    )
+  end
+
+  defp issue(_ast, _issue_meta), do: nil
+end

--- a/lib/credo/check/readability/one_arity_function_in_pipe.ex
+++ b/lib/credo/check/readability/one_arity_function_in_pipe.ex
@@ -10,7 +10,6 @@ defmodule Credo.Check.Readability.OneArityFunctionInPipe do
 
           # preferred
           some_string |> String.downcase() |> String.trim()
-      ```
       """
     ]
 

--- a/test/credo/check/readability/one_arity_function_in_pipe_test.exs
+++ b/test/credo/check/readability/one_arity_function_in_pipe_test.exs
@@ -1,0 +1,74 @@
+defmodule Credo.Check.Readability.OneArityFunctionInPipeTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Readability.OneArityFunctionInPipe
+
+  test "it should report a violation for missing parentheses" do
+    """
+    defmodule Test do
+      def some_function(arg) do
+        arg
+        |> foo()
+        |> bar
+        |> baz()
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report violations for missing parentheses" do
+    """
+    defmodule Test do
+      def some_function(arg) do
+        arg
+        |> foo
+        |> bar
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issues()
+  end
+
+  test "it should NOT report violation for a valid pipe" do
+    """
+    defmodule Test do
+      def some_function(arg) do
+        arg |> foo() |> bar()
+      end
+
+      def other_function(arg) do
+        arg
+        |> foo()
+        |> bar()
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report violation for a valid pipe with a block" do
+    """
+    defmodule Test do
+      def other_function(arg) do
+        arg
+        |> foo()
+        |> case do
+          :x -> :y
+          :u -> :u
+        end
+        |> bar()
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+end


### PR DESCRIPTION
Some style guides propose:
> Use parentheses for one-arity functions when using the pipe operator (|>)
> ```elixir
> # not preferred
> some_string |> String.downcase |> String.trim
> 
> # preferred
> some_string |> String.downcase() |> String.trim()
> ```
This PR provides a check for that.