### PR TITLE
Fix false positive with unquote_splicing

### DIFF
--- a/lib/credo/check/readability/with_single_clause.ex
+++ b/lib/credo/check/readability/with_single_clause.ex
@@ -80,18 +80,24 @@ defmodule Credo.Check.Readability.WithSingleClause do
   end
 
   defp issue_if_one_pattern_clause_with_else(clauses, body, line, issue_meta) do
+    contains_unquote_splicing? = Enum.any?(clauses, &match?({:unquote_splicing, _, _}, &1))
     pattern_clauses_count = Enum.count(clauses, &match?({:<-, _, _}, &1))
 
-    if pattern_clauses_count <= 1 and Keyword.has_key?(body, :else) do
-      [
-        format_issue(issue_meta,
-          message:
-            "`with` contains only one <- clause and an `else` branch, consider using `case` instead",
-          line_no: line
-        )
-      ]
-    else
-      []
+    cond do
+      contains_unquote_splicing? ->
+        []
+
+      pattern_clauses_count <= 1 and Keyword.has_key?(body, :else) ->
+        [
+          format_issue(issue_meta,
+            message:
+              "`with` contains only one <- clause and an `else` branch, consider using `case` instead",
+            line_no: line
+          )
+        ]
+
+      true ->
+        []
     end
   end
 end

--- a/test/credo/check/readability/with_single_clause_test.exs
+++ b/test/credo/check/readability/with_single_clause_test.exs
@@ -49,6 +49,21 @@ defmodule Credo.Check.Readability.WithSingleClauseTest do
     |> refute_issues()
   end
 
+  test "it should NOT report when using unquote_splicing" do
+    """
+    quote do
+      with unquote_splicing(cases) do
+        {:ok, unquote(ret)}
+      else
+        _ -> :error
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
   #
   # cases raising issues
   #


### PR DESCRIPTION
Fix #972

As mentioned in the issue discussion, there is no way to know if [unquote_splicing/1](https://hexdocs.pm/elixir/Kernel.SpecialForms.html#unquote_splicing/1) will expand to more than one clause.
I changed `Credo.Check.Readability.WithSingleClause` to never return an error if using `unquote_splicing`, regardless of the amount of `<-` used or `else` branches.