### PR TITLE
Grammar fix

### DIFF
--- a/lib/credo/check/refactor/unless_with_else.ex
+++ b/lib/credo/check/refactor/unless_with_else.ex
@@ -29,7 +29,7 @@ defmodule Credo.Check.Refactor.UnlessWithElse do
 
       The reason for this is not a technical but a human one. The `else` in this
       case will be executed when the condition is met, which is the opposite of
-      what the wording seems to apply.
+      what the wording seems to imply.
       """
     ]
 


### PR DESCRIPTION
Hello, I am a maintainer of the Elixir track on [Exercism](https://exercism.org), and one of the tool in the track I work on is a [code analyzer](https://github.com/exercism/elixir-analyzer). Credo has inspired us a lot for that project, so many thanks to you.

Long story short, we were working on a check for `unless` with `else`, we looked at the message you provided, and found a typo in it.