### PR TITLE
Add refactoring check suggesting to use Enum.count/2 if applicable

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -131,6 +131,7 @@
           {Credo.Check.Refactor.Nesting, []},
           {Credo.Check.Refactor.UnlessWithElse, []},
           {Credo.Check.Refactor.WithClauses, []},
+          {Credo.Check.Refactor.FilterCount, []},
           {Credo.Check.Refactor.FilterFilter, []},
           {Credo.Check.Refactor.RejectReject, []},
           {Credo.Check.Refactor.RedundantWithClauseResult, []},

--- a/lib/credo/check/refactor/filter_count.ex
+++ b/lib/credo/check/refactor/filter_count.ex
@@ -1,0 +1,98 @@
+defmodule Credo.Check.Refactor.FilterCount do
+  use Credo.Check,
+    id: "EX4030",
+    base_priority: :high,
+    explanations: [
+      check: """
+      `Enum.count/2` is more efficient than `Enum.filter/2 |> Enum.count/1`.
+
+      This should be refactored:
+
+          [1, 2, 3, 4, 5]
+          |> Enum.filter(fn x -> rem(x, 3) == 0 end)
+          |> Enum.count()
+
+      to look like this:
+
+          Enum.count([1, 2, 3, 4, 5], fn x -> rem(x, 3) == 0 end)
+
+      The reason for this is performance, because the two separate calls
+      to `Enum.filter/2` and `Enum.count/1` require two iterations whereas
+      `Enum.count/2` performs the same work in one pass.
+      """
+    ]
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse(
+         {:|>, _,
+          [
+            {:|>, _,
+             [
+               _,
+               {{:., meta, [{:__aliases__, _, [:Enum]}, :filter]}, _, _}
+             ]},
+            {{:., _, [{:__aliases__, _, [:Enum]}, :count]}, _, []}
+          ]} = ast,
+         issues,
+         issue_meta
+       ) do
+    new_issue = issue_for(issue_meta, meta[:line], "filter_count")
+    {ast, issues ++ List.wrap(new_issue)}
+  end
+
+  defp traverse(
+         {{:., meta, [{:__aliases__, _, [:Enum]}, :count]}, _,
+          [
+            {{:., _, [{:__aliases__, _, [:Enum]}, :filter]}, _, _}
+          ]} = ast,
+         issues,
+         issue_meta
+       ) do
+    new_issue = issue_for(issue_meta, meta[:line], "filter_count")
+    {ast, issues ++ List.wrap(new_issue)}
+  end
+
+  defp traverse(
+         {:|>, _,
+          [
+            {{:., meta, [{:__aliases__, _, [:Enum]}, :filter]}, _, _},
+            {{:., _, [{:__aliases__, _, [:Enum]}, :count]}, _, []}
+          ]} = ast,
+         issues,
+         issue_meta
+       ) do
+    new_issue = issue_for(issue_meta, meta[:line], "filter_count")
+    {ast, issues ++ List.wrap(new_issue)}
+  end
+
+  defp traverse(
+         {{:., meta, [{:__aliases__, _, [:Enum]}, :count]}, _,
+          [
+            {:|>, _, [_, {{:., _, [{:__aliases__, _, [:Enum]}, :filter]}, _, _}]}
+          ]} = ast,
+         issues,
+         issue_meta
+       ) do
+    new_issue = issue_for(issue_meta, meta[:line], "filter_count")
+    {ast, issues ++ List.wrap(new_issue)}
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue(
+      issue_meta,
+      message: "`Enum.count/2` is more efficient than `Enum.filter/2 |> Enum.count/1`",
+      trigger: trigger,
+      line_no: line_no
+    )
+  end
+end

--- a/test/credo/check/refactor/filter_count_test.exs
+++ b/test/credo/check/refactor/filter_count_test.exs
@@ -1,0 +1,170 @@
+defmodule Credo.Check.Refactor.FilterCountTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Refactor.FilterCount
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "does not trigger when using Enum.count/2" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        Enum.count([1, 2, 3], fn x -> rem(x, 3) == 0 end)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "does not trigger when piping list into Enum.filter/2 and piping result of that into Enum.count/2" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        [1, 2, 3]
+        |> Enum.filter(fn x -> rem(x, 3) == 0 end)
+        |> Enum.count(fn x -> x > 2 end)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "does not trigger when filter-count pipeline is part of a larger pipeline using Enum.count/2" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        [1, 2, 3]
+        |> Enum.sort()
+        |> Enum.filter(fn x -> rem(x, 3) == 0 end)
+        |> Enum.count(fn x -> x > 2 end)
+        |> then(fn x -> x + 1 end)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "does not trigger when piping list into Enum.filter/2 and passing result as parameter to Enum.count/2" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        Enum.count([1, 2, 3] |> Enum.filter(fn x -> rem(x, 3) == 0 end), fn x -> x > 2 end)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "does not trigger when applying Enum.filter/2 to two arguments and passing result to Enum.count/2" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5, p6) do
+        Enum.count(Enum.filter([1, 2, 3], fn x -> rem(x, 3) == 0 end), fn x -> x > 2 end)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "does not trigger when applying Enum.filter/2 to two arguments and piping into Enum.count/2" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        Enum.filter([1, 2, 3], fn x -> rem(x, 3) == 0 end)
+        |> Enum.count(fn x -> x > 2 end)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "triggers when piping list into Enum.filter/2 and piping result of that into Enum.count/1" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        [1, 2, 3]
+        |> Enum.filter(fn x -> rem(x, 3) == 0 end)
+        |> Enum.count()
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "triggers when filter-count pipeline is part of a larger pipeline" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        [1, 2, 3]
+        |> Enum.sort()
+        |> Enum.filter(fn x -> rem(x, 3) == 0 end)
+        |> Enum.count()
+        |> then(fn x -> x + 1 end)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "triggers when piping list into Enum.filter/2 and passing result as parameter to Enum.count/1" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        Enum.count([1, 2, 3] |> Enum.filter(fn x -> rem(x, 3) == 0 end))
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "triggers when applying Enum.filter/2 to two arguments and passing result to Enum.count/1" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5, p6) do
+        Enum.count(Enum.filter([1, 2, 3], fn x -> rem(x, 3) == 0 end))
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "triggers when applying Enum.filter/2 to two arguments and piping into Enum.count/1" do
+    """
+    defmodule Credo.Sample.Module do
+      def some_function(p1, p2, p3, p4, p5) do
+        Enum.filter([1, 2, 3], fn x -> rem(x, 3) == 0 end)
+        |> Enum.count()
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+end


### PR DESCRIPTION
This extends Credo such that it looks for use cases for [Enum.count/2](https://hexdocs.pm/elixir/1.14.2/Enum.html#count/2). Alas, I only learned about https://github.com/rrrene/credo-proposals _after_ creating these commits so this PR is 'out of the blue'. 😔 However, I hope that it's not too controversial since the proposed refactoring is much like the one for `Enum.map_join/3`.

Using `Enum.count/2` instead of composing `Enum.filter/2` with `Enum.count/1` is preferable since

1. `Enum.count/2` requires just a single pass, so it's a little more efficient
2. It's less code

The check ID `EX4030` was determined by checking the other IDs and simply picking the next larger value; the largest check ID for refactoring checks appears to be `EX4029`, so that's how I ended up with `EX4030`. 😊 

The test suite exercises various ways of composing `Enum.filter/2` and `Enum.count/1`, making sure that uses of the `|>` operator don't confuse the check and that e.g. using `Enum.filter/2` with `Enum.count/2` does _not_ trigger.