### PR TITLE
feat: Add Ignore option for Credo.Check.Readability.ModuleNames

### DIFF
--- a/lib/credo/check/readability/module_names.ex
+++ b/lib/credo/check/readability/module_names.ex
@@ -25,8 +25,7 @@ defmodule Credo.Check.Readability.ModuleNames do
       it easier to follow.
       """,
       params: [
-        ignore:
-          "List of ignored name segment patterns e.g. `[~r/Sample_Module/, \"Sample_Module\"]`"
+        ignore: "List of ignored module names and patterns e.g. `[~r/Sample_Module/, \"Credo.Sample_Module\"]`"
       ]
     ]
 
@@ -63,17 +62,11 @@ defmodule Credo.Check.Readability.ModuleNames do
   end
 
   defp issues_for_name(name, meta, issues, issue_meta, ignored_patterns) do
-    segments =
+    module_name =
       name
       |> to_string
-      |> String.split(".")
 
-    all_correct? =
-      Enum.all?(segments, fn segment ->
-         Name.pascal_case?(segment) or ignored_segment?(ignored_patterns, segment) 
-      end)
-
-    if all_correct? do
+    if Name.pascal_case?(module_name) or ignored_module?(ignored_patterns, module_name) do
       issues
     else
       [issue_for(issue_meta, meta[:line], name) | issues]
@@ -89,15 +82,14 @@ defmodule Credo.Check.Readability.ModuleNames do
     )
   end
 
-  defp ignored_segment?([], _segment), do: false
+  defp ignored_module?([], _module_name), do: false
 
-  defp ignored_segment?(ignored_patterns, segment) do
+  defp ignored_module?(ignored_patterns, module_name) do
     Enum.any?(ignored_patterns, fn
       %Regex{} = pattern ->
-        String.match?(segment, pattern)
-
-      module_name ->
-        String.equivalent?(segment, to_string(module_name))
+        String.match?(module_name, pattern)
+      name ->
+        module_name == name
     end)
   end
 end

--- a/lib/credo/check/readability/module_names.ex
+++ b/lib/credo/check/readability/module_names.ex
@@ -70,7 +70,7 @@ defmodule Credo.Check.Readability.ModuleNames do
 
     all_correct? =
       Enum.all?(segments, fn segment ->
-         allowed_segment?(allowed_patterns, segment) or Name.pascal_case?(segment)
+         Name.pascal_case?(segment) or allowed_segment?(allowed_patterns, segment) 
       end)
 
     if all_correct? do

--- a/lib/credo/check/readability/module_names.ex
+++ b/lib/credo/check/readability/module_names.ex
@@ -1,6 +1,9 @@
 defmodule Credo.Check.Readability.ModuleNames do
   use Credo.Check,
     base_priority: :high,
+    param_defaults: [
+      allow: []
+    ],
     explanations: [
       check: """
       Module names are always written in PascalCase in Elixir.
@@ -20,7 +23,11 @@ defmodule Credo.Check.Readability.ModuleNames do
       Like all `Readability` issues, this one is not a technical concern.
       But you can improve the odds of other reading and liking your code by making
       it easier to follow.
-      """
+      """,
+      params: [
+        allow:
+          "List of allowed name segment patterns e.g. `[~r/Sample_Module/, \"Sample_Module\"]`"
+      ]
     ]
 
   alias Credo.Code.Name
@@ -29,39 +36,44 @@ defmodule Credo.Check.Readability.ModuleNames do
   @impl true
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
+    allowed_patterns = Credo.Check.Params.get(params, :allow, __MODULE__)
 
-    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta, allowed_patterns))
   end
 
-  defp traverse({:defmodule, _meta, arguments} = ast, issues, issue_meta) do
-    {ast, issues_for_def(arguments, issues, issue_meta)}
+  defp traverse({:defmodule, _meta, arguments} = ast, issues, issue_meta, allowed_patterns) do
+    {ast, issues_for_def(arguments, issues, issue_meta, allowed_patterns)}
   end
 
