### PR TITLE
Add check to prefer explicit lists over ~w and ~W sigils

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -178,6 +178,7 @@
           {Credo.Check.Readability.ImplTrue, []},
           {Credo.Check.Readability.MultiAlias, []},
           {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.NoListSigils, []},
           {Credo.Check.Readability.OneArityFunctionInPipe, []},
           {Credo.Check.Readability.SeparateAliasRequire, []},
           {Credo.Check.Readability.SingleFunctionToBlockPipe, []},

--- a/lib/credo/check/readability/no_list_sigils.ex
+++ b/lib/credo/check/readability/no_list_sigils.ex
@@ -1,0 +1,63 @@
+defmodule Credo.Check.Readability.NoListSigils do
+  @moduledoc """
+  A check to suggest explicit lists over the ~w and ~W sigls.
+  """
+  use Credo.Check,
+    param_defaults: [],
+    explanations: [
+      check: ~S"""
+      Although the ~w and ~W sigils allow for brevity when writing code, code is
+      read many more times than it is written. List definitions are both relatively
+      brief and completely unambiguous; consider defining lists explicitly rather than
+      via the sigil.
+
+      Instead of
+
+          ~w'foo bar baz'
+          ~w/例（括弧）+追加 別言葉/a
+          ~W({"key":"value"} {"key2":"value2"})
+
+      Prefer:
+
+          ["foo", "bar", "baz"]
+          [:"例（括弧）+追加", :別言葉]
+          [~S({"key":"value"}), ~S({"key2":"value2"})]
+      """,
+      params: []
+    ]
+
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse({:sigil_w, context, _args} = ast, issues, issue_meta) do
+    issue =
+      format_issue(
+        issue_meta,
+        message: ~S{Avoid ~w sigil: ~w(foo bar), prefer explicit lists: ["foo", "bar"]},
+        trigger: :sigil_w,
+        line_no: context[:line]
+      )
+
+    {ast, [issue | issues]}
+  end
+
+  defp traverse({:sigil_W, context, _args} = ast, issues, issue_meta) do
+    issue =
+      format_issue(
+        issue_meta,
+        message:
+          ~S<Avoid ~W sigil: ~W({"key":"value"}), prefer explicit lists: [~S({"key":"value"})]>,
+        trigger: :sigil_W,
+        line_no: context[:line]
+      )
+
+    {ast, [issue | issues]}
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+end

--- a/test/credo/check/readability/no_list_sigils_test.exs
+++ b/test/credo/check/readability/no_list_sigils_test.exs
@@ -1,0 +1,41 @@
+defmodule Credo.Check.Readability.NoListSigilsTest do
+  use Credo.Test.Case, async: true
+
+  @described_check Credo.Check.Readability.NoListSigils
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report when no ~w or ~W sigil is used" do
+    ~S"""
+    ["foo", "bar", "baz"] == ["foo", "bar", "baz"]
+    ["{\"key\":\"value\"}"] == [~S({"key":"value"})]
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report when a ~w sigil is used" do
+    """
+    ~w(foo bar baz) == ["foo", "bar", "baz"]
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report when a ~W sigil is used" do
+    """
+    ~W({"key":"value"}) == [~S({"key":"value"})]
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+end


### PR DESCRIPTION
This is a check I have wanted myself for a while. I thought I would submit it upstream in case it's useful to others.

I have added it as disabled by default/controversial.