### PR TITLE
Make Credo.Check.Warning.ForbiddenModule work for grouped aliases

### DIFF
--- a/lib/credo/check/warning/forbidden_module.ex
+++ b/lib/credo/check/warning/forbidden_module.ex
@@ -40,16 +40,41 @@ defmodule Credo.Check.Warning.ForbiddenModule do
   defp traverse(ast = {:__aliases__, meta, modules}, issues, forbidden_modules, issue_meta) do
     module = Name.full(modules)
 
-    forbidden_module_names = Enum.map(forbidden_modules, &elem(&1, 0))
+    issues = put_issue_if_forbidden(issues, issue_meta, meta[:line], module, forbidden_modules)
 
-    if found_module?(forbidden_module_names, module) do
-      {ast, [issue_for(issue_meta, meta[:line], module, forbidden_modules) | issues]}
-    else
-      {ast, issues}
-    end
+    {ast, issues}
+  end
+
+  defp traverse(
+         ast = {:alias, _meta, [{{_, _, [{:__aliases__, _opts, base_alias}, :{}]}, _, aliases}]},
+         issues,
+         forbidden_modules,
+         issue_meta
+       ) do
+    modules =
+      Enum.map(aliases, fn {:__aliases__, meta, module} ->
+        {Name.full([base_alias, module]), meta[:line]}
+      end)
+
+    issues =
+      Enum.reduce(modules, issues, fn {module, line}, issues ->
+        put_issue_if_forbidden(issues, issue_meta, line, module, forbidden_modules)
+      end)
+
+    {ast, issues}
   end
 
   defp traverse(ast, issues, _, _), do: {ast, issues}
+
+  defp put_issue_if_forbidden(issues, issue_meta, line_no, module, forbidden_modules) do
+    forbidden_module_names = Enum.map(forbidden_modules, &elem(&1, 0))
+
+    if found_module?(forbidden_module_names, module) do
+      [issue_for(issue_meta, line_no, module, forbidden_modules) | issues]
+    else
+      issues
+    end
+  end
 
   defp found_module?(forbidden_module_names, module) do
     Enum.member?(forbidden_module_names, module)

--- a/lib/credo/check/warning/forbidden_module.ex
+++ b/lib/credo/check/warning/forbidden_module.ex
@@ -93,6 +93,9 @@ defmodule Credo.Check.Warning.ForbiddenModule do
   end
 
   defp message(forbidden_modules, module) do
-    Enum.find_value(forbidden_modules, fn {^module, message} -> message end)
+    Enum.find_value(forbidden_modules, fn
+      {^module, message} -> message
+      _ -> nil
+    end)
   end
 end

--- a/test/credo/check/warning/forbidden_module_test.exs
+++ b/test/credo/check/warning/forbidden_module_test.exs
@@ -115,4 +115,16 @@ defmodule Credo.Check.Warning.ForbiddenModuleTest do
       assert issue.message == expected_message
     end)
   end
+
+  test "it should work with multiple forbidden modules" do
+    """
+    defmodule CredoSampleModule do
+      def some_function, do: CredoSampleModule.ForbiddenModule.another_function()
+      def some_function2, do: CredoSampleModule.ForbiddenModule2.another_function()
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, modules: [CredoSampleModule.ForbiddenModule, CredoSampleModule.ForbiddenModule2])
+    |> assert_issues()
+  end
 end

--- a/test/credo/check/warning/forbidden_module_test.exs
+++ b/test/credo/check/warning/forbidden_module_test.exs
@@ -65,6 +65,18 @@ defmodule Credo.Check.Warning.ForbiddenModuleTest do
     |> assert_issue()
   end
 
+  test "it should report on grouped aliases" do
+    """
+    defmodule CredoSampleModule do
+      alias CredoSampleModule.{ForbiddenModule}
+      def some_function, do: ForbiddenModule.another_function()
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, modules: [CredoSampleModule.ForbiddenModule])
+    |> assert_issue()
+  end
+
   test "it should report on import" do
     """
     defmodule CredoSampleModule do

--- a/test/credo/check/warning/forbidden_module_test.exs
+++ b/test/credo/check/warning/forbidden_module_test.exs
@@ -68,13 +68,13 @@ defmodule Credo.Check.Warning.ForbiddenModuleTest do
   test "it should report on grouped aliases" do
     """
     defmodule CredoSampleModule do
-      alias CredoSampleModule.{ForbiddenModule}
+      alias CredoSampleModule.{AllowedModule, ForbiddenModule, ForbiddenModule2}
       def some_function, do: ForbiddenModule.another_function()
     end
     """
     |> to_source_file
-    |> run_check(@described_check, modules: [CredoSampleModule.ForbiddenModule])
-    |> assert_issue()
+    |> run_check(@described_check, modules: [CredoSampleModule.ForbiddenModule, CredoSampleModule.ForbiddenModule2])
+    |> assert_issues()
   end
 
   test "it should report on import" do


### PR DESCRIPTION
Fixes #946 

Makes the `Credo.Check.Warning.ForbiddenModule` check work when the forbidden module is aliased in a grouped alias like:

```elixir
defmodule CredoSampleModule do
    alias CredoSampleModule.{ForbiddenModule}
    def some_function, do: ForbiddenModule.another_function()
end
```