### PR TITLE
[956] Add test and maybe a fix for modules passed as arguments

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 24.2
+erlang 24.3.4.2
 elixir 1.13.4-otp-24

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 24.3.4.2
+erlang 24.2
 elixir 1.13.4-otp-24

--- a/lib/credo/check/design/alias_usage.ex
+++ b/lib/credo/check/design/alias_usage.ex
@@ -61,6 +61,8 @@ defmodule Credo.Check.Design.AliasUsage do
 
   alias Credo.Code.Name
 
+  @keywords [:alias]
+
   @doc false
   @impl true
   def run(%SourceFile{} = source_file, params) do
@@ -169,38 +171,88 @@ defmodule Credo.Check.Design.AliasUsage do
          mod_deps
        )
        when is_list(mod_list) and is_atom(fun_atom) do
+    {ast,
+     maybe_add_issue(
+       mod_list,
+       meta,
+       issues,
+       issue_meta,
+       excluded_namespaces,
+       excluded_lastnames,
+       only,
+       aliases,
+       mod_deps
+     )}
+  end
+
+  defp find_issues(
+         {fun_atom, _, [{:__aliases__, meta, mod_list}]} = ast,
+         issues,
+         issue_meta,
+         excluded_namespaces,
+         excluded_lastnames,
+         only,
+         aliases,
+         mod_deps
+       )
+       when is_list(mod_list) and is_atom(fun_atom) and fun_atom not in @keywords do
+    {ast,
+     maybe_add_issue(
+       mod_list,
+       meta,
+       issues,
+       issue_meta,
+       excluded_namespaces,
+       excluded_lastnames,
+       only,
+       aliases,
+       mod_deps
+     )}
+  end
+
+  defp find_issues(ast, issues, _, _, _, _, _, _) do
+    {ast, issues}
+  end
+
+  defp maybe_add_issue(
+         mod_list,
+         meta,
+         issues,
+         issue_meta,
+         excluded_namespaces,
+         excluded_lastnames,
+         only,
+         aliases,
+         mod_deps
+       ) do
     cond do
       Enum.count(mod_list) <= 1 || Enum.any?(mod_list, &tuple?/1) ->
-        {ast, issues}
+        issues
 
       Enum.any?(mod_list, &unquote?/1) ->
-        {ast, issues}
+        issues
 
       excluded_lastname_or_namespace?(
         mod_list,
         excluded_namespaces,
         excluded_lastnames
       ) ->
-        {ast, issues}
+        issues
 
       excluded_with_only?(mod_list, only) ->
-        {ast, issues}
+        issues
 
       conflicting_with_aliases?(mod_list, aliases) ->
-        {ast, issues}
+        issues
 
       conflicting_with_other_modules?(mod_list, mod_deps) ->
-        {ast, issues}
+        issues
 
       true ->
         trigger = Credo.Code.Name.full(mod_list)
 
-        {ast, issues ++ [issue_for(issue_meta, meta[:line], trigger)]}
+        issues ++ [issue_for(issue_meta, meta[:line], trigger)]
     end
-  end
-
-  defp find_issues(ast, issues, _, _, _, _, _, _) do
-    {ast, issues}
   end
 
   defp unquote?({:unquote, _, arguments}) when is_list(arguments), do: true

--- a/test/credo/check/design/alias_usage_test.exs
+++ b/test/credo/check/design/alias_usage_test.exs
@@ -343,6 +343,23 @@ defmodule Credo.Check.Design.AliasUsageTest do
     |> refute_issues()
   end
 
+  test "reports violation when module passed as argument" do
+    """
+    defmodule Test do
+      def fun1 do
+        fun2(Credo.Foo.Bar)
+      end
+
+      def fun2(mod) do
+        mod.call
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
   #
   # cases raising issues
   #


### PR DESCRIPTION
Related to #956 

I want to check in early to make sure I'm on the right path.

When a module is passed as an argument to a function, it should maybe be aliased?

What I'm actually trying to fix is probably when a module is passed to a macro and not aliased. I may try to update the PR if I'm on the right path.