### PR TITLE
New check: PassAsync

### DIFF
--- a/lib/credo/check/design/pass_async.ex
+++ b/lib/credo/check/design/pass_async.ex
@@ -1,0 +1,78 @@
+defmodule Credo.Check.Design.PassAsync do
+  @moduledoc """
+  Check that we pass an `async` option when we `use` test case modules.
+  """
+
+  use Credo.Check,
+    base_priority: :normal,
+    category: :consistency,
+    param_defaults: [],
+    explanations: [
+      check: """
+      Test modules marked `async: true` are run concurrently, speeding up the
+      test suite and improving productivity. This should always be done when
+      possible.
+
+      Leaving off the `async:` option silently defaults to `false`, which may make
+      a test suite slower for no real reason.
+
+      Test modules which cannot be run concurrently should be explicitly marked
+      `async: false`, ideally with a comment explaining why.
+      """
+    ]
+
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  # `use` with options
+  defp traverse({:use, _, [{_, meta, module_namespace}, options]} = ast, issues, issue_meta) do
+    module_name = module_name_from(module_namespace)
+
+    if String.ends_with?(module_name, "Case") and !Keyword.has_key?(options, :async) do
+      {ast, issues ++ [issue_for(ast, meta[:line], issue_meta)]}
+    else
+      {ast, issues}
+    end
+  end
+
+  # `use` without options
+  defp traverse({:use, _, [{_, meta, module_namespace}]} = ast, issues, issue_meta) do
+    module_name = module_name_from(module_namespace)
+
+    if String.ends_with?(module_name, "Case") do
+      {ast, issues ++ [issue_for(ast, meta[:line], issue_meta)]}
+    else
+      {ast, issues}
+    end
+  end
+
+  # Ignore all other AST nodes
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issue_for(ast, line_no, issue_meta) do
+    format_issue(
+      issue_meta,
+      message: "Pass an `:async` boolean option to `use` a test case module",
+      trigger: to_code(ast),
+      line_no: line_no
+    )
+  end
+
+  defp module_name_from(module_namespace) do
+    module_namespace
+    |> List.last()
+    |> to_string()
+  end
+
+  defp to_code(ast) do
+    ast
+    |> Code.quoted_to_algebra()
+    |> Inspect.Algebra.format(:infinity)
+    |> IO.iodata_to_binary()
+  end
+end

--- a/lib/credo/check/design/pass_async.ex
+++ b/lib/credo/check/design/pass_async.ex
@@ -70,9 +70,17 @@ defmodule Credo.Check.Design.PassAsync do
   end
 
   defp to_code(ast) do
-    ast
-    |> Code.quoted_to_algebra()
-    |> Inspect.Algebra.format(:infinity)
-    |> IO.iodata_to_binary()
+    if has_quoted_to_algebra?() do
+      ast
+      |> Code.quoted_to_algebra()
+      |> Inspect.Algebra.format(:infinity)
+      |> IO.iodata_to_binary()
+    else
+      ast
+    end
+  end
+
+  defp has_quoted_to_algebra? do
+    function_exported?(Code, :quoted_to_algebra, 1)
   end
 end

--- a/test/credo/check/design/pass_async_test.exs
+++ b/test/credo/check/design/pass_async_test.exs
@@ -1,0 +1,72 @@
+defmodule Credo.Check.Design.PassAsyncTest do
+  use Credo.Test.Case, async: true
+  @described_check Credo.Check.Design.PassAsync
+
+  test "it ignores `use` statements for modules not ending in 'Case'" do
+    """
+    defmodule FooTest do
+      use SomeModule
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  for case_name <- ~w[MyApp.DataCase ConnCase Foo.Bar.BazCase] do
+    @case_name case_name
+
+    test "it allows `use #{@case_name}, async: true`" do
+      """
+      defmodule FooTest do
+        use #{@case_name}, async: true
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it allows `use #{@case_name}, async: false`" do
+      """
+      defmodule BlahTest do
+        use #{@case_name}, async: false
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it does not allow `use #{@case_name}` with other options but not `async:`" do
+      """
+      defmodule ThingTest do
+        use #{@case_name}, bite_strength: :xtreme
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> assert_issue(fn issue ->
+        assert issue.line_no == 2
+        assert issue.column == 3
+        assert issue.trigger == "use #{@case_name}, bite_strength: :xtreme"
+      end)
+    end
+
+    test "it does not allow `use #{@case_name}` without options" do
+      """
+      defmodule FooTest do
+        # some comment
+        use #{@case_name}
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> assert_issue(fn issue ->
+        assert issue.line_no == 3
+        assert issue.column == 3
+        assert issue.trigger == "use #{@case_name}"
+      end)
+    end
+  end
+end

--- a/test/credo/check/design/pass_async_test.exs
+++ b/test/credo/check/design/pass_async_test.exs
@@ -48,8 +48,10 @@ defmodule Credo.Check.Design.PassAsyncTest do
       |> run_check(@described_check)
       |> assert_issue(fn issue ->
         assert issue.line_no == 2
-        assert issue.column == 3
-        assert issue.trigger == "use #{@case_name}, bite_strength: :xtreme"
+        if has_quoted_to_algebra?() do
+          assert issue.column == 3
+          assert issue.trigger == "use #{@case_name}, bite_strength: :xtreme"
+        end
       end)
     end
 
@@ -64,9 +66,15 @@ defmodule Credo.Check.Design.PassAsyncTest do
       |> run_check(@described_check)
       |> assert_issue(fn issue ->
         assert issue.line_no == 3
-        assert issue.column == 3
-        assert issue.trigger == "use #{@case_name}"
+        if has_quoted_to_algebra?() do
+          assert issue.column == 3
+          assert issue.trigger == "use #{@case_name}"
+        end
       end)
     end
+  end
+
+  def has_quoted_to_algebra? do
+    function_exported?(Code, :quoted_to_algebra, 1)
   end
 end


### PR DESCRIPTION
Extracted from an app. We configure this in `.credo.exs` like:

```elixir
{MyApp.Checks.PassAsync, files: %{included: ["**/*_test.exs"]}}
```