-  defp traverse(ast, issues, _issue_meta) do
+  defp traverse(ast, issues, _issue_meta, _allowed_patterns) do
     {ast, issues}
   end
 
-  defp issues_for_def(body, issues, issue_meta) do
+  defp issues_for_def(body, issues, issue_meta, allowed_patterns) do
     case Enum.at(body, 0) do
       {:__aliases__, meta, names} ->
         names
         |> Enum.filter(&String.Chars.impl_for/1)
         |> Enum.join(".")
-        |> issues_for_name(meta, issues, issue_meta)
+        |> issues_for_name(meta, issues, issue_meta, allowed_patterns)
 
       _ ->
         issues
     end
   end
 
-  defp issues_for_name(name, meta, issues, issue_meta) do
-    all_pascal_case? =
+  defp issues_for_name(name, meta, issues, issue_meta, allowed_patterns) do
+    segments =
       name
       |> to_string
       |> String.split(".")
-      |> Enum.all?(&Name.pascal_case?/1)
 
-    if all_pascal_case? do
+    all_correct? =
+      Enum.all?(segments, fn segment ->
+         allowed_segment?(allowed_patterns, segment) or Name.pascal_case?(segment)
+      end)
+
+    if all_correct? do
       issues
     else
       [issue_for(issue_meta, meta[:line], name) | issues]
@@ -75,5 +87,17 @@ defmodule Credo.Check.Readability.ModuleNames do
       trigger: trigger,
       line_no: line_no
     )
+  end
+
+  defp allowed_segment?([], _segment), do: false
+
+  defp allowed_segment?(allowed_patterns, segment) do
+    Enum.any?(allowed_patterns, fn
+      %Regex{} = pattern ->
+        String.match?(segment, pattern)
+
+      module_name ->
+        String.equivalent?(segment, to_string(module_name))
+    end)
   end
 end

--- a/lib/credo/check/readability/module_names.ex
+++ b/lib/credo/check/readability/module_names.ex
@@ -2,7 +2,7 @@ defmodule Credo.Check.Readability.ModuleNames do
   use Credo.Check,
     base_priority: :high,
     param_defaults: [
-      allow: []
+      ignore: []
     ],
     explanations: [
       check: """
@@ -25,8 +25,8 @@ defmodule Credo.Check.Readability.ModuleNames do
       it easier to follow.
       """,
       params: [
-        allow:
-          "List of allowed name segment patterns e.g. `[~r/Sample_Module/, \"Sample_Module\"]`"
+        ignore:
+          "List of ignored name segment patterns e.g. `[~r/Sample_Module/, \"Sample_Module\"]`"
       ]
     ]
 
@@ -36,33 +36,33 @@ defmodule Credo.Check.Readability.ModuleNames do
   @impl true
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
-    allowed_patterns = Credo.Check.Params.get(params, :allow, __MODULE__)
+    ignored_patterns = Credo.Check.Params.get(params, :ignore, __MODULE__)
 
-    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta, allowed_patterns))
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta, ignored_patterns))
   end
 
-  defp traverse({:defmodule, _meta, arguments} = ast, issues, issue_meta, allowed_patterns) do
-    {ast, issues_for_def(arguments, issues, issue_meta, allowed_patterns)}
+  defp traverse({:defmodule, _meta, arguments} = ast, issues, issue_meta, ignored_patterns) do
+    {ast, issues_for_def(arguments, issues, issue_meta, ignored_patterns)}
   end
 
-  defp traverse(ast, issues, _issue_meta, _allowed_patterns) do
+  defp traverse(ast, issues, _issue_meta, _ignored_patterns) do
     {ast, issues}
   end
 
-  defp issues_for_def(body, issues, issue_meta, allowed_patterns) do
+  defp issues_for_def(body, issues, issue_meta, ignored_patterns) do
     case Enum.at(body, 0) do
       {:__aliases__, meta, names} ->
         names
         |> Enum.filter(&String.Chars.impl_for/1)
         |> Enum.join(".")
