### PR TITLE
Add custom operators for Readability.FunctionNames

### DIFF
--- a/lib/credo/check/readability/function_names.ex
+++ b/lib/credo/check/readability/function_names.ex
@@ -34,7 +34,7 @@ defmodule Credo.Check.Readability.FunctionNames do
   @all_sigil_atoms Enum.map(@all_sigil_chars, &:"sigil_#{&1}")
 
   # all non-special-form operators
-  @all_nonspecial_operators ~W(! && ++ -- .. <> =~ @ |> || != !== * + - / < <= == === > >= ||| &&& <<< >>> <<~ ~>> <~ ~> <~> <|> ^^^ ~~~)a
+  @all_nonspecial_operators ~W(! && ++ -- .. <> =~ @ |> || != !== * + - / < <= == === > >= ||| &&& <<< >>> <<~ ~>> <~ ~> <~> <|> ^^^ ~~~ +++ ---)a
 
   @doc false
   @impl true


### PR DESCRIPTION
Hi, thank you for credo!

I'm trying to use newly added custom operators `+++` and `---` from Elixir v1.11.0, but `Readability.FunctionName` didn't seem to support it. 
This pull request only add it.