### PR TITLE
FIX: detect unused variable when using guards

### DIFF
--- a/lib/credo/check/consistency/unused_variable_names/collector.ex
+++ b/lib/credo/check/consistency/unused_variable_names/collector.ex
@@ -37,7 +37,13 @@ defmodule Credo.Check.Consistency.UnusedVariableNames.Collector do
   defp reduce_unused_variables(nil, _callback, acc), do: acc
 
   defp reduce_unused_variables(ast, callback, acc) do
-    Enum.reduce(ast, acc, &if(unused_variable_name?(&1), do: callback.(&1, &2), else: &2))
+    Enum.reduce(ast, acc, fn
+      {_, _, params}, param_acc when is_list(params) ->
+        reduce_unused_variables(params, callback, param_acc)
+
+      param_ast, param_acc ->
+        if unused_variable_name?(param_ast), do: callback.(param_ast, param_acc), else: param_acc
+    end)
   end
 
   defp unused_variable_name?({:_, _, _}), do: true

--- a/test/credo/check/consistency/unused_variable_names_test.exs
+++ b/test/credo/check/consistency/unused_variable_names_test.exs
@@ -105,12 +105,72 @@ defmodule Credo.Check.Consistency.UnusedVariableNamesTest do
     end)
   end
 
+  test "it should report a violation for different naming schemes with guards (expects anonymous)" do
+    [
+      """
+      defmodule Credo.SampleOne do
+        defmodule Foo do
+          def bar(_, _, _) do
+          end
+        end
+      end
+      """,
+      """
+      defmodule Credo.SampleTwo do
+        defmodule Foo do
+          def bar(_, x2, _x3) when is_nil(x2) do
+          end
+        end
+      end
+      """
+    ]
+    |> to_source_files
+    |> run_check(@described_check)
+    |> assert_issue(fn issue ->
+      assert "_x3" == issue.trigger
+      assert 3 == issue.line_no
+    end)
+  end
+
   test "it should report a violation for different naming schemes (expects meaningful)" do
     [
       """
       defmodule Credo.SampleOne do
         defmodule Foo do
           def bar(name, _) do
+            case name do
+              "foo" <> _name -> "FOO"
+              "bar" <> _name -> "BAR"
+              _name -> "DEFAULT"
+            end
+          end
+        end
+      end
+      """,
+      """
+      defmodule Credo.SampleTwo do
+        defmodule Foo do
+          def bar(list) do
+            Enum.map(list, fn _item -> 1 end)
+          end
+        end
+      end
+      """
+    ]
+    |> to_source_files
+    |> run_check(@described_check)
+    |> assert_issue(fn issue ->
+      assert "_" == issue.trigger
+      assert 3 == issue.line_no
+    end)
+  end
+
+  test "it should report a violation for different naming schemes with guards (expects meaningful)" do
+    [
+      """
+      defmodule Credo.SampleOne do
+        defmodule Foo do
+          def bar(name, _) when is_binary(name) do
             case name do
               "foo" <> _name -> "FOO"
               "bar" <> _name -> "BAR"


### PR DESCRIPTION
Hello credo team! 👋 

First of all thankyou for this great package! 

When enabling`UnusedVariableNames` rule I noticed that it doesnt detect the unused variable when using guard due to different structure of the ast

```elixir
# ast without guard <--- supported
[
  {:_, [line: 3, column: 13], nil},
  {:_, [line: 3, column: 16], nil},
  {:_, [line: 3, column: 19], nil}
]

# ast with guard <--- not supported
[
  {:bar, [line: 3, column: 9],
   [
     {:_, [line: 3, column: 13], nil},
     {:x2, [line: 3, column: 16], nil},
     {:_x3, [line: 3, column: 20], nil}
   ]},
  {:is_nil, [line: 3, column: 30], [{:x2, [line: 3, column: 37], nil}]}
]
```

To give concrete example, if the function is using guard with unused variable, the unused variable will not be detected by the collector
```elixir
# credo.exs
Credo.Check.Consistency.UnusedVariableNames, [force: :anonymous]

# some_file.ex
# _x3 will be not be detected as unused variable, and will NOT complain about the consistency
def bar(_, x2, _x3) when is_nil(x2) do
```

so this proposal change will try to address that. 
This is my first time contributing this repo, so please let me know if I needed to do something else.

Thankyou! 