### PR TITLE
show sarif as format option

### DIFF
--- a/guides/commands/suggest_command.md
+++ b/guides/commands/suggest_command.md
@@ -17,26 +17,26 @@ $ mix credo suggest --checks-without-tag formatter --checks-without-tag controve
 
 ## Command Line Switches
 
-| Name, shorthand                                                                                    | Description                                                             |
-|----------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| [`--all`](#all), [`-a`](#all)                                                                      | Show all issues for each category                                       |
-| [`--all-priorities`](#all-priorities-aliased-as-strict), [`-A`](#all-priorities-aliased-as-strict) | Show all issues including low priority ones                             |
-| [`--checks`](#checks-aliased-as-only)                                                              | Only include checks that match the given comma-seperated patterns       |
-| [`--checks-with-tag`](#checks-with-tag)                                                            | Only include checks that match the given tag                            |
-| [`--checks-without-tag`](#checks-without-tag)                                                      | Ignore checks that match the given tag                                  |
-| [`--config-file`](#config-file)                                                                    | Use the given config file as Credo's config                             |
-| [`--config-name`](#config-name)                                                                    | Use the given config instead of "default"                               |
-| [`--enable-disabled-checks`](#enable-disabled-checks)                                              | Re-enable disabled checks that match the given comma-seperated patterns |
-| [`--files-included`](#files-included)                                                              | Only include these files                                                |
-| [`--files-excluded`](#files-excluded)                                                              | Exclude these files                                                     |
-| [`--format`](#format)                                                                              | Display the list in a specific format (json, flycheck, or oneline)      |
-| [`--ignore-checks`](#ignore-checks-aliased-as-ignore)                                              | Ignore checks that match the given comma-seperated patterns             |
-| [`--ignore`](#ignore)                                                                              | Alias for [`--ignore-checks`](#ignore-checks-aliased-as-ignore)         |
-| [`--min-priority`](#min-priority)                                                                  | Minimum priority to show issues                                         |
-| [`--mute-exit-status`](#mute-exit-status)                                                          | Exit with status zero even if there are issues                          |
-| [`--only`](#only)                                                                                  | Alias for [`--checks`](#checks-aliased-as-only)                         |
-| [`--strict`](#strict)                                                                              | Alias for [`--all-priorities`](#all-priorities-aliased-as-strict)       |
-| [`--verbose`](#verbose)                                                                            | Additionally print the check and the source code that raised the issue  |
+| Name, shorthand                                                                                    | Description                                                              |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`--all`](#all), [`-a`](#all)                                                                      | Show all issues for each category                                        |
+| [`--all-priorities`](#all-priorities-aliased-as-strict), [`-A`](#all-priorities-aliased-as-strict) | Show all issues including low priority ones                              |
+| [`--checks`](#checks-aliased-as-only)                                                              | Only include checks that match the given comma-seperated patterns        |
+| [`--checks-with-tag`](#checks-with-tag)                                                            | Only include checks that match the given tag                             |
+| [`--checks-without-tag`](#checks-without-tag)                                                      | Ignore checks that match the given tag                                   |
+| [`--config-file`](#config-file)                                                                    | Use the given config file as Credo's config                              |
+| [`--config-name`](#config-name)                                                                    | Use the given config instead of "default"                                |
+| [`--enable-disabled-checks`](#enable-disabled-checks)                                              | Re-enable disabled checks that match the given comma-seperated patterns  |
+| [`--files-included`](#files-included)                                                              | Only include these files                                                 |
+| [`--files-excluded`](#files-excluded)                                                              | Exclude these files                                                      |
+| [`--format`](#format)                                                                              | Display the list in a specific format (json, flycheck, sarif or oneline) |
+| [`--ignore-checks`](#ignore-checks-aliased-as-ignore)                                              | Ignore checks that match the given comma-seperated patterns              |
+| [`--ignore`](#ignore)                                                                              | Alias for [`--ignore-checks`](#ignore-checks-aliased-as-ignore)          |
+| [`--min-priority`](#min-priority)                                                                  | Minimum priority to show issues                                          |
+| [`--mute-exit-status`](#mute-exit-status)                                                          | Exit with status zero even if there are issues                           |
+| [`--only`](#only)                                                                                  | Alias for [`--checks`](#checks-aliased-as-only)                          |
+| [`--strict`](#strict)                                                                              | Alias for [`--all-priorities`](#all-priorities-aliased-as-strict)        |
+| [`--verbose`](#verbose)                                                                            | Additionally print the check and the source code that raised the issue   |
 
 ## Descriptions
 
@@ -151,7 +151,7 @@ $ mix credo --files-excluded "./test/**/*.exs"
 
 ### `--format`
 
-Display the list in a specific format (json, flycheck, or oneline)
+Display the list in a specific format (json, flycheck, sarif or oneline)
 
 ```bash
 $ mix credo --format json

--- a/guides/configuration/cli_switches.md
+++ b/guides/configuration/cli_switches.md
@@ -14,6 +14,7 @@ Use `--format` to format the output in one of the following formats:
 
 - `--format flycheck` for [Flycheck](http://www.flycheck.org/) output
 - `--format json` for [JSON](https://www.json.org/) output
+- `--format sarif` for [SARIF](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=sarif) output
 
 Additionally, you can deactivate the output's coloring by using `--no-color`.
 
@@ -139,7 +140,7 @@ Suggest options:
       --enable-disabled-checks  Re-enable disabled checks that match the given strings
       --files-included          Only include these files (accepts globs, can be used multiple times)
       --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-      --format                  Display the list in a specific format (json,flycheck,oneline)
+      --format                  Display the list in a specific format (json,flycheck,sarif,oneline)
   -i, --ignore-checks           Ignore checks that match the given strings
       --ignore                  Alias for --ignore-checks
       --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)

--- a/lib/credo/cli/command/diff/diff_output.ex
+++ b/lib/credo/cli/command/diff/diff_output.ex
@@ -41,7 +41,7 @@ defmodule Credo.CLI.Command.Diff.DiffOutput do
             --enable-disabled-checks  Re-enable disabled checks that match the given strings
             --files-included          Only include these files (accepts globs, can be used multiple times)
             --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-            --format                  Display the list in a specific format (json,flycheck,oneline)
+            --format                  Display the list in a specific format (json,flycheck,sarif,oneline)
             --from-dir                Diff from the given directory
             --from-git-ref            Diff from the given Git ref
             --from-git-merge-base     Diff from where the current HEAD branched off from the given merge base

--- a/lib/credo/cli/command/explain/explain_output.ex
+++ b/lib/credo/cli/command/explain/explain_output.ex
@@ -31,7 +31,7 @@ defmodule Credo.CLI.Command.Explain.ExplainOutput do
       """
 
       Explain options:
-            --format            Display the list in a specific format (json,flycheck,oneline)
+            --format            Display the list in a specific format (json,flycheck,sarif,oneline)
 
       General options:
             --[no-]color        Toggle colored output

--- a/lib/credo/cli/command/info/info_output.ex
+++ b/lib/credo/cli/command/info/info_output.ex
@@ -40,7 +40,7 @@ defmodule Credo.CLI.Command.Info.InfoOutput do
             --enable-disabled-checks  Re-enable disabled checks that match the given strings
             --files-included          Only include these files (accepts globs, can be used multiple times)
             --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-            --format                  Display the list in a specific format (json,flycheck,oneline)
+            --format                  Display the list in a specific format (json,flycheck,sarif,oneline)
         -i, --ignore-checks           Ignore checks that match the given strings
             --ignore                  Alias for --ignore-checks
             --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)

--- a/lib/credo/cli/command/list/list_output.ex
+++ b/lib/credo/cli/command/list/list_output.ex
@@ -42,7 +42,7 @@ defmodule Credo.CLI.Command.List.ListOutput do
             --enable-disabled-checks  Re-enable disabled checks that match the given strings
             --files-included          Only include these files (accepts globs, can be used multiple times)
             --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-            --format                  Display the list in a specific format (json,flycheck,oneline)
+            --format                  Display the list in a specific format (json,flycheck,sarif,oneline)
         -i, --ignore-checks           Ignore checks that match the given strings
             --ignore                  Alias for --ignore-checks
             --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)

--- a/lib/credo/cli/command/suggest/suggest_output.ex
+++ b/lib/credo/cli/command/suggest/suggest_output.ex
@@ -42,7 +42,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
             --enable-disabled-checks  Re-enable disabled checks that match the given strings
             --files-included          Only include these files (accepts globs, can be used multiple times)
             --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-            --format                  Display the list in a specific format (json,flycheck,oneline)
+            --format                  Display the list in a specific format (json,flycheck,sarif,oneline)
         -i, --ignore-checks           Ignore checks that match the given strings
             --ignore                  Alias for --ignore-checks
             --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)


### PR DESCRIPTION
When I recently set up code scanning for Github, I noticed that the SARIF format was not documented everywhere. This PR extends the documentation in this regard.