### PR TITLE
Extend Credo.Check.Warning.IoInspect to consider Elixir.IO.inspect in addition to IO.inspect

### DIFF
--- a/lib/credo/check/warning/io_inspect.ex
+++ b/lib/credo/check/warning/io_inspect.ex
@@ -22,6 +22,14 @@ defmodule Credo.Check.Warning.IoInspect do
   end
 
   defp traverse(
+        {{:., _, [{:__aliases__, _, [:Elixir, :IO]}, :inspect]}, meta, _arguments} = ast,
+        issues,
+        issue_meta
+      ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(
          {{:., _, [{:__aliases__, _, [:IO]}, :inspect]}, meta, _arguments} = ast,
          issues,
          issue_meta

--- a/test/credo/check/warning/io_inspect_test.exs
+++ b/test/credo/check/warning/io_inspect_test.exs
@@ -63,4 +63,17 @@ defmodule Credo.Check.Warning.IoInspectTest do
     |> run_check(@described_check)
     |> assert_issue()
   end
+
+  test "it should report a violation /4" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        Elixir.IO.inspect parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
 end


### PR DESCRIPTION
As originally proposed in https://github.com/rrrene/credo-proposals/issues/72, this PR extends the `Credo.Check.Warning.IoInspect` check to also consider calls to `Elixir.IO.inspect` under the same rule, as the two calls are functionally the same.