### PR TITLE
Dependency sorting check

### DIFF
--- a/lib/credo/check/readability/dependency_order.ex
+++ b/lib/credo/check/readability/dependency_order.ex
@@ -1,0 +1,66 @@
+defmodule Credo.Check.Readability.DependencyOrder do
+  use Credo.Check,
+    id: "",
+    base_priority: :low,
+    explanations: [
+      check: """
+
+      """
+    ]
+
+  alias Credo.Code.Name
+
+  @doc false
+  @impl true
+  def run(%SourceFile{filename: "mix.exs"} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  def run(%SourceFile{} = _source_file, _params) do
+    []
+  end
+
+  defp traverse({:defp, _, [{:deps, meta, _}, [do: deps]]} = ast, issues, issue_meta) do
+    result = Enum.reduce_while(deps, true, &compare/2)
+
+    case result do
+      {:error, deps_name} ->
+        # credo:disable-for-next-line Credo.Check.Refactor.AppendSingleItem
+        {ast, issues ++ [issue_for(deps_name, meta[:line], issue_meta)]}
+
+      {:error, deps_name, deps_meta} ->
+        # credo:disable-for-next-line Credo.Check.Refactor.AppendSingleItem
+        {ast, issues ++ [issue_for(deps_name, deps_meta[:line], issue_meta)]}
+
+      _atom ->
+        {ast, issues}
+    end
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp compare({deps_name, _version}, true), do: {:cont, deps_name}
+  defp compare({:{}, _, [deps_name, _version, _params]}, true), do: {:cont, deps_name}
+  defp compare({deps_name, _version}, prev) when deps_name > prev, do: {:cont, deps_name}
+
+  defp compare({:{}, _, [deps_name, _version, _params]}, prev) when deps_name > prev,
+    do: {:cont, deps_name}
+
+  defp compare({deps_name, _version}, _prev), do: {:halt, {:error, deps_name}}
+
+  defp compare({:{}, meta, [deps_name, _version, _params]}, _prev),
+    do: {:halt, {:error, deps_name, meta}}
+
+  defp issue_for(deps_name, line_no, issue_meta) do
+    format_issue(
+      issue_meta,
+      message: "Mix dependency #{deps_name} not sorted correctly",
+      trigger: deps_name,
+      line_no: line_no
+    )
+  end
+end

--- a/test/credo/check/readability/dependency_order_test.exs
+++ b/test/credo/check/readability/dependency_order_test.exs
@@ -1,0 +1,27 @@
+defmodule Credo.Check.Readability.DependencyOrderTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Readability.DependencyOrder
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report violation" do
+    """
+    defmodule Test do
+      defp deps do
+        [
+          {:a, "~> 0.0.1"},
+          {:b, "~> 0.0.1", only: :dev},
+          {:x, "~> 0.0.1"},
+          {:z, "~> 0.0.1", runtime: false}
+        ]
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+end


### PR DESCRIPTION
This check ensures the dependencies in the mix file are sorted alphabetically.

ToDos:

- [ ] Read the dependencies from the project function instead of assuming the name of the private function
- [ ] Add tests
- [ ] Add docs
- [ ] Adjust documentation to include `mix.exs` into the credo config
- [ ] Discuss edge cases