### PR TITLE
properly analyze function with guards

### DIFF
--- a/lib/credo/code/module.ex
+++ b/lib/credo/code/module.ex
@@ -378,6 +378,11 @@ defmodule Credo.Code.Module do
        when clause in ~w/use import alias require defstruct/a and is_list(args),
        do: add_module_element(state, clause, meta)
 
+  defp analyze(state, {clause, meta, [{:when, _, [fun | _rest]}, body]})
+       when clause in ~w/def defmacro defguard defp defmacrop defguardp/a do
+    analyze(state, {clause, meta, [fun, body]})
+  end
+
   defp analyze(state, {clause, meta, definition})
        when clause in ~w/def defmacro defguard defp defmacrop defguardp/a do
     fun_name = fun_name(definition)

--- a/test/credo/code/module_test.exs
+++ b/test/credo/code/module_test.exs
@@ -526,12 +526,19 @@ defmodule Credo.Code.ModuleTest do
 
              defp d(1), do: true
              defp d(2), do: false
+
+             @impl true
+             def e(x) when is_binary(x), do: true
+             def e(nil), do: false
+             def e(x) when is_integer(x) and x > 10, do: true
+             def e(1), do: true
              """) == [
                {Test,
                 public_fun: [line: 2, column: 3],
                 callback_fun: [line: 6, column: 3],
                 private_fun: [line: 10, column: 3],
-                private_fun: [line: 13, column: 3]}
+                private_fun: [line: 13, column: 3],
+                callback_fun: [line: 17, column: 3]}
              ]
     end
 


### PR DESCRIPTION
In case of a guard the `ast` was not properly traversed and in case of a callback implementation the `@impl` attribute was not propagated to the remaining clauses