### PR TITLE
Add Kernel.dbg call warning

### DIFF
--- a/lib/credo/check/warning/kernel_dbg.ex
+++ b/lib/credo/check/warning/kernel_dbg.ex
@@ -1,0 +1,70 @@
+defmodule Credo.Check.Warning.KernelDbg do
+  @moduledoc false
+
+  use Credo.Check,
+    base_priority: :high,
+    explanations: [
+      check: """
+      While calls to dbg might appear in some parts of production code,
+      most calls to this function are added during debugging sessions.
+
+      This check warns about those calls, because they might have been committed
+      in error.
+      """
+    ]
+
+  @call_string "dbg"
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse({:dbg, _meta, nil} = ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp traverse({:dbg, meta, _arguments} = ast, issues, issue_meta) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(
+         {{:., _, [{:__aliases__, _, [:"Elixir", :Kernel]}, :dbg]}, meta, _arguments} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(
+         {{:., _, [{:__aliases__, _, [:Kernel]}, :dbg]}, meta, _arguments} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse({:|>, _, [_, {:dbg, meta, nil}]} = ast, issues, issue_meta) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issues_for_call(meta, issues, issue_meta) do
+    [issue_for(issue_meta, meta[:line], @call_string) | issues]
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue(
+      issue_meta,
+      message: "There should be no calls to dbg/2.",
+      trigger: trigger,
+      line_no: line_no
+    )
+  end
+end

--- a/test/credo/check/warning/kernel_dbg_test.exs
+++ b/test/credo/check/warning/kernel_dbg_test.exs
@@ -1,0 +1,117 @@
+defmodule Credo.Check.Warning.KernelDbgTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Warning.KernelDbg
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report expected code" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report when dbg is variable" do
+    """
+    defmodule CredoSampleModule do
+      def some_function() do
+        dbg = "hello"
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report when dbg is variable /2" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(dbg) do
+        dbg
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report a violation" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        dbg parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /2" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        parameter1 + parameter2
+        |> dbg
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        parameter1 + parameter2
+        |> dbg()
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /4" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        Elixir.Kernel.dbg parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /5" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        Kernel.dbg parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+end


### PR DESCRIPTION
Start tackle https://github.com/rrrene/credo-proposals/issues/80 by adding a simple case of `Kernel.dbg` calls.