### PR TITLE
fix: sanitize map before converting to json

### DIFF
--- a/lib/credo/cli/output/formatter/json.ex
+++ b/lib/credo/cli/output/formatter/json.ex
@@ -26,7 +26,7 @@ defmodule Credo.CLI.Output.Formatter.JSON do
   def prepare_for_json([]), do: []
   def prepare_for_json([h | t]), do: [prepare_for_json(h) | prepare_for_json(t)]
 
-  def prepare_for_json(%Regex{} = regex), do: "~r/#{Regex.source(regex)}/"
+  def prepare_for_json(%Regex{} = regex), do: inspect(regex)
 
   def prepare_for_json(%{} = term) do
     Enum.into(term, %{}, fn {key, value} ->

--- a/lib/credo/cli/output/formatter/json.ex
+++ b/lib/credo/cli/output/formatter/json.ex
@@ -13,34 +13,34 @@ defmodule Credo.CLI.Output.Formatter.JSON do
 
   def print_map(map) do
     map
-    |> sanitize()
+    |> prepare_for_json()
     |> Jason.encode!(pretty: true)
     |> UI.puts()
   end
 
-  def sanitize(term)
+  def prepare_for_json(term)
       when is_atom(term) or is_number(term) or is_binary(term) do
     term
   end
 
-  def sanitize([]), do: []
-  def sanitize([h | t]), do: [sanitize(h) | sanitize(t)]
+  def prepare_for_json([]), do: []
+  def prepare_for_json([h | t]), do: [prepare_for_json(h) | prepare_for_json(t)]
 
-  def sanitize(%Regex{} = regex), do: "~r/#{Regex.source(regex)}/"
+  def prepare_for_json(%Regex{} = regex), do: "~r/#{Regex.source(regex)}/"
 
-  def sanitize(%{} = term) do
+  def prepare_for_json(%{} = term) do
     Enum.into(term, %{}, fn {key, value} ->
-      {sanitize(key), sanitize(value)}
+      {prepare_for_json(key), prepare_for_json(value)}
     end)
   end
 
-  def sanitize(term) when is_tuple(term) do
+  def prepare_for_json(term) when is_tuple(term) do
     term
     |> Tuple.to_list()
-    |> sanitize()
+    |> prepare_for_json()
   end
 
-  def sanitize(term) do
+  def prepare_for_json(term) do
     inspect(term)
   end
 

--- a/lib/credo/cli/output/formatter/json.ex
+++ b/lib/credo/cli/output/formatter/json.ex
@@ -30,7 +30,7 @@ defmodule Credo.CLI.Output.Formatter.JSON do
 
   def prepare_for_json(%{} = term) do
     Enum.into(term, %{}, fn {key, value} ->
-      {prepare_for_json(key), prepare_for_json(value)}
+      {prepare_key_for_json(key), prepare_for_json(value)}
     end)
   end
 
@@ -42,6 +42,14 @@ defmodule Credo.CLI.Output.Formatter.JSON do
 
   def prepare_for_json(term) do
     inspect(term)
+  end
+
+  defp prepare_key_for_json(k) when is_atom(k) or is_binary(k) or is_number(k) do
+    k
+  end
+
+  defp prepare_key_for_json(k) do
+    inspect(k)
   end
 
   def issue_to_json(

--- a/test/credo/cli/output/formatter/json_test.exs
+++ b/test/credo/cli/output/formatter/json_test.exs
@@ -4,7 +4,7 @@ defmodule Credo.CLI.Output.Formatter.JsonTest do
   alias Credo.CLI.Output.Formatter.JSON
 
   test "print_map/1 does not raise when map contains a regex" do
-    assert JSON.print_map(%{"option" => ~r/foo/}) == nil
+    JSON.print_map(%{"option" => ~r/foo/})
   end
 
   test "prepare_for_json/1 converts values invalid in json" do

--- a/test/credo/cli/output/formatter/json_test.exs
+++ b/test/credo/cli/output/formatter/json_test.exs
@@ -1,0 +1,29 @@
+defmodule Credo.CLI.Output.Formatter.JsonTest do
+  use Credo.Test.Case
+
+  alias Credo.CLI.Output.Formatter.JSON
+
+  test "print_map/1 does not raise when map contains a regex" do
+    assert JSON.print_map(%{"option" => ~r/foo/}) == nil
+  end
+
+  test "sanitize/1 sanitizes values" do
+    assert JSON.sanitize(%{
+             "bool" => true,
+             "list" => ["a", %{"a" => "b", "b" => ~r/foo/}],
+             "map" => %{"c" => "d", "e" => ["f", 8, ~r/foo/]},
+             "number" => 5,
+             "regex" => ~r/foo/,
+             "string" => "a",
+             "tuple" => {"a", 2, ~r/foo/}
+           }) == %{
+             "bool" => true,
+             "list" => ["a", %{"a" => "b", "b" => "~r/foo/"}],
+             "map" => %{"c" => "d", "e" => ["f", 8, "~r/foo/"]},
+             "number" => 5,
+             "regex" => "~r/foo/",
+             "string" => "a",
+             "tuple" => ["a", 2, "~r/foo/"]
+           }
+  end
+end

--- a/test/credo/cli/output/formatter/json_test.exs
+++ b/test/credo/cli/output/formatter/json_test.exs
@@ -15,7 +15,10 @@ defmodule Credo.CLI.Output.Formatter.JsonTest do
              "number" => 5,
              "regex" => ~r/foo/,
              "string" => "a",
-             "tuple" => {"a", 2, ~r/foo/}
+             "tuple" => {"a", 2, ~r/foo/},
+             :atom_key => 0,
+             {"tuple", "key"} => 1,
+             0 => 2
            }) == %{
              "bool" => true,
              "list" => ["a", %{"a" => "b", "b" => "~r/foo/"}],
@@ -23,7 +26,10 @@ defmodule Credo.CLI.Output.Formatter.JsonTest do
              "number" => 5,
              "regex" => "~r/foo/",
              "string" => "a",
-             "tuple" => ["a", 2, "~r/foo/"]
+             "tuple" => ["a", 2, "~r/foo/"],
+             :atom_key => 0,
+             "{\"tuple\", \"key\"}" => 1,
+             0 => 2
            }
   end
 end

