### PR TITLE
Fixes `:all` Logger metadata handling from MissedMetadataKeyInLoggerConfig check

### DIFF
--- a/lib/credo/check/warning/missed_metadata_key_in_logger_config.ex
+++ b/lib/credo/check/warning/missed_metadata_key_in_logger_config.ex
@@ -121,6 +121,10 @@ defmodule Credo.Check.Warning.MissedMetadataKeyInLoggerConfig do
     nil
   end
 
+  defp issue_for_call(_logger_metadata, _meta, _issue_meta, :all) do
+    nil
+  end
+
   defp issue_for_call(logger_metadata, meta, issue_meta, metadata_keys) do
     if Keyword.keyword?(logger_metadata) do
       case Keyword.drop(logger_metadata, metadata_keys) do

--- a/test/credo/check/warning/missed_metadata_key_in_logger_config_test.exs
+++ b/test/credo/check/warning/missed_metadata_key_in_logger_config_test.exs
@@ -134,4 +134,21 @@ defmodule Credo.Check.Warning.MissedMetadataKeyInLoggerConfigTest do
     |> run_check(@described_check)
     |> refute_issues()
   end
+
+  for fun <- @logger_functions do
+    test "it should NOT report Logger.#{fun}/2 is used and `all` metadata is allowed" do
+      """
+      defmodule CredoSampleModule do
+        def some_function(parameter1, parameter2) do
+          Logger.#{unquote(fun)}(fn ->
+            "A warning message: #{inspect(1)}"
+          end, account_id: 1)
+        end
+      end
+      """
+      |> to_source_file
+      |> run_check(@described_check, metadata_keys: :all)
+      |> refute_issues()
+    end
+  end
 end


### PR DESCRIPTION
Hey folks! 🖖 

Credo 1.7 was released with the [MissedMetadataKeyInLoggerConfig](https://github.com/rrrene/credo/blob/master/lib/credo/check/warning/missed_metadata_key_in_logger_config.ex) check. The check ensures all `Logger` calls have their metadata fields defined in the `configs.exs` - in other words, it ensures all metadata fields are really logged and no metadata field is ignored from the logs.

There is a small issue with the new check: 

- It expects the metadata keys from the config file to be a list. 
- But it may be the `:all` - which makes all metadata fields to be logged.
 
The issue is that when the value is `:all`, the check crashes. 😿  

### What this PR does?

Even though it doesn't make much sense to run `MissedMetadataKeyInLoggerConfig` check for the codebases where all metadata fields are already logged, the check is enabled by default Credo configs. 
 
So this pull request fixes the problem by skipping issues when `metadata_keys == :all`. 
   
### More details

[From Logger.Backends.Console documentation:](https://hexdocs.pm/logger/1.14.3/Logger.Backends.Console.html#module-options)

>:metadata - the metadata to be printed by $metadata. Defaults to an empty list (no metadata). Setting :metadata to :all prints all metadata. See the "Metadata" section for more information.
