### PR TITLE
Add alias -i to ignore options

### DIFF
--- a/lib/credo/cli/command/suggest/suggest_command.ex
+++ b/lib/credo/cli/command/suggest/suggest_command.ex
@@ -25,7 +25,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestCommand do
       Switch.string("format"),
       Switch.boolean("help", alias: :h),
       Switch.string("ignore_checks"),
-      Switch.string("ignore"),
+      Switch.string("ignore", alias: :i),
       Switch.string("only"),
       Switch.boolean("read_from_stdin"),
       Switch.boolean("strict"),


### PR DESCRIPTION
The documentation lists `-i` as an alias for `--ignore`/`--ignore-checks`, however it wasn't specified in the options.