--- a/test/credo/cli/output/formatter/json_test.exs
+++ b/test/credo/cli/output/formatter/json_test.exs
@@ -7,8 +7,8 @@ defmodule Credo.CLI.Output.Formatter.JsonTest do
     assert JSON.print_map(%{"option" => ~r/foo/}) == nil
   end
 
-  test "sanitize/1 sanitizes values" do
-    assert JSON.sanitize(%{
+  test "prepare_for_json/1 converts values invalid in json" do
+    assert JSON.prepare_for_json(%{
              "bool" => true,
              "list" => ["a", %{"a" => "b", "b" => ~r/foo/}],
              "map" => %{"c" => "d", "e" => ["f", 8, ~r/foo/]},


### PR DESCRIPTION
This fixes an issue that can occur when the credo config contains values that cannot be serialized by Jason.

To reproduce the issue:

1. `mix credo gen.config`
2. change the `ModuleDoc` check config to:

```elixir
          {Credo.Check.Readability.ModuleDoc,
           [
             ignore_names: [
               ~r/(\.\w+Controller|\.Endpoint|\.Repo|\.Router|\.\w+Socket|\.\w+View|\.\w+Components|\.\w+Live\.\w+)$/
             ]
           ]},
```

3. run `mix credo info --format json --verbose`

This will result in:

```
** (Protocol.UndefinedError) protocol Jason.Encoder not implemented for ~r/(\.\w+Controller|\.Endpoint|\.Repo|\.Router|\.\w+Socket|\.\w+View|\.\w+Components|\.\w+Live\.\w+)$/ of type Regex (a struct), Jason.Encoder protocol must always be explicitly implemented.

If you own the struct, you can derive the implementation specifying which fields should be encoded to JSON:

    @derive {Jason.Encoder, only: [....]}
    defstruct ...

It is also possible to encode all fields, although this should be used carefully to avoid accidentally leaking private information when new fields are added:

    @derive Jason.Encoder
    defstruct ...

Finally, if you don't own the struct you want to encode to JSON, you may use Protocol.derive/3 placed outside of any module:

    Protocol.derive(Jason.Encoder, NameOfTheStruct, only: [...])
    Protocol.derive(Jason.Encoder, NameOfTheStruct)

    lib/jason.ex:150: Jason.encode!/2
    lib/credo/cli/output/formatter/json.ex:15: Credo.CLI.Output.Formatter.JSON.print_map/1
    lib/credo/cli/command/info/info_command.ex:32: Credo.CLI.Command.Info.InfoCommand.PrintInfo.call/2
    lib/credo/execution/task.ex:133: Credo.Execution.Task.do_run/3
    (elixir 1.13.0) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/credo/execution/task.ex:133: Credo.Execution.Task.do_run/3
    (elixir 1.13.0) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/credo.ex:30: Credo.run/1
```

Noticed because this happened with a certain VS code plugin.