### PR TITLE
Add nested function calls check

### DIFF
--- a/lib/credo/check/readability/nested_function_calls.ex
+++ b/lib/credo/check/readability/nested_function_calls.ex
@@ -111,16 +111,6 @@ defmodule Credo.Check.Readability.NestedFunctionCalls do
   # Module.function_call()
   defp valid_chain_start?({{:., _, _}, _, []}), do: true
 
-  # Elixir <= 1.8.0
-  # '__#{val}__' are compiled to String.to_charlist("__#{val}__")
-  # we want to consider these charlists a valid pipe chain start
-  defp valid_chain_start?({{:., _, [String, :to_charlist]}, _, [{:<<>>, _, _}]}), do: true
-
-  # Elixir >= 1.8.0
-  # '__#{val}__' are compiled to String.to_charlist("__#{val}__")
-  # we want to consider these charlists a valid pipe chain start
-  defp valid_chain_start?({{:., _, [List, :to_charlist]}, _, [[_ | _]]}), do: true
-
   # Kernel.to_string is invoked for string interpolation e.g. "string #{variable}"
   defp valid_chain_start?({{:., _, [Kernel, :to_string]}, _, _}), do: true
 

--- a/lib/credo/check/readability/nested_function_calls.ex
+++ b/lib/credo/check/readability/nested_function_calls.ex
@@ -13,12 +13,12 @@ defmodule Credo.Check.Readability.NestedFunctionCalls do
 
       The code in this example ...
 
-          Enum.shuffle(integers(3))
+          Enum.shuffle(Enum.uniq([1,2,3,3]))
 
       ... should be refactored to look like this:
 
-          3
-          |> integers()
+          [1,2,3,3]
+          |> Enum.uniq()
           |> Enum.shuffle()
 
       Nested function calls make the code harder to read. Instead, break the

--- a/lib/credo/check/readability/nested_function_calls.ex
+++ b/lib/credo/check/readability/nested_function_calls.ex
@@ -1,0 +1,126 @@
+defmodule Credo.Check.Readability.NestedFunctionCalls do
+  use Credo.Check,
+    base_priority: :high,
+    tags: [:controversial],
+    param_defaults: [min_pipeline_length: 2],
+    explanations: [
+      check: """
+      A function call should not be nested inside another function call.
+
+      So while this is fine:
+
+          Enum.shuffle([1,2,3])
+
+      The code in this example ...
+
+          Enum.shuffle(integers(3))
+
+      ... should be refactored to look like this:
+
+          3
+          |> integers()
+          |> Enum.shuffle()
+
+      Nested function calls make the code harder to read. Instead, break the
+      function calls out into a pipeline.
+
+      Like all `Readability` issues, this one is not a technical concern.
+      But you can improve the odds of others reading and liking your code by making
+      it easier to follow.
+      """,
+      params: [
+        min_pipeline_length: "Set a minimum pipeline length"
+      ]
+    ]
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    min_pipeline_length = Params.get(params, :min_pipeline_length, __MODULE__)
+
+    {_continue, issues} =
+      Credo.Code.prewalk(
+        source_file,
+        &traverse(&1, &2, issue_meta, min_pipeline_length),
+        {true, []}
+      )
+
+    issues
+  end
+
+  # A call with no arguments
+  defp traverse({{:., _loc, call}, meta, []} = ast, {_, issues}, _, min_pipeline_length) do
+    {ast, {true, issues}}
+  end
+
+  # A call with arguments
+  defp traverse({{:., _loc, call}, meta, args} = ast, {_, issues}, issue_meta, min_pipeline_length) do
+    if valid_chain_start?(ast) do
+      {ast, {min_pipeline_length, issues}}
+    else
+      case length_as_pipeline(args) + 1 do
+        potential_pipeline_length when potential_pipeline_length >= min_pipeline_length ->
+          {ast, {min_pipeline_length, issues ++ [issue_for(issue_meta, meta[:line], "something")]}}
+        _ ->
+          {ast, {min_pipeline_length, issues}}
+      end
+    end
+  end
+
+  # Another expression
+  defp traverse(ast, {_, issues}, _issue_meta, min_pipeline_length) do
+    {ast, {min_pipeline_length, issues}}
+  end
+
+  # Call with no arguments
+  defp length_as_pipeline([{{:., _loc, call}, meta, []}|_]) do
+    0
+  end
+
+  # Call with function call for first argument
+  defp length_as_pipeline([{{:., _loc, call}, meta, args} = call_ast|_]) do
+    if valid_chain_start?(call_ast) do
+      0
+    else
+      1 + length_as_pipeline(args)
+    end
+  end
+
+  # Call where the first argument isn't another function call
+  defp length_as_pipeline(args) do
+    0
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue(
+      issue_meta,
+      message: "Use a pipeline when there are nested function calls",
+      trigger: trigger,
+      line_no: line_no
+    )
+  end
+
+  # Taken from the Credo.Check.Refactor.PipeChainStart module, with modifications
+  # map[:access]
+  defp valid_chain_start?({{:., _, [Access, :get]}, _, _}), do: true
+
+  # Module.function_call()
+  defp valid_chain_start?({{:., _, _}, _, []}), do: true
+
+  # Elixir <= 1.8.0
+  # '__#{val}__' are compiled to String.to_charlist("__#{val}__")
+  # we want to consider these charlists a valid pipe chain start
+  defp valid_chain_start?({{:., _, [String, :to_charlist]}, _, [{:<<>>, _, _}]}), do: true
+
+  # Elixir >= 1.8.0
+  # '__#{val}__' are compiled to String.to_charlist("__#{val}__")
+  # we want to consider these charlists a valid pipe chain start
+  defp valid_chain_start?({{:., _, [List, :to_charlist]}, _, [[_ | _]]}), do: true
+
+  # Kernel.to_string is invoked for string interpolation e.g. "string #{variable}"
+  defp valid_chain_start?({{:., _, [Kernel, :to_string]}, _, _}), do: true
+
+  defp valid_chain_start?(_), do: false
+end