-        |> issues_for_name(meta, issues, issue_meta, allowed_patterns)
+        |> issues_for_name(meta, issues, issue_meta, ignored_patterns)
 
       _ ->
         issues
     end
   end
 
-  defp issues_for_name(name, meta, issues, issue_meta, allowed_patterns) do
+  defp issues_for_name(name, meta, issues, issue_meta, ignored_patterns) do
     segments =
       name
       |> to_string
@@ -70,7 +70,7 @@ defmodule Credo.Check.Readability.ModuleNames do
 
     all_correct? =
       Enum.all?(segments, fn segment ->
-         Name.pascal_case?(segment) or allowed_segment?(allowed_patterns, segment) 
+         Name.pascal_case?(segment) or ignored_segment?(ignored_patterns, segment) 
       end)
 
     if all_correct? do
@@ -89,10 +89,10 @@ defmodule Credo.Check.Readability.ModuleNames do
     )
   end
 
-  defp allowed_segment?([], _segment), do: false
+  defp ignored_segment?([], _segment), do: false
 
-  defp allowed_segment?(allowed_patterns, segment) do
-    Enum.any?(allowed_patterns, fn
+  defp ignored_segment?(ignored_patterns, segment) do
+    Enum.any?(ignored_patterns, fn
       %Regex{} = pattern ->
         String.match?(segment, pattern)
 

--- a/test/credo/check/readability/module_names_test.exs
+++ b/test/credo/check/readability/module_names_test.exs
@@ -42,7 +42,7 @@ defmodule Credo.Check.Readability.ModuleNamesTest do
     |> refute_issues()
   end
 
-  test "it should not raise on ignored segment name" do
+  test "it should not raise on ignored module" do
     """
     defmodule Sample_Module do
     end
@@ -52,7 +52,7 @@ defmodule Credo.Check.Readability.ModuleNamesTest do
     |> refute_issues()
   end
 
-  test "it should not raise on ignored segment pattern" do
+  test "it should not raise on ignored pattern" do
     """
     defmodule Credo.Sample_Module do
     end
@@ -72,13 +72,23 @@ defmodule Credo.Check.Readability.ModuleNamesTest do
     |> refute_issues()
   end
 
-  test "it should not raise on multiple ignored segments" do
+  test "it should not raise on multiple ignored segment patterns" do
     """
     defmodule Credo.Another_Module.Sample_Module do
     end
     """
     |> to_source_file
-    |> run_check(@described_check, ignore: ["Another_Module", "Sample_Module"])
+    |> run_check(@described_check, ignore: [~r/Another_Module\.Sample_Module/])
+    |> refute_issues()
+  end
+
+  test "it should not raise on long segmented module" do
+    """
+    defmodule Credo.Another_Module.Sample_Module do
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, ignore: ["Credo.Another_Module.Sample_Module"])
     |> refute_issues()
   end
 
@@ -112,7 +122,7 @@ defmodule Credo.Check.Readability.ModuleNamesTest do
     end
     """
     |> to_source_file
-    |> run_check(@described_check, ignore: [~r/Another_Module/])
+    |> run_check(@described_check, ignore: [~r/Another_Module$/])
     |> assert_issue()
   end
 end

--- a/test/credo/check/readability/module_names_test.exs
+++ b/test/credo/check/readability/module_names_test.exs
@@ -42,6 +42,46 @@ defmodule Credo.Check.Readability.ModuleNamesTest do
     |> refute_issues()
   end
 
+  test "it should not raise on allowed segment name" do
+    """
+    defmodule Credo.Sample_Module do
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, allow: ["Sample_Module"])
+    |> refute_issues()
+  end
+
+  test "it should not raise on allowed segment pattern" do
+    """
+    defmodule Credo.Sample_Module do
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, allow: [~r/Sample_Module/])
+    |> refute_issues()
+  end
+
+  test "it should not raise on allowed segment when multiple are present" do
+    """
+    defmodule Credo.Another_Module.SampleModule do
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, allow: [~r/Another_Module/])
+    |> refute_issues()
+  end
+
+  test "it should not raise on multiple allowed segments" do
+    """
+    defmodule Credo.Another_Module.Sample_Module do
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, allow: ["Another_Module", "Sample_Module"])
+    |> refute_issues()
+  end
+
   #
   # cases raising issues
   #
