### PR TITLE
fix bug with string literals after custom sigils

### DIFF
--- a/lib/credo/code/strings.ex
+++ b/lib/credo/code/strings.ex
@@ -272,15 +272,13 @@ defmodule Credo.Code.Strings do
       parse_removable_sigil(t, acc <> "\\\\", unquote(sigil_end), replacement)
     end
 
-    if sigil_end != "\"" do
-      defp parse_removable_sigil(
-             <<"\""::utf8, t::binary>>,
-             acc,
-             unquote(sigil_end),
-             replacement
-           ) do
-        parse_removable_sigil(t, acc <> "\"", unquote(sigil_end), replacement)
-      end
+    defp parse_removable_sigil(
+           <<unquote(sigil_end)::utf8, t::binary>>,
+           acc,
+           unquote(sigil_end),
+           replacement
+         ) do
+      parse_code(t, acc <> unquote(sigil_end), replacement)
     end
 
     defp parse_removable_sigil(
@@ -297,13 +295,15 @@ defmodule Credo.Code.Strings do
       )
     end
 
-    defp parse_removable_sigil(
-           <<unquote(sigil_end)::utf8, t::binary>>,
-           acc,
-           unquote(sigil_end),
-           replacement
-         ) do
-      parse_code(t, acc <> unquote(sigil_end), replacement)
+    if sigil_end != "\"" do
+      defp parse_removable_sigil(
+             <<"\""::utf8, t::binary>>,
+             acc,
+             unquote(sigil_end),
+             replacement
+           ) do
+        parse_removable_sigil(t, acc <> "\"", unquote(sigil_end), replacement)
+      end
     end
 
     defp parse_removable_sigil(

--- a/test/credo/check/readability/space_after_commas_test.exs
+++ b/test/credo/check/readability/space_after_commas_test.exs
@@ -39,6 +39,21 @@ defmodule Credo.Check.Readability.SpaceAfterCommasTest do
     |> refute_issues()
   end
 
+  test "it should NOT report when commas are in binaries" do
+    ~S[
+    defmodule SpaceMissingInBinary do
+      custom_sigil =
+        ~X"""
+        """
+
+      string = ","
+    end
+    ]
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
   test "it should NOT report when commas have newlines" do
     """
     defmodule CredoSampleModule do

--- a/test/credo/code/strings_test.exs
+++ b/test/credo/code/strings_test.exs
@@ -68,6 +68,30 @@ defmodule Credo.Code.StringsTest do
     assert expected == Strings.replace_with_spaces(source)
   end
 
+  test "it should work with custom sigils" do
+    source = ~S[
+      defmodule Foo do
+        custom =
+          ~X"""
+          """
+
+        literal = "anything"
+      end
+    ]
+
+    expected = ~S[
+      defmodule Foo do
+        custom =
+          ~X"""
+          """
+
+        literal = "        "
+      end
+    ]
+
+    assert expected == Strings.replace_with_spaces(source)
+  end
+
   test "it should return the source without string literals 3" do
     source = """
     x =   "↑ ↗ →"


### PR DESCRIPTION
Fixes #940 (at least the space after comma warning) for my use-case