--- a/lib/credo/check/readability/nested_function_calls.ex
+++ b/lib/credo/check/readability/nested_function_calls.ex
@@ -33,6 +33,8 @@ defmodule Credo.Check.Readability.NestedFunctionCalls do
       ]
     ]
 
+  alias Credo.Code.Name
+
   @doc false
   @impl true
   def run(%SourceFile{} = source_file, params) do
@@ -56,13 +58,13 @@ defmodule Credo.Check.Readability.NestedFunctionCalls do
   end
 
   # A call with arguments
-  defp traverse({{:., _loc, _call}, meta, args} = ast, {_, issues}, issue_meta, min_pipeline_length) do
+  defp traverse({{:., _loc, call}, meta, args} = ast, {_, issues}, issue_meta, min_pipeline_length) do
     if valid_chain_start?(ast) do
       {ast, {min_pipeline_length, issues}}
     else
       case length_as_pipeline(args) + 1 do
         potential_pipeline_length when potential_pipeline_length >= min_pipeline_length ->
-          {ast, {min_pipeline_length, issues ++ [issue_for(issue_meta, meta[:line], "something")]}}
+          {ast, {min_pipeline_length, issues ++ [issue_for(issue_meta, meta[:line], Name.full(call))]}}
         _ ->
           {ast, {min_pipeline_length, issues}}
       end

--- a/lib/credo/check/readability/nested_function_calls.ex
+++ b/lib/credo/check/readability/nested_function_calls.ex
@@ -51,12 +51,12 @@ defmodule Credo.Check.Readability.NestedFunctionCalls do
   end
 
   # A call with no arguments
-  defp traverse({{:., _loc, call}, meta, []} = ast, {_, issues}, _, min_pipeline_length) do
-    {ast, {true, issues}}
+  defp traverse({{:., _loc, _call}, _meta, []} = ast, {_, issues}, _, min_pipeline_length) do
+    {ast, {min_pipeline_length, issues}}
   end
 
   # A call with arguments
-  defp traverse({{:., _loc, call}, meta, args} = ast, {_, issues}, issue_meta, min_pipeline_length) do
+  defp traverse({{:., _loc, _call}, meta, args} = ast, {_, issues}, issue_meta, min_pipeline_length) do
     if valid_chain_start?(ast) do
       {ast, {min_pipeline_length, issues}}
     else
@@ -75,12 +75,12 @@ defmodule Credo.Check.Readability.NestedFunctionCalls do
   end
 
   # Call with no arguments
-  defp length_as_pipeline([{{:., _loc, call}, meta, []}|_]) do
+  defp length_as_pipeline([{{:., _loc, _call}, _meta, []}|_]) do
     0
   end
 
   # Call with function call for first argument
-  defp length_as_pipeline([{{:., _loc, call}, meta, args} = call_ast|_]) do
+  defp length_as_pipeline([{{:., _loc, _call}, _meta, args} = call_ast|_]) do
     if valid_chain_start?(call_ast) do
       0
     else
@@ -89,7 +89,7 @@ defmodule Credo.Check.Readability.NestedFunctionCalls do
   end
 
   # Call where the first argument isn't another function call
-  defp length_as_pipeline(args) do
+  defp length_as_pipeline(_args) do
     0
   end
 

--- a/test/credo/check/readability/nested_function_calls_test.exs
+++ b/test/credo/check/readability/nested_function_calls_test.exs
@@ -29,6 +29,58 @@ defmodule Credo.Check.Readability.NestedFunctionCallsTest do
     |> refute_issues()
   end
 
