### PR TITLE
Add null-ls diagnostic to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Some IDEs and editors are able to run Credo in the background and mark issues in
 * [Elixir Linter (Credo)](https://marketplace.visualstudio.com/items?itemName=pantajoe.vscode-elixir-credo) - VSCode extension (by @pantajoe)
 * [flycheck](https://www.flycheck.org/en/latest/languages.html#elixir) - Emacs syntax checking extension
 * [kakoune](https://github.com/mawww/kakoune/wiki/Lint#elixir) - Config for linting support in Kakoune editor
+* [Neovim via null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/diagnostics/credo.lua) - diagnostics builtin
 
 ### Automated Code Review
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18191/152073617-8dc43f68-7946-4ad1-a157-aed8be8affba.png)

I'm seriously impressed with `null-ls` and it's `credo` integration, thought it was worth documenting for others. Thanks!