### PR TITLE
Make Credo.Check.Refactor.NegatedIsNil work for multi clause guard

### DIFF
--- a/lib/credo/check/refactor/negated_is_nil.ex
+++ b/lib/credo/check/refactor/negated_is_nil.ex
@@ -63,5 +63,12 @@ defmodule Credo.Check.Refactor.NegatedIsNil do
     {ast, [issue | issues]}
   end
 
+  defp traverse({:when, meta, [fun, {_ , _, [first_op | second_op]}]} = ast, issues, issue_meta) do
+        {_, first_op_issues} = traverse({:when, meta, [fun, first_op]}, issues, issue_meta)
+        {_, second_op_issues} = traverse({:when, meta, [fun, second_op]}, issues, issue_meta)
+
+    {ast, first_op_issues ++ second_op_issues ++ issues}
+  end
+
   defp traverse(ast, issues, _), do: {ast, issues}
 end

--- a/test/credo/check/refactor/negated_is_nil_test.exs
+++ b/test/credo/check/refactor/negated_is_nil_test.exs
@@ -56,4 +56,56 @@ defmodule Credo.Check.Refactor.NegatedIsNilTest do
     |> run_check(@described_check)
     |> assert_issue()
   end
+
+  test "it should report a violation - `when not is_nil is part of a multi clause guard`" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(%{parameter1: parameter2, id: id}) when not is_nil(parameter2) and is_binary(parameter2) do
+        something
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation - `when !is_nil is part of a multi clause guard`" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(%{parameter1: parameter2, id: id}) when !is_nil(parameter2) and is_binary(parameter2) do
+        something
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should NOT report a violation - `not is_nil is not part of a guard clause`" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(%{parameter1: parameter2, id: id}) when is_binary(parameter2) do
+        something = not is_nil(parameter2)
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report a violation - ` !is_nil is not part of a guard clause`" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(%{parameter1: parameter2, id: id}) when is_binary(parameter2) do
+        something = !is_nil(parameter2)
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
 end


### PR DESCRIPTION
Fixes #958
 
Make `Credo.Check.Refactor.NegatedIsNil` work for multi clause guard like:

```elixir
def foo(%{item_map: item_map, item_type: item_type})
    when not is_nil(item_type) and is_map(item_map) do
  ...
end
```