### PR TITLE
Add test for case-sensitive alias ordering

### DIFF
--- a/test/credo/check/readability/alias_order_test.exs
+++ b/test/credo/check/readability/alias_order_test.exs
@@ -118,6 +118,18 @@ defmodule Credo.Check.Readability.AliasOrderTest do
     |> refute_issues()
   end
 
+  test "it should work with case-sensitive sorting" do
+    """
+    defmodule Test do
+      alias MyApp.AlphaBravoCharlie
+      alias MyApp.AlphaBravoalpha
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, sort_method: :ascii)
+    |> refute_issues()
+  end
+
   #
   # cases raising issues
   #
@@ -227,5 +239,17 @@ defmodule Credo.Check.Readability.AliasOrderTest do
     |> assert_issue(fn issue ->
       assert issue.trigger == "Sorter"
     end)
+  end
+
+  test "it should repot violation with case-sensitive sorting" do
+    """
+    defmodule Test do
+      alias MyApp.AlphaBravoalpha
+      alias MyApp.AlphaBravoCharlie
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, sort_method: :ascii)
+    |> refute_issues()
   end
 end


### PR DESCRIPTION
I have an app where this is the case. Vim's `sort` and recode's alias order say that this test should be correct but credo disagrees.

I took a stab at trying to fix this but I only had a limited time and I couldn't get it work work with existing tests. I'll open an issue and link theses. Let me know if there's anything else I can do.