### PR TITLE
Check plugin module loaded fixed

### DIFF
--- a/lib/credo/execution/task/initialize_plugins.ex
+++ b/lib/credo/execution/task/initialize_plugins.ex
@@ -12,7 +12,7 @@ defmodule Credo.Execution.Task.InitializePlugins do
   defp init_plugin(exec, {_mod, false}), do: exec
 
   defp init_plugin(exec, {mod, _params}) do
-    module_loaded? = function_exported?(mod, :__info__, 1)
+    module_loaded? = Code.ensure_loaded?(mod)
 
     if module_loaded? do
       exec


### PR DESCRIPTION
Closes #928 replacing `function_exported?/3` by `Code.ensure_loaded?/1` as well as indicated in documentation:

> Note that this function does not load the module in case it is not loaded. Check Code.ensure_loaded/1 for more information.

[https://hexdocs.pm/elixir/Kernel.html#function_exported?/3](https://hexdocs.pm/elixir/Kernel.html#function_exported?/3)