### PR TITLE
If reading from standard input, do not consult the filesystem

### DIFF
--- a/lib/credo/check/runner.ex
+++ b/lib/credo/check/runner.ex
@@ -42,12 +42,17 @@ defmodule Credo.Check.Runner do
     files_excluded = Params.files_excluded(params, check)
 
     found_relevant_files =
-      if files_included == [] and files_excluded == [] do
-        []
-      else
-        exec
-        |> Execution.working_dir()
-        |> Credo.Sources.find_in_dir(files_included, files_excluded)
+      cond do
+        files_included == [] and files_excluded == [] ->
+          []
+
+        exec.read_from_stdin ->
+          []
+
+        true ->
+          exec
+          |> Execution.working_dir()
+          |> Credo.Sources.find_in_dir(files_included, files_excluded)
       end
 
     source_files =


### PR DESCRIPTION
Files coming in via standard input are not on the filesystem, and consulting includes and excludes makes an execution run hundreds of times slower than it should be.

This PR checks to see if the execution is reading from standard input and if so, returns an empty list to bypass the checks.

Fixes #1054