### PR TITLE
Add module nesting in docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,9 +31,24 @@ defmodule Credo.Mixfile do
       extra_section: "GUIDES",
       assets: "guides/assets",
       formatters: ["html"],
+      nest_modules_by_prefix: nest_modules_by_prefix(),
       groups_for_modules: groups_for_modules(),
       extras: extras(),
       groups_for_extras: groups_for_extras()
+    ]
+  end
+
+  defp nest_modules_by_prefix do
+    [
+      Credo.Code,
+      Credo.Test,
+      Credo.Check,
+      Credo.Check.Design,
+      Credo.Check.Readability,
+      Credo.Check.Refactor,
+      Credo.Check.Warning,
+      Credo.Check.Consistency,
+      Credo.CLI
     ]
   end
 


### PR DESCRIPTION
In current docs it's really hard to navigate between check modules - the names are so long they don't fit the sidebar. This PR adds a `nest_modules_by_prefix` config for `ex_doc` that shortens the names as seen below:

![image](https://user-images.githubusercontent.com/2119556/167448657-d9ae7c83-0f36-452f-a1ab-a9d357b31185.png) ![image](https://user-images.githubusercontent.com/2119556/167448778-9617aaa0-3f51-470b-80f5-01cf3a12ec0b.png)
