### PR TITLE
Initial spike on Autocorrect

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -153,6 +153,9 @@ defmodule Credo.Check do
   @callback format_issue(issue_meta :: Credo.IssueMeta.t(), opts :: Keyword.t()) ::
               Credo.Issue.t()
 
+  @doc false
+  @callback autocorrect(source_file :: String.t()) :: String.t()
+
   @base_category_exit_status_map %{
     consistency: 1,
     design: 2,
@@ -393,6 +396,12 @@ defmodule Credo.Check do
 
       def run(%SourceFile{} = source_file, params) do
         throw("Implement me")
+      end
+
+      @doc false
+      @impl true
+      def autocorrect(source_file) do
+        source_file
       end
 
       defoverridable Credo.Check

--- a/lib/credo/check/readability/trailing_blank_line.ex
+++ b/lib/credo/check/readability/trailing_blank_line.ex
@@ -39,4 +39,8 @@ defmodule Credo.Check.Readability.TrailingBlankLine do
       line_no: line_no
     )
   end
+
+  def autocorrect(file) do
+    "#{file}\n"
+  end
 end

--- a/lib/credo/cli/command/suggest/suggest_command.ex
+++ b/lib/credo/cli/command/suggest/suggest_command.ex
@@ -30,6 +30,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestCommand do
       Switch.boolean("read_from_stdin"),
       Switch.boolean("strict"),
       Switch.boolean("verbose"),
+      Switch.boolean("autocorrect"),
       Switch.boolean("watch")
     ]
 

--- a/lib/credo/cli/command/suggest/suggest_command.ex
+++ b/lib/credo/cli/command/suggest/suggest_command.ex
@@ -41,6 +41,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestCommand do
       print_before_analysis: [__MODULE__.PrintBeforeInfo],
       run_analysis: [Task.RunChecks],
       filter_issues: [Task.SetRelevantIssues],
+      run_autocorrect: [Task.RunAutocorrect],
       print_after_analysis: [__MODULE__.PrintResultsAndSummary]
     )
   end

--- a/lib/credo/cli/task/run_autocorrect.ex
+++ b/lib/credo/cli/task/run_autocorrect.ex
@@ -1,0 +1,26 @@
+defmodule Credo.CLI.Task.RunAutocorrect do
+  @moduledoc false
+
+  use Credo.Execution.Task
+
+  def call(exec, opts) do
+    issues = Keyword.get_lazy(opts, :issues, fn -> Execution.get_issues(exec) end)
+
+    issues
+    |> group_by_file
+    |> Enum.each(fn {file_name, issues} ->
+      file = File.read!(file_name)
+      Enum.reduce(issues, file, fn issue, corrected_file ->
+        issue.check.autocorrect(corrected_file)
+      end)
+    end)
+
+    exec
+  end
+
+  defp group_by_file(issues) do
+    Enum.reduce(issues, %{}, fn issue, acc ->
+      Map.update(acc, issue.filename, [issue], &[issue | &1])
+    end)
+  end
+end

--- a/lib/credo/config_builder.ex
+++ b/lib/credo/config_builder.ex
@@ -81,6 +81,7 @@ defmodule Credo.ConfigBuilder do
     |> add_switch_ignore(switches)
     |> add_switch_mute_exit_status(switches)
     |> add_switch_only(switches)
+    |> add_switch_autocorrect(switches)
     |> add_switch_read_from_stdin(switches)
     |> add_switch_strict(switches)
     |> add_switch_min_priority(switches)
@@ -261,6 +262,14 @@ defmodule Credo.ConfigBuilder do
   end
 
   defp add_switch_only(exec, _), do: exec
+
+  # add_switch_autocorrect
+
+  defp add_switch_autocorrect(exec, %{autocorrect: true}) do
+    %Execution{exec | autocorrect: true}
+  end
+
+  defp add_switch_autocorrect(exec, _), do: exec
 
   # add_switch_ignore
 

