### PR TITLE
Add github actions formatter

### DIFF
--- a/lib/credo/cli/command/diff/diff_output.ex
+++ b/lib/credo/cli/command/diff/diff_output.ex
@@ -5,7 +5,8 @@ defmodule Credo.CLI.Command.Diff.DiffOutput do
     default: Credo.CLI.Command.Diff.Output.Default,
     flycheck: Credo.CLI.Command.Diff.Output.FlyCheck,
     oneline: Credo.CLI.Command.Diff.Output.Oneline,
-    json: Credo.CLI.Command.Diff.Output.Json
+    json: Credo.CLI.Command.Diff.Output.Json,
+    github: Credo.CLI.Command.Diff.Output.Github
 
   alias Credo.CLI.Output.UI
 

--- a/lib/credo/cli/command/diff/output/github.ex
+++ b/lib/credo/cli/command/diff/output/github.ex
@@ -1,0 +1,14 @@
+defmodule Credo.CLI.Command.Diff.Output.Github do
+  @moduledoc false
+
+  alias Credo.CLI.Output.Formatter.Github
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> Github.print_issues()
+  end
+end

--- a/lib/credo/cli/command/list/list_output.ex
+++ b/lib/credo/cli/command/list/list_output.ex
@@ -5,7 +5,8 @@ defmodule Credo.CLI.Command.List.ListOutput do
     default: Credo.CLI.Command.List.Output.Default,
     flycheck: Credo.CLI.Command.List.Output.FlyCheck,
     oneline: Credo.CLI.Command.List.Output.Oneline,
-    json: Credo.CLI.Command.List.Output.Json
+    json: Credo.CLI.Command.List.Output.Json,
+    github: Credo.CLI.Command.List.Output.Github
 
   alias Credo.CLI.Output.UI
 

--- a/lib/credo/cli/command/list/output/github.ex
+++ b/lib/credo/cli/command/list/output/github.ex
@@ -1,0 +1,14 @@
+defmodule Credo.CLI.Command.List.Output.Github do
+  @moduledoc false
+
+  alias Credo.CLI.Output.Formatter.Github
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> Github.print_issues()
+  end
+end

--- a/lib/credo/cli/command/suggest/output/github.ex
+++ b/lib/credo/cli/command/suggest/output/github.ex
@@ -1,0 +1,14 @@
+defmodule Credo.CLI.Command.Suggest.Output.Github do
+  @moduledoc false
+
+  alias Credo.CLI.Output.Formatter.Github
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> Github.print_issues()
+  end
+end

--- a/lib/credo/cli/command/suggest/suggest_output.ex
+++ b/lib/credo/cli/command/suggest/suggest_output.ex
@@ -5,7 +5,8 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
     default: Credo.CLI.Command.Suggest.Output.Default,
     flycheck: Credo.CLI.Command.Suggest.Output.FlyCheck,
     oneline: Credo.CLI.Command.Suggest.Output.Oneline,
-    json: Credo.CLI.Command.Suggest.Output.Json
+    json: Credo.CLI.Command.Suggest.Output.Json,
+    github: Credo.CLI.Command.Suggest.Output.Github
 
   alias Credo.CLI.Output.UI
 

--- a/lib/credo/cli/output/format_delegator.ex
+++ b/lib/credo/cli/output/format_delegator.ex
@@ -64,6 +64,14 @@ defmodule Credo.CLI.Output.FormatDelegator do
 
       unquote(format_mods)
 
+      defp format_mod(%Execution{format: nil} = exec) do
+        if System.get_env("GITHUB_ACTION") do
+          format_mod(%{exec | format: "github"})
+        else
+          format_mod(%{exec | format: "default"})
+        end
+      end
+
       unquote(default_format_mod)
     end
   end

--- a/lib/credo/cli/output/formatter/github.ex
+++ b/lib/credo/cli/output/formatter/github.ex
@@ -1,0 +1,53 @@
+defmodule Credo.CLI.Output.Formatter.Github do
+  @moduledoc false
+
+  alias Credo.CLI.Output.UI
+  alias Credo.Issue
+  alias Credo.Priority
+
+  def print_issues(issues) do
+    issues
+    |> Enum.sort_by(fn issue -> {issue.filename, issue.line_no, issue.column} end)
+    |> Enum.each(fn issue ->
+      UI.puts(to_github(issue))
+    end)
+  end
+
+  defp to_github(
+         %Issue{
+           check: check,
+           filename: filename,
+           line_no: line_no,
+           message: message,
+           priority: priority
+         } = issue
+       ) do
+    check_name =
+      check
+      |> to_string()
+      |> String.replace(~r/^(Elixir\.)/, "")
+
+    column_end =
+      if issue.column && issue.trigger do
+        issue.column + String.length(to_string(issue.trigger))
+      end
+
+    type =
+      case Priority.to_atom(priority) do
+        :higher -> "error"
+        :high -> "error"
+        :normal -> "warning"
+        _ -> "notice"
+      end
+
+    [
+      "::#{type} ",
+      "file=#{to_string(filename)},",
+      "line=#{line_no},",
+      "col=#{issue.column},",
+      "endColumn=#{column_end},",
+      "title=#{check_name}",
+      "::#{message}"
+    ]
+  end
+end


### PR DESCRIPTION
Using this formatter you can annotate your github actions checks and see credo checks in your diff views online.

Demo: https://github.com/alisinabh/credo-test/pull/1/files