### PR TITLE
fix LineEndings check for windows line endings.

### DIFF
--- a/lib/credo/check/consistency/line_endings/collector.ex
+++ b/lib/credo/check/consistency/line_endings/collector.ex
@@ -6,6 +6,7 @@ defmodule Credo.Check.Consistency.LineEndings.Collector do
   def collect_matches(source_file, _params) do
     source_file
     |> SourceFile.lines()
+    |> List.delete_at(-1)
     |> Enum.reduce(%{}, fn line, stats ->
       Map.update(stats, line_ending(line), 1, &(&1 + 1))
     end)

--- a/test/credo/check/consistency/line_endings_test.exs
+++ b/test/credo/check/consistency/line_endings_test.exs
@@ -24,15 +24,22 @@ defmodule Credo.Check.Readability.LineEndingsTest do
   end
   """
   @windows_line_endings """
-  defmodule Credo.Sample do\r\n@test_attribute :foo\r\nend\r\n
+  defmodule Credo.Sample do\r\n@test_attribute :foo\r\nend
   """
 
   #
   # cases NOT raising issues
   #
 
-  test "it should not report expected code" do
+  test "it should not report expected code for linux" do
     [@unix_line_endings, @unix_line_endings2]
+    |> to_source_files
+    |> run_check(@described_check)
+    |> refute_issues
+  end
+
+  test "it should not report expected code for windows" do
+    [@windows_line_endings |> String.trim()]
     |> to_source_files
     |> run_check(@described_check)
     |> refute_issues


### PR DESCRIPTION
The last line of a file has no line break. So after the splitting into lines the last line of a windows file was always detected as unix because the line never ended with \r.
To fix this do not check the last line of a file.