### PR TITLE
Load application configuration in mix task

### DIFF
--- a/lib/mix/tasks/credo.ex
+++ b/lib/mix/tasks/credo.ex
@@ -4,6 +4,9 @@ defmodule Mix.Tasks.Credo do
   @shortdoc "Run code analysis (use `--help` for options)"
   @moduledoc @shortdoc
 
+  # Load application config because some custom checks depend on configuration
+  @requirements ["app.config"]
+
   @doc false
   def run(argv) do
     Credo.CLI.main(argv)


### PR DESCRIPTION
There are some custom credo checks that depend on configuration being loaded so most developers would assume that `config/runtime.exs` is loaded. This PR ensures that the projects `config/runtime.exs` is loaded.

For example https://github.com/Artur-Sulej/excellent_migrations uses application configuration so that there is only one place to configure the rules since it can be run from its own mix task, as a migration task or via a credo check.