### PR TITLE
Includes the 'only_greater_than' value in the LargeNumbers message

### DIFF
--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -30,8 +30,8 @@ defmodule Credo.Check.Readability.LargeNumbers do
   @doc false
   # TODO: consider for experimental check front-loader (tokens)
   def run(%SourceFile{} = source_file, params) do
-    issue_meta = IssueMeta.for(source_file, params)
     min_number = Params.get(params, :only_greater_than, __MODULE__)
+    issue_meta = IssueMeta.for(source_file, Keyword.merge(params, [min_number: min_number]))
 
     allowed_trailing_digits =
       case Params.get(params, :trailing_digits, __MODULE__) do
@@ -197,10 +197,12 @@ defmodule Credo.Check.Readability.LargeNumbers do
     |> Enum.uniq()
   end
 
-  defp issue_for(issue_meta, line_no, column, trigger, expected) do
+  defp issue_for({_, _, params} = issue_meta, line_no, column, trigger, expected) do
+    min_number = Params.get(params, :only_greater_than, __MODULE__)
+
     format_issue(
       issue_meta,
-      message: "Large numbers should be written with underscores: #{Enum.join(expected, " or ")}",
+      message: "Numbers larger than #{min_number} should be written with underscores: #{Enum.join(expected, " or ")}",
       line_no: line_no,
       column: column,
       trigger: trigger

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -31,7 +31,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
   # TODO: consider for experimental check front-loader (tokens)
   def run(%SourceFile{} = source_file, params) do
     min_number = Params.get(params, :only_greater_than, __MODULE__)
-    issue_meta = IssueMeta.for(source_file, Keyword.merge(params, [min_number: min_number]))
+    issue_meta = IssueMeta.for(source_file, Keyword.merge(params, only_greater_than: min_number))
 
     allowed_trailing_digits =
       case Params.get(params, :trailing_digits, __MODULE__) do
@@ -197,12 +197,14 @@ defmodule Credo.Check.Readability.LargeNumbers do
     |> Enum.uniq()
   end
 
-  defp issue_for({_, _, params} = issue_meta, line_no, column, trigger, expected) do
-    min_number = Params.get(params, :only_greater_than, __MODULE__)
+  defp issue_for(issue_meta, line_no, column, trigger, expected) do
+    params = IssueMeta.params(issue_meta)
+    only_greater_than = Params.get(params, :only_greater_than, __MODULE__)
 
     format_issue(
       issue_meta,
-      message: "Numbers larger than #{min_number} should be written with underscores: #{Enum.join(expected, " or ")}",
+      message:
+        "Numbers larger than #{only_greater_than} should be written with underscores: #{Enum.join(expected, " or ")}",
       line_no: line_no,
       column: column,
       trigger: trigger

--- a/test/credo/check/readability/large_numbers_test.exs
+++ b/test/credo/check/readability/large_numbers_test.exs
@@ -257,7 +257,7 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
     |> to_source_file
     |> run_check(@described_check)
     |> assert_issue(fn %Credo.Issue{message: message} ->
-      assert ~r/[\d\._]+/ |> Regex.run(message) |> hd == "10_000.00001"
+      assert  ~r/[\d\._]+/ |> Regex.scan(message) |> List.flatten == ["9999", "10_000.00001"]
     end)
   end
 
@@ -270,7 +270,7 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
     |> to_source_file
     |> run_check(@described_check)
     |> assert_issue(fn %Credo.Issue{message: message} ->
-      assert ~r/[\d\._]+/ |> Regex.run(message) |> hd == "10_000.000010"
+      assert  ~r/[\d\._]+/ |> Regex.scan(message) |> List.flatten === ["9999", "10_000.000010"]
     end)
   end
 
@@ -295,5 +295,19 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
     |> to_source_file
     |> run_check(@described_check, trailing_digits: [3])
     |> assert_issues()
+  end
+
+  test "it should include configured `only_greater_than` values" do
+    only_greater_than = 1_000_000
+    """
+    def numbers do
+      1000001
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, only_greater_than: only_greater_than)
+    |> assert_issue(fn %Credo.Issue{message: message} ->
+      assert  ~r/[\d\._]+/ |> Regex.scan(message) |> List.flatten == ["1000000", "1_000_001"]
+    end)
   end
 end

--- a/test/credo/check/readability/large_numbers_test.exs
+++ b/test/credo/check/readability/large_numbers_test.exs
@@ -257,7 +257,7 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
     |> to_source_file
     |> run_check(@described_check)
     |> assert_issue(fn %Credo.Issue{message: message} ->
-      assert  ~r/[\d\._]+/ |> Regex.scan(message) |> List.flatten == ["9999", "10_000.00001"]
+      assert ~r/[\d\._]+/ |> Regex.scan(message) |> List.flatten() == ["9999", "10_000.00001"]
     end)
   end
 
@@ -270,7 +270,7 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
     |> to_source_file
     |> run_check(@described_check)
     |> assert_issue(fn %Credo.Issue{message: message} ->
-      assert  ~r/[\d\._]+/ |> Regex.scan(message) |> List.flatten === ["9999", "10_000.000010"]
+      assert ~r/[\d\._]+/ |> Regex.scan(message) |> List.flatten() == ["9999", "10_000.000010"]
     end)
   end
 
@@ -299,6 +299,7 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
 
   test "it should include configured `only_greater_than` values" do
     only_greater_than = 1_000_000
+
     """
     def numbers do
       1000001
@@ -307,7 +308,7 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
     |> to_source_file
     |> run_check(@described_check, only_greater_than: only_greater_than)
     |> assert_issue(fn %Credo.Issue{message: message} ->
-      assert  ~r/[\d\._]+/ |> Regex.scan(message) |> List.flatten == ["1000000", "1_000_001"]
+      assert ~r/[\d\._]+/ |> Regex.scan(message) |> List.flatten() == ["1000000", "1_000_001"]
     end)
   end
 end


### PR DESCRIPTION
More specificity is helpful in the messages. While the old message gives you the correct value for the violation, it did not offer guidance on avoiding the error subsequently. Additionally, given that the `only_greater_than` is user-configurable, teams that change the default would have to go digging to find the threshold.