### PR TITLE
Ignore Phoenix.LiveView modules by default

### DIFF
--- a/lib/credo/check/readability/module_doc.ex
+++ b/lib/credo/check/readability/module_doc.ex
@@ -2,7 +2,7 @@ defmodule Credo.Check.Readability.ModuleDoc do
   use Credo.Check,
     param_defaults: [
       ignore_names: [
-        ~r/(\.\w+Controller|\.Endpoint|\.Repo|\.Router|\.\w+Socket|\.\w+View)$/
+        ~r/(\.\w+Controller|\.Endpoint|\.\w+Live|\.Repo|\.Router|\.\w+Socket|\.\w+View)$/
       ]
     ],
     explanations: [


### PR DESCRIPTION
This change will ignore module docs for phoenix live views by default. According to [this code sample](https://github.com/phoenixframework/phoenix_live_view/blob/master/lib/phoenix_live_view/router.ex#L415) live views should end with a `Live` suffix like so `MyApp.ExampleLive`.