### PR TITLE
feat: warn on dbg calls

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -192,6 +192,7 @@
           {Credo.Check.Refactor.PipeChainStart, []},
           {Credo.Check.Refactor.RejectFilter, []},
           {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.Dbg, []},
           {Credo.Check.Warning.LazyLogging, []},
           {Credo.Check.Warning.LeakyEnvironment, []},
           {Credo.Check.Warning.MapGetUnsafePass, []},

--- a/lib/credo/check/warning/dbg.ex
+++ b/lib/credo/check/warning/dbg.ex
@@ -1,5 +1,6 @@
 defmodule Credo.Check.Warning.Dbg do
   use Credo.Check,
+    id: "EX5026",
     base_priority: :high,
     elixir_version: ">= 1.14.0-dev",
     explanations: [

--- a/lib/credo/check/warning/dbg.ex
+++ b/lib/credo/check/warning/dbg.ex
@@ -1,0 +1,79 @@
+defmodule Credo.Check.Warning.Dbg do
+  use Credo.Check,
+    base_priority: :high,
+    elixir_version: ">= 1.14.0-dev",
+    explanations: [
+      check: """
+      Calls to dbg/0 and dbg/2 should mostly be used during debugging sessions.
+
+      This check warns about those calls, because they probably have been committed
+      in error.
+      """
+    ]
+
+  @call_string "dbg"
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse(
+         {:dbg, meta, []} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(
+         {:dbg, meta, [_single_param]} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(
+         {:dbg, meta, [_first_param, _second_param]} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(
+         {{:., _, [{:__aliases__, _, [:"Elixir", :Kernel]}, :dbg]}, meta, _args} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(
+         {{:., _, [{:__aliases__, _, [:Kernel]}, :dbg]}, meta, _args} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issues_for_call(meta, issues, issue_meta) do
+    [issue_for(issue_meta, meta[:line], @call_string) | issues]
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue(
+      issue_meta,
+      message: "There should be no calls to dbg.",
+      trigger: trigger,
+      line_no: line_no
+    )
+  end
+end

--- a/test/credo/check/warning/dbg_test.exs
+++ b/test/credo/check/warning/dbg_test.exs
@@ -1,0 +1,184 @@
+defmodule Credo.Check.Warning.DbgTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Warning.Dbg
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report expected code" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report when defining dbg fn" do
+    """
+    defmodule CredoSampleModule do
+      def dbg(my_param1, my_param2, myparam3) do
+        my_param
+      end
+
+      def some_fun(param1, param2, param3) do
+        dbg(param1 + param2, param3 * 4, false)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues
+  end
+
+  test "it should NOT report when assigning and using dbg var" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun(param1, param2) do
+        dbg = param1 + param2
+        param3 = dbg + 4
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report a violation" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        dbg parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /2" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        parameter1 + parameter2 |> dbg()
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /3" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(a, b, c) do
+        map([a,b,c], &dbg(&1))
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /4" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        Kernel.dbg(parameter1 + parameter2)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /5" do
+    """
+    defmodule CredoSampleModule do
+      def dbg(my_param, my_param2, my_param3) do
+        my_param
+      end
+
+      def some_fun(param1, param2) do
+        Kernel.dbg(param1)
+        dbg(param1, AnotherModule.another_fun(param2), param1 + param2)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /6" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun(params) do
+        dbg = dbg(params)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /7" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun(params) do
+        dbg()
+        params
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /8" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun(params) do
+        dbg = params + 1
+        dbg
+        dbg()
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /9" do
+    """
+    defmodule CredoSampleModule do
+      defmodule CredoSampleModule do
+        def some_function(parameter1, parameter2) do
+          Elixir.Kernel.dbg(parameter1 + parameter2)
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+end


### PR DESCRIPTION
Implements a warning for calls to the dbg/0 or dbg/2 Kernel fns.

I used the IO.inspect check as a reference.