### PR TITLE
fix: handle errors from tokenizer on elixir 1.13+

### DIFF
--- a/lib/credo/check/refactor/abc_size.ex
+++ b/lib/credo/check/refactor/abc_size.ex
@@ -211,7 +211,7 @@ defmodule Credo.Check.Refactor.ABCSize do
          [a: a, b: b, c: c, var_names: var_names],
          excluded_functions
        )
-       when is_atom(fun_name) and not (fun_name in @non_calls) and is_list(arguments) do
+       when is_atom(fun_name) and fun_name not in @non_calls and is_list(arguments) do
     if Enum.member?(excluded_functions, to_string(fun_name)) do
       {nil, [a: a, b: b, c: c, var_names: var_names]}
     else

--- a/lib/credo/check/warning/application_config_in_module_attribute.ex
+++ b/lib/credo/check/warning/application_config_in_module_attribute.ex
@@ -98,9 +98,7 @@ defmodule Credo.Check.Warning.ApplicationConfigInModuleAttribute do
   defp issues_for_call(attribute, call, meta, issue_meta, issues) do
     options = [
       message:
-        "Module attribute @#{Atom.to_string(attribute)} makes use of unsafe Application configuration call #{
-          call
-        }",
+        "Module attribute @#{Atom.to_string(attribute)} makes use of unsafe Application configuration call #{call}",
       trigger: call,
       line_no: meta[:line]
     ]

--- a/lib/credo/check/warning/forbidden_module.ex
+++ b/lib/credo/check/warning/forbidden_module.ex
@@ -15,7 +15,9 @@ defmodule Credo.Check.Warning.ForbiddenModule do
       but direct usage of the `Ecto.Adapters.SQL.query/4` function, and related functions, may
       cause issues when using Ecto's dynamic repositories.
       """,
-      params: [modules: "List of Modules or {Module, \"Error message\"} Tuples that must not be used."]
+      params: [
+        modules: "List of Modules or {Module, \"Error message\"} Tuples that must not be used."
+      ]
     ]
 
   alias Credo.Code

--- a/lib/credo/cli/output/ui.ex
+++ b/lib/credo/cli/output/ui.ex
@@ -55,9 +55,7 @@ defmodule Credo.CLI.Output.UI do
   end
 
   def wrap_at(text, number) do
-    "(?:((?>.{1,#{number}}(?:(?<=[^\\S\\r\\n])[^\\S\\r\\n]?|(?=\\r?\\n)|$|[^\\S\\r\\n]))|.{1,#{
-      number
-    }})(?:\\r?\\n)?|(?:\\r?\\n|$))"
+    "(?:((?>.{1,#{number}}(?:(?<=[^\\S\\r\\n])[^\\S\\r\\n]?|(?=\\r?\\n)|$|[^\\S\\r\\n]))|.{1,#{number}})(?:\\r?\\n)?|(?:\\r?\\n|$))"
     |> Regex.compile!("u")
     |> Regex.scan(text)
     |> Enum.map(&List.first/1)

--- a/lib/credo/code.ex
+++ b/lib/credo/code.ex
@@ -143,6 +143,9 @@ defmodule Credo.Code do
       # Elixir >= 1.13
       {:ok, _, _, _, tokens} ->
         tokens
+
+      {:error, _, _, _, tokens} ->
+        tokens
     end
   end
 

--- a/lib/credo/code/interpolation_helper.ex
+++ b/lib/credo/code/interpolation_helper.ex
@@ -80,7 +80,6 @@ defmodule Credo.Code.InterpolationHelper do
     handle_heredoc(token, source)
   end
 
-
   #
   # Elixir >= 1.11.0
   #
@@ -130,7 +129,7 @@ defmodule Credo.Code.InterpolationHelper do
     handle_atom_string_or_sigil(token, list, source)
   end
 
-  defp map_interpolations(token, _source) do 
+  defp map_interpolations(_token, _source) do
     []
   end
 
@@ -167,7 +166,7 @@ defmodule Credo.Code.InterpolationHelper do
          _source
        )
        when is_list(list) do
-     {line_no, col_start, line_no_end, col_end + 1}
+    {line_no, col_start, line_no_end, col_end + 1}
   end
 
   # {{1, 25, 32}, [{:identifier, {1, 27, 31}, :name}]}

--- a/lib/credo/code/interpolation_helper.ex
+++ b/lib/credo/code/interpolation_helper.ex
@@ -71,6 +71,17 @@ defmodule Credo.Code.InterpolationHelper do
   end
 
   #
+  # Elixir >= 1.13.0
+  #
+  defp map_interpolations(
+         {:bin_heredoc, {_line_no, _col_start, _}, _, _list} = token,
+         source
+       ) do
+    handle_heredoc(token, source)
+  end
+
+
+  #
   # Elixir >= 1.11.0
   #
   defp map_interpolations(
@@ -119,7 +130,9 @@ defmodule Credo.Code.InterpolationHelper do
     handle_atom_string_or_sigil(token, list, source)
   end
 
-  defp map_interpolations(_, _source), do: []
+  defp map_interpolations(token, _source) do 
+    []
+  end
 
   defp handle_atom_string_or_sigil(_token, list, source) do
     find_interpolations(list, source)
@@ -138,6 +151,11 @@ defmodule Credo.Code.InterpolationHelper do
     |> add_to_col_start_and_end(padding_in_first_line)
   end
 
+  # Elixir 1.13+
+  defp handle_heredoc({atom, {line_no, col_start, col_end}, _, list}, source) do
+    handle_heredoc({atom, {line_no, col_start, col_end}, list}, source)
+  end
+
   defp find_interpolations(list, source) when is_list(list) do
     Enum.map(list, &find_interpolations(&1, source))
   end
@@ -149,7 +167,7 @@ defmodule Credo.Code.InterpolationHelper do
          _source
        )
        when is_list(list) do
-    {line_no, col_start, line_no_end, col_end + 1}
+     {line_no, col_start, line_no_end, col_end + 1}
   end
 
   # {{1, 25, 32}, [{:identifier, {1, 27, 31}, :name}]}

--- a/test/credo/check/readability/single_pipe_test.exs
+++ b/test/credo/check/readability/single_pipe_test.exs
@@ -137,5 +137,4 @@ defmodule Credo.Check.Readability.SinglePipeTest do
     |> run_check(@described_check, allow_0_arity_functions: true)
     |> assert_issues()
   end
-
 end

--- a/test/credo/check/refactor/redundant_with_clause_result_test.exs
+++ b/test/credo/check/refactor/redundant_with_clause_result_test.exs
@@ -67,7 +67,6 @@ defmodule Credo.Check.Refactor.RedundantWithClauseResultTest do
     |> refute_issues()
   end
 
-
   test "it shouldn't check calls to functions called \"with\"" do
     """
     def some_function(parameter1, parameter2) do


### PR DESCRIPTION
Related to https://github.com/rrrene/credo/issues/893. 

This still doesn't fix interpolation, which is broken.