### PR TITLE
feat: add dbg warning check

### DIFF
--- a/lib/credo/check/warning/dbg.ex
+++ b/lib/credo/check/warning/dbg.ex
@@ -1,0 +1,65 @@
+defmodule Credo.Check.Warning.Dbg do
+  use Credo.Check,
+    id: "EX5026",
+    base_priority: :high,
+    explanations: [
+      check: """
+      While calls to dbg might appear in some parts of production code,
+      most calls to this function are added during debugging sessions.
+
+      This check warns about those calls, because they might have been committed
+      in error.
+      """
+    ]
+
+  @call_string "dbg"
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse(
+         {{:., _, [{:__aliases__, _, [:"Elixir", :Kernel]}, :dbg]}, meta, _arguments} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(
+         {{:., _, [{:__aliases__, _, [:Kernel]}, :dbg]}, meta, _arguments} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(
+         {:dbg, meta, _arguments} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues_for_call(meta, issues, issue_meta)}
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issues_for_call(meta, issues, issue_meta) do
+    [issue_for(issue_meta, meta[:line], @call_string) | issues]
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue(
+      issue_meta,
+      message: "There should be no calls to dbg/2.",
+      trigger: trigger,
+      line_no: line_no
+    )
+  end
+end

--- a/test/credo/check/warning/dbg_test.exs
+++ b/test/credo/check/warning/dbg_test.exs
@@ -1,0 +1,92 @@
+defmodule Credo.Check.Warning.DbgTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Warning.Dbg
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report expected code" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report a violation" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        dbg parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /2" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        parameter1 + parameter2
+        |> dbg
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /3" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(a, b, c) do
+        map([a,b,c], &dbg(&1))
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /4" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        Elixir.Kernel.dbg parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation /5" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        Kernel.dbg parameter1 + parameter2
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+end


### PR DESCRIPTION
This PR adds a check similar to the `IO.inspect` warning. The new `dbg` macro will also get a ton of use during debugging and it would be great to check for this in a similar way.

This is my first time jumping into the credo source so if I missed anything please let me know, will be happy to fix it! For the `id` I just grabbed the next available `EX50..` number, `EX5026`.

Thanks ahead of time for your review & all your hard work on credo! ❤️ 