### PR TITLE
Application config agnostic testing instructions

### DIFF
--- a/guides/custom_checks/testing_checks.md
+++ b/guides/custom_checks/testing_checks.md
@@ -11,15 +11,10 @@ Using this module will:
 * import all the functions from this module
 * make the test case `:async` by default (use `async: false` to opt out of this behaviour)
 
-In `mix.exs`, add `:credo` in `extra_applications:`:
+In `test_helper.exs`, make sure `credo` is started:
 
 ```
-def application do
-  [
-     ...,
-     extra_applications: [:credo, ...]
-  ]
-end
+{:ok, _} = Application.ensure_all_started(:credo)
 ```
 
 Let's test the `RejectModuleAttributes` check that we implemented in [Adding custom checks](./adding_checks.md).


### PR DESCRIPTION
The current instructions for testing a custom check do not work if you do not want to add `credo` to your production build.  Adding `:credo` to `extra_applications` causes environments where credo is not included to fail to start.

As an alternative this PR replaces that instruction with an instruction to add `Application.ensure_all_started(:credo)` to the `test_helper.exs` file.  That way credo starts but does not have to be included in all envs.

See https://github.com/rrrene/credo/issues/1003