+  test "it should NOT report char list interpolation" do
+    """
+    defmodule CredoSampleModule do
+      def some_code do
+        'Take 10 #{Enum.take([1,2,2,3,3], 10)}'
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(NestedFunctionCalls)
+    |> refute_issues()
+  end
+
+  test "it should NOT report a violation for string concatenation" do
+    """
+    defmodule Test do
+      def test do
+        String.captialize("hello" <> "world")
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(NestedFunctionCalls)
+    |> refute_issues()
+  end
+
+  test "it should NOT report a violation for ++" do
+    """
+    defmodule CredoSampleModule do
+      def some_code do
+        Enum.max([1,2,3] ++ [4,5,7])
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(NestedFunctionCalls)
+    |> refute_issues()
+  end
+
+  test "it should NOT report a violation for --" do
+    """
+    defmodule CredoSampleModule do
+      def some_code do
+        Enum.max([1,2,3] -- [4,5,7])
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(NestedFunctionCalls)
+    |> refute_issues()
+  end
+
   test "it should NOT report Access protocol lookups" do
     """
     defmodule CredoSampleModule do

--- a/test/credo/check/readability/nested_function_calls_test.exs
+++ b/test/credo/check/readability/nested_function_calls_test.exs
@@ -46,7 +46,7 @@ defmodule Credo.Check.Readability.NestedFunctionCallsTest do
     """
     defmodule CredoSampleModule do
       def some_code do
-        Enum.shuffle(Enum.uniq())
+        Enum.uniq(some_list())
       end
     end
     """
@@ -78,6 +78,32 @@ defmodule Credo.Check.Readability.NestedFunctionCallsTest do
     """
     |> to_source_file()
     |> run_check(NestedFunctionCalls)
+    |> assert_issues()
+  end
+
+  test "it should report two nested functions calls when min_pipeline_length is set to one" do
+    """
+    defmodule CredoSampleModule do
+      def some_code do
+        Enum.uniq(some_list())
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(NestedFunctionCalls, min_pipeline_length: 1)
     |> assert_issue()
+  end
+
+  test "it should NOT report two nested functions calls with arguments when min_pipeline_length is set to three" do
+    """
+    defmodule CredoSampleModule do
+      def some_code do
+        Enum.shuffle(Enum.uniq([1,2,2,3,3]))
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(NestedFunctionCalls, min_pipeline_length: 3)
+    |> refute_issues()
   end
 end

--- a/test/credo/check/readability/nested_function_calls_test.exs
+++ b/test/credo/check/readability/nested_function_calls_test.exs
@@ -1,0 +1,83 @@
+defmodule Credo.Check.Readability.NestedFunctionCallsTest do
+  use Credo.Test.Case
+
+  alias Credo.Check.Readability.NestedFunctionCalls
+
+  test "it should NOT code with no nested function calls" do
+    """
+    defmodule CredoSampleModule do
+      def some_code do
+        Enum.shuffle([1,2,3])
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(NestedFunctionCalls)
+    |> refute_issues()
+  end
+
+  test "it should NOT report string interpolation" do
+    """
+    defmodule CredoSampleModule do
+      def some_code do
+        "Take 10 #{Enum.take([1,2,2,3,3], 10)}"
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(NestedFunctionCalls)
+    |> refute_issues()
+  end
+
+  test "it should NOT report Access protocol lookups" do
+    """
+    defmodule CredoSampleModule do
+      def some_code do
+        Enum.take(map[:some_key])
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(NestedFunctionCalls)
+    |> refute_issues()
+  end
+
+  test "it should NOT two nested functions calls when the inner function call takes no arguments" do
+    """
+    defmodule CredoSampleModule do
+      def some_code do
+        Enum.shuffle(Enum.uniq())
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(NestedFunctionCalls)
+    |> refute_issues()
+  end
+
+  test "it should report two nested functions calls when the inner call receives some arguments" do
+    """
+    defmodule CredoSampleModule do
+      def some_code do
+        Enum.shuffle(Enum.uniq([1,2,2,3,3]))
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(NestedFunctionCalls)
+    |> assert_issue()
+  end
+
+  test "it should report three nested functions calls" do
+    """
+    defmodule CredoSampleModule do
+      def some_code do
+        Enum.shuffle(Enum.uniq(Enum.take([1,2,2,3,3], 10)))
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(NestedFunctionCalls)
+    |> assert_issue()
+  end
+end


### PR DESCRIPTION
This PR adds a check named `Credo.Check.Readability.NestedFunctionCalls` that checks for nested function calls that could be converted to pipelines. I created this check to catch violations of the rule about nested function calls specified in the Christopher Adam's style guide (https://github.com/christopheradams/elixir_style_guide#pipe-operator)

It tries to be smart enough to handle things like access protocol, string interpolation, and function calls with no arguments. See the tests for examples.

Context:

* https://github.com/christopheradams/elixir_style_guide/issues/143#issuecomment-394191496