@@ -53,6 +93,26 @@ defmodule Credo.Check.Readability.ModuleNamesTest do
     """
     |> to_source_file
     |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation for invalid segment" do
+    """
+    defmodule Credo.Sample_Module do
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation with multiple segments when one is invalid" do
+    """
+    defmodule Credo.Another_Module.Sample_Module do
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, allow: [~r/Another_Module/])
     |> assert_issue()
   end
 end

--- a/test/credo/check/readability/module_names_test.exs
+++ b/test/credo/check/readability/module_names_test.exs
@@ -42,43 +42,43 @@ defmodule Credo.Check.Readability.ModuleNamesTest do
     |> refute_issues()
   end
 
-  test "it should not raise on allowed segment name" do
+  test "it should not raise on ignored segment name" do
+    """
+    defmodule Sample_Module do
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, ignore: ["Sample_Module"])
+    |> refute_issues()
+  end
+
+  test "it should not raise on ignored segment pattern" do
     """
     defmodule Credo.Sample_Module do
     end
     """
     |> to_source_file
-    |> run_check(@described_check, allow: ["Sample_Module"])
+    |> run_check(@described_check, ignore: [~r/Sample_Module/])
     |> refute_issues()
   end
 
-  test "it should not raise on allowed segment pattern" do
-    """
-    defmodule Credo.Sample_Module do
-    end
-    """
-    |> to_source_file
-    |> run_check(@described_check, allow: [~r/Sample_Module/])
-    |> refute_issues()
-  end
-
-  test "it should not raise on allowed segment when multiple are present" do
+  test "it should not raise on ignored segment when multiple are present" do
     """
     defmodule Credo.Another_Module.SampleModule do
     end
     """
     |> to_source_file
-    |> run_check(@described_check, allow: [~r/Another_Module/])
+    |> run_check(@described_check, ignore: [~r/Another_Module/])
     |> refute_issues()
   end
 
-  test "it should not raise on multiple allowed segments" do
+  test "it should not raise on multiple ignored segments" do
     """
     defmodule Credo.Another_Module.Sample_Module do
     end
     """
     |> to_source_file
-    |> run_check(@described_check, allow: ["Another_Module", "Sample_Module"])
+    |> run_check(@described_check, ignore: ["Another_Module", "Sample_Module"])
     |> refute_issues()
   end
 
@@ -112,7 +112,7 @@ defmodule Credo.Check.Readability.ModuleNamesTest do
     end
     """
     |> to_source_file
-    |> run_check(@described_check, allow: [~r/Another_Module/])
+    |> run_check(@described_check, ignore: [~r/Another_Module/])
     |> assert_issue()
   end
 end

--- a/test/credo/check/readability/module_names_test.exs
+++ b/test/credo/check/readability/module_names_test.exs
@@ -54,7 +54,7 @@ defmodule Credo.Check.Readability.ModuleNamesTest do
 
   test "it should not raise on ignored pattern" do
     """
-    defmodule Credo.Sample_Module do
+    defmodule Sample_Module do
     end
     """
     |> to_source_file


### PR DESCRIPTION
- Adds :ignore param
  - :ignore is a list of regexes
- Adds tests for the functionality

Given
  ignore: [~r/Sample_Module$/]

Credo.Sample_Module will pass ✅ 
Credo.Another_Module.Sample_Module will fail ❌

Context:
On our project for versioning reasons, we decided to add an API version to a module name, but credo didn't have an option to configure it.

closes https://github.com/rrrene/credo-proposals/issues/83