### PR TITLE
Update `ModuleDoc` defaults for Phoenix 1.7+ views

### DIFF
--- a/lib/credo/check/readability/module_doc.ex
+++ b/lib/credo/check/readability/module_doc.ex
@@ -2,7 +2,7 @@ defmodule Credo.Check.Readability.ModuleDoc do
   use Credo.Check,
     param_defaults: [
       ignore_names: [
-        ~r/(\.\w+Controller|\.Endpoint|\.\w+Live(\.\w+)?|\.Repo|\.Router|\.\w+Socket|\.\w+View)$/
+        ~r/(\.\w+Controller|\.Endpoint|\.\w+Live(\.\w+)?|\.Repo|\.Router|\.\w+Socket|\.\w+View|\.\w+HTML|\.\w+JSON)$/
       ]
     ],
     explanations: [


### PR DESCRIPTION
Phoenix 1.7 introduces [new approach to defining views](https://www.phoenixframework.org/blog/phoenix-1.7-released) where the module name is suffixed with the format like so:

```
defmodule AppWeb.PageHTML do
  use AppWeb, :html

  embed_templates "page_html/*"
end

defmodule AppWeb.PostJSON do
  # ...
end
```

The PR updates the defaults for the `ModuleDoc` check.