### PR TITLE
Fix docs for priority

### DIFF
--- a/guides/commands/suggest_command.md
+++ b/guides/commands/suggest_command.md
@@ -181,7 +181,7 @@ Alias for [`--ignore-checks`](#ignore-checks-aliased-as-ignore)
 
 ### `--min-priority`
 
-Minimum priority to show issues (high,medium,normal,low,lower or number)
+Minimum priority to show issues (higher,high,normal,low,ignore or number)
 
 ```bash
 $ mix credo --min-priority high

--- a/guides/configuration/cli_switches.md
+++ b/guides/configuration/cli_switches.md
@@ -142,7 +142,7 @@ Suggest options:
       --format                  Display the list in a specific format (json,flycheck,oneline)
   -i, --ignore-checks           Ignore checks that match the given strings
       --ignore                  Alias for --ignore-checks
-      --min-priority            Minimum priority to show issues (high,medium,normal,low,lower or number)
+      --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)
       --mute-exit-status        Exit with status zero even if there are issues
       --only                    Alias for --checks
       --strict                  Alias for --all-priorities

--- a/lib/credo/cli/command/diff/diff_output.ex
+++ b/lib/credo/cli/command/diff/diff_output.ex
@@ -47,7 +47,7 @@ defmodule Credo.CLI.Command.Diff.DiffOutput do
             --from-git-merge-base     Diff from where the current HEAD branched off from the given merge base
         -i, --ignore-checks           Ignore checks that match the given strings
             --ignore                  Alias for --ignore-checks
-            --min-priority            Minimum priority to show issues (high,medium,normal,low,lower or number)
+            --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)
             --mute-exit-status        Exit with status zero even if there are issues
             --only                    Alias for --checks
             --since                   Diff from the given point in time (using Git)

--- a/lib/credo/cli/command/info/info_output.ex
+++ b/lib/credo/cli/command/info/info_output.ex
@@ -43,7 +43,7 @@ defmodule Credo.CLI.Command.Info.InfoOutput do
             --format                  Display the list in a specific format (json,flycheck,oneline)
         -i, --ignore-checks           Ignore checks that match the given strings
             --ignore                  Alias for --ignore-checks
-            --min-priority            Minimum priority to show issues (high,medium,normal,low,lower or number)
+            --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)
             --only                    Alias for --checks
             --verbose                 Display more information (e.g. checked files)
 

--- a/lib/credo/cli/command/list/list_output.ex
+++ b/lib/credo/cli/command/list/list_output.ex
@@ -45,7 +45,7 @@ defmodule Credo.CLI.Command.List.ListOutput do
             --format                  Display the list in a specific format (json,flycheck,oneline)
         -i, --ignore-checks           Ignore checks that match the given strings
             --ignore                  Alias for --ignore-checks
-            --min-priority            Minimum priority to show issues (high,medium,normal,low,lower or number)
+            --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)
             --mute-exit-status        Exit with status zero even if there are issues
             --only                    Alias for --checks
             --strict                  Alias for --all-priorities

--- a/lib/credo/cli/command/suggest/suggest_output.ex
+++ b/lib/credo/cli/command/suggest/suggest_output.ex
@@ -45,7 +45,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
             --format                  Display the list in a specific format (json,flycheck,oneline)
         -i, --ignore-checks           Ignore checks that match the given strings
             --ignore                  Alias for --ignore-checks
-            --min-priority            Minimum priority to show issues (high,medium,normal,low,lower or number)
+            --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)
             --mute-exit-status        Exit with status zero even if there are issues
             --only                    Alias for --checks
             --strict                  Alias for --all-priorities


### PR DESCRIPTION
They weren't updated to add higher and remove medium/lower

I took the valid values from:
https://github.com/axelson/credo/blob/e3f2c21a7a88db54d6256d67997cda6acfe06c08/lib/credo/priority.ex#L15-L21

Without this fix user's may run into this error:
```
$ mix credo suggest --min-priority=medium
** (RuntimeError) Got an invalid priority: :medium
    lib/credo/priority.ex:37: Credo.Priority.to_integer/1
    lib/credo/cli/options.ex:179: Credo.CLI.Options.patch_switch/2
    (elixir 1.14.3) lib/enum.ex:1780: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    lib/credo/cli/options.ex:173: Credo.CLI.Options.patch_switches/1
    lib/credo/cli/options.ex:114: Credo.CLI.Options.parse_result/7
    lib/credo/execution/task/parse_options.ex:39: Credo.Execution.Task.ParseOptions.call/2
    lib/credo/execution/task.ex:133: Credo.Execution.Task.do_run/3
    (elixir 1.14.3) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
```