### PR TITLE
Update missed_metadata_key_in_logger_config.ex

### DIFF
--- a/lib/credo/check/warning/missed_metadata_key_in_logger_config.ex
+++ b/lib/credo/check/warning/missed_metadata_key_in_logger_config.ex
@@ -19,7 +19,7 @@ defmodule Credo.Check.Warning.MissedMetadataKeyInLoggerConfig do
       In your app's logger configuration, you would need to include the `:error_code` key:
 
           config :logger, :console,
-            format: "[$level] $message $metadata\n",
+            format: "[$level] $message $metadata",
             metadata: [:error_code, :file]
 
       That way your logs might then receive lines like this:


### PR DESCRIPTION
It looks like the `/n` in the code sample causes ex_docs to add a line break and corrupt the code block. Removing `/n` fixes this.