--- a/lib/credo/execution.ex
+++ b/lib/credo/execution.ex
@@ -29,7 +29,7 @@ defmodule Credo.Execution do
             plugins: [],
             parse_timeout: 5000,
             strict: false,
-            autocorrect: true,
+            autocorrect: false,
 
             # options, set by the command line
             format: nil,

--- a/lib/credo/execution.ex
+++ b/lib/credo/execution.ex
@@ -29,7 +29,7 @@ defmodule Credo.Execution do
             plugins: [],
             parse_timeout: 5000,
             strict: false,
-            autocorrect: false,
+            autocorrect: true,
 
             # options, set by the command line
             format: nil,

--- a/lib/credo/execution.ex
+++ b/lib/credo/execution.ex
@@ -29,6 +29,7 @@ defmodule Credo.Execution do
             plugins: [],
             parse_timeout: 5000,
             strict: false,
+            autocorrect: false,
 
             # options, set by the command line
             format: nil,

--- a/test/credo/cli/task/run_autocorrect_test.exs
+++ b/test/credo/cli/task/run_autocorrect_test.exs
@@ -1,0 +1,64 @@
+defmodule Credo.CLI.Task.RunAutocorrectTest do
+  use ExUnit.Case, async: true
+
+  alias Credo.CLI.Task.RunAutocorrect
+
+  defmodule CheckOne do
+    def autocorrect(file) do
+      send(self(), {:check_one, file})
+      "check_one"
+    end
+  end
+
+  defmodule CheckTwo do
+    def autocorrect(file) do
+      send(self(), {:check_two, file})
+      "check_two"
+    end
+  end
+
+  defmodule CheckThree do
+    def autocorrect(file) do
+      send(self(), {:check_three, file})
+      "check_three"
+    end
+  end
+
+  describe "run/2" do
+    test "calls `autocorrect/1` for each issue with the correct arguments if autocorrect is true" do
+      issues = [
+        %Credo.Issue{filename: "a", check: CheckTwo},
+        %Credo.Issue{filename: "a", check: CheckOne},
+        %Credo.Issue{filename: "b", check: CheckThree}
+      ]
+
+      exec = %Credo.Execution{autocorrect: true}
+      read_fun = fn _ -> "start" end
+      write_fun = fn file_path, contents -> send(self(), {:write, file_path, contents}) end
+      RunAutocorrect.call(exec, [issues: issues], read_fun, write_fun)
+      assert_receive({:check_one, "start"})
+      assert_receive({:check_two, "check_one"})
+      assert_receive({:check_three, "start"})
+      assert_receive({:write, "a", "check_two"})
+      assert_receive({:write, "b", "check_three"})
+    end
+
+    test "does nothing if autocorrect is false" do
+      issues = [
+        %Credo.Issue{filename: "a", check: CheckTwo},
+        %Credo.Issue{filename: "a", check: CheckOne},
+        %Credo.Issue{filename: "b", check: CheckThree}
+      ]
+
+      exec = %Credo.Execution{autocorrect: false}
+      read_fun = fn _ -> "start" end
+      write_fun = fn file_path, contents -> send(self(), {:write, file_path, contents}) end
+      RunAutocorrect.call(exec, [issues: issues], read_fun, write_fun)
+      refute_receive({:check_one, "start"})
+      refute_receive({:check_two, "check_one"})
+      refute_receive({:check_three, "start"})
+      refute_receive({:write, "a", "check_two"})
+      refute_receive({:write, "b", "check_three"})
+    end
+  end
+end


### PR DESCRIPTION
This PR is for #944. It's really just a spike at this point, but it works for the single check I've implemented autocorrect for! At the moment the UI is probably confusing as we still show issues that have been autocorrected, but this general idea I _think_ should work.

Remaining work here is:
- [ ] Improve UI to remove any issue that has been autocorrected from the list of issues printed at the end of the run
- [ ] Add documentation
- [ ] Implement autocorrect callbacks for more checks
- [ ] Try and break this to see how it might fail in real-world use cases