### PR TITLE
Update docs to use import Bitwise

### DIFF
--- a/guides/introduction/exit_statuses.md
+++ b/guides/introduction/exit_statuses.md
@@ -13,7 +13,7 @@ This enables shell based pipeline workflows (e.g. on CI systems) which test Cred
 The exit status of each check is used to construct a bit map of the types of issues which were encountered by or-ing them together to produce the final result:
 
 ```elixir
-use Bitwise
+import Bitwise
 
 issues
 |> Enum.map(&(&1.exit_status))


### PR DESCRIPTION
I noticed that we're now supporting elixir 1.14, just saw one remaining doc that still using `use Bitwise`, as per deprecation notice we want to use `import Bitwise` instead of `use Bitwise`