### PR TITLE
Update ModuleDoc regex for LiveView

### DIFF
--- a/lib/credo/check/readability/module_doc.ex
+++ b/lib/credo/check/readability/module_doc.ex
@@ -2,7 +2,7 @@ defmodule Credo.Check.Readability.ModuleDoc do
   use Credo.Check,
     param_defaults: [
       ignore_names: [
-        ~r/(\.\w+Controller|\.Endpoint|\.\w+Live|\.Repo|\.Router|\.\w+Socket|\.\w+View)$/
+        ~r/(\.\w+Controller|\.Endpoint|\.\w+Live(\.\w+)?|\.Repo|\.Router|\.\w+Socket|\.\w+View)$/
       ]
     ],
     explanations: [


### PR DESCRIPTION
This is a follow up from https://github.com/rrrene/credo/pull/961#issuecomment-1197071958. Sorry for the delay. This should cover modules like `DemoWeb.TestLive` and `DemoWeb.TestLive.Index`.