### PR TITLE
Cache scope priorities

### DIFF
--- a/lib/credo/application.ex
+++ b/lib/credo/application.ex
@@ -8,6 +8,7 @@ defmodule Credo.Application do
     Credo.Service.SourceFileAST,
     Credo.Service.SourceFileLines,
     Credo.Service.SourceFileScopes,
+    Credo.Service.SourceFileScopePriorities,
     Credo.Service.SourceFileSource
   ]
 

--- a/lib/credo/service/source_file_scope_priorities.ex
+++ b/lib/credo/service/source_file_scope_priorities.ex
@@ -1,0 +1,5 @@
+defmodule Credo.Service.SourceFileScopePriorities do
+  @moduledoc false
+
+  use Credo.Service.ETSTableHelper
+end


### PR DESCRIPTION
Currently, every call to `format_issue` recalculates the scope priorities. This significantly hurts performance when many issues are reported. 

This change adds another ETS table (following the present cache design) to lazily cache these prios. On a large project with almost 7000 issues, this brings the running time of `mix credo` from 26 seconds to 10 seconds. 

Obviously there's more room for improvement, but I think this gain is already significant, and the change is simple enough to be merged on its own. Time-permitting I'll investigate further, but I can't make any promises.