### PR TITLE
fix logger metadata check when metadata :all set

### DIFF
--- a/lib/credo/check/warning/missed_metadata_key_in_logger_config.ex
+++ b/lib/credo/check/warning/missed_metadata_key_in_logger_config.ex
@@ -44,16 +44,14 @@ defmodule Credo.Check.Warning.MissedMetadataKeyInLoggerConfig do
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
 
-    case ignore_check?(issue_meta) do
-      true ->
-        []
+    if ignore_check?(issue_meta) do
+      []
+    else
+      state = {false, []}
 
-      false ->
-        state = {false, []}
+      {_, issues} = Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta), state)
 
-        {_, issues} = Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta), state)
-
-        issues
+      issues
     end
   end
 

--- a/lib/credo/check/warning/missed_metadata_key_in_logger_config.ex
+++ b/lib/credo/check/warning/missed_metadata_key_in_logger_config.ex
@@ -43,11 +43,25 @@ defmodule Credo.Check.Warning.MissedMetadataKeyInLoggerConfig do
   @impl Credo.Check
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
-    state = {false, []}
 
-    {_, issues} = Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta), state)
+    case ignore_check?(issue_meta) do
+      true ->
+        []
 
-    issues
+      false ->
+        state = {false, []}
+
+        {_, issues} = Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta), state)
+
+        issues
+    end
+  end
+
+  # if logger metadata: :all is set, then ignore this check
+  defp ignore_check?(issue_meta) do
+    issue_meta_params = IssueMeta.params(issue_meta)
+    metadata_keys = find_metadata_keys(issue_meta_params)
+    metadata_keys == :all
   end
 
   defp traverse(

--- a/test/credo/check/warning/missed_metadata_key_in_logger_config_test.exs
+++ b/test/credo/check/warning/missed_metadata_key_in_logger_config_test.exs
@@ -120,6 +120,21 @@ defmodule Credo.Check.Warning.MissedMetadataKeyInLoggerConfigTest do
     |> refute_issues()
   end
 
+  test "it should NOT report when Logger.log/3 is used with metadata set to :all" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        Logger.log(:info, fn ->
+          "A warning message: #{inspect(1)}"
+        end, account_id: 1)
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, metadata_keys: :all)
+    |> refute_issues()
+  end
+
   test "it should NOT report when Logger.log/2 is used" do
     """
     defmodule CredoSampleModule do


### PR DESCRIPTION
Hello, this is another take on this PR https://github.com/rrrene/credo/pull/1035 which fixes the `metadata: :all` behavior for [MissedMetadataKeyInLoggerConfig](https://github.com/rrrene/credo/blob/master/lib/credo/check/warning/missed_metadata_key_in_logger_config.ex) check.

The issue with the check is that it doesn't properly support the `metadata: :all` configuration. This PR is different from the linked one because it skips running the check entirely if `metadata: :all` is set (since it makes no sense to run it), I've also added a new test that covers the scenario.

Please let me know if it needs to be tweaked before merging.

**What this PR does?**

This pull request prevents credo from crashing when `metadata_keys == :all` and when `MissedMetadataKeyInLoggerConfig` check runs.

**More details**

[From Logger.Backends.Console documentation:](https://hexdocs.pm/logger/1.14.3/Logger.Backends.Console.html#module-options)

>    :metadata - the metadata to be printed by $metadata. Defaults to an empty list (no metadata). Setting :metadata to :all prints all metadata. See the "Metadata" section for more information.

