### PR TITLE
Detect end of ~A""" style sigils correctly when searching for config comments

### DIFF
--- a/lib/credo/code/sigils.ex
+++ b/lib/credo/code/sigils.ex
@@ -271,17 +271,6 @@ defmodule Credo.Code.Sigils do
       parse_removable_sigil(t, acc <> replacement <> replacement, unquote(sigil_end), replacement)
     end
 
-    if sigil_end != "\"" do
-      defp parse_removable_sigil(
-             <<"\""::utf8, t::binary>>,
-             acc,
-             unquote(sigil_end),
-             replacement
-           ) do
-        parse_removable_sigil(t, acc <> replacement, unquote(sigil_end), replacement)
-      end
-    end
-
     defp parse_removable_sigil(
            <<unquote("\\#{sigil_end}")::utf8, t::binary>>,
            acc,
@@ -303,6 +292,17 @@ defmodule Credo.Code.Sigils do
            replacement
          ) do
       parse_code(t, acc <> unquote(sigil_end), replacement)
+    end
+
+    if sigil_end != "\"" do
+      defp parse_removable_sigil(
+             <<"\""::utf8, t::binary>>,
+             acc,
+             unquote(sigil_end),
+             replacement
+           ) do
+        parse_removable_sigil(t, acc <> replacement, unquote(sigil_end), replacement)
+      end
     end
 
     defp parse_removable_sigil(

--- a/test/credo/check/config_comment_finder_test.exs
+++ b/test/credo/check/config_comment_finder_test.exs
@@ -44,4 +44,29 @@ defmodule Credo.Check.ConfigCommentFinderTest do
     assert Enum.find(config_comments, &(&1.line_no == 11 && &1.line_no_end == 15))
     assert Enum.find(config_comments, &(&1.line_no == 18 && &1.line_no_end == 21))
   end
+
+  test "it finds config comments after sigils with heredoc delimiter" do
+    source_files =
+      [
+        """
+        defmodule MyModule do
+          def render do
+            ~F\"\"\"
+            \"\"\"
+          end
+
+          # credo:disable-for-next-line
+          def foo, do: :ok
+        end
+        """
+      ]
+      |> to_source_files
+
+    config_comments =
+      source_files
+      |> ConfigCommentFinder.run()
+      |> Enum.flat_map(fn {_filename, config_comments} -> config_comments end)
+
+    assert [%Credo.Check.ConfigComment{instruction: "disable-for-next-line", line_no: 7}] = config_comments
+  end
 end

--- a/test/credo/code/sigils_test.exs
+++ b/test/credo/code/sigils_test.exs
@@ -340,4 +340,24 @@ defmodule Credo.Code.SigilsTest do
     assert result == result2, "Sigils.replace_with_spaces/2 should be idempotent"
     assert match?({:ok, _}, Code.string_to_quoted(result))
   end
+
+  test "it should not replace the remaining contents of the file with whitespace" do
+    source = "
+    ~F\"\"\"
+    \"\"\"
+
+    :ok
+    "
+
+    expected = "
+    ~F\"\"\"
+    \"\"\"
+
+    :ok
+    "
+
+    result = Sigils.replace_with_spaces(source)
+    assert result == expected
+    assert match?({:ok, _}, Code.string_to_quoted(result))
+  end
 end


### PR DESCRIPTION
# Summary

This fixes a bug that presents itself with the following behavior:

The existence of a heredoc-style sigil (with `"""` delimiters) causes credo to ignore all config comments appearing after the sigil.

# Impact

This affects code written with any library that defines a sigil and is commonly used in heredoc style, such as [LiveView](https://hex.pm/packages/phoenix_live_view) (with HEEx `~H` sigils) and [Surface](https://hex.pm/packages/surface) (with `~F` sigils).

# Explanation of Fix

Internally, there is a mechanism that replaces the contents of sigils with spaces in order to avoid misinterpreting their contents as config comments. This mechanism was unable to properly detect the end of the sigil. As a result, code like this

```elixir
defmodule MyModule do
  def render do
    ~F"""
    """
  end

  # BUG: The following config comment will be ignored by Credo
  # credo:disable-for-next-line
  def foo, do: :ok
end
```

would be replaced with

```elixir
defmodule MyModule do
  def render do
    ~F"""
       
     

                                                              
                               
                  
   
```

before searching it for `# credo:`-style config comments. (Note, the last 7 lines were replaced with space characters)