### PR TITLE
Be explicit about steps to avoid warnings

### DIFF
--- a/lib/credo/check/consistency/multi_alias_import_require_use/collector.ex
+++ b/lib/credo/check/consistency/multi_alias_import_require_use/collector.ex
@@ -24,7 +24,7 @@ defmodule Credo.Check.Consistency.MultiAliasImportRequireUse.Collector do
     aliases =
       case arguments do
         [{:__aliases__, _, nested_modules}] when length(nested_modules) > 1 ->
-          base_name = Enum.slice(nested_modules, 0..-2)
+          base_name = Enum.slice(nested_modules, 0..-2//1)
           {:single, base_name}
 
         [{{:., _, [{:__aliases__, _, _namespaces}, :{}]}, _, _nested_aliases}] ->

--- a/lib/credo/check/consistency/space_around_operators.ex
+++ b/lib/credo/check/consistency/space_around_operators.ex
@@ -144,7 +144,7 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators do
 
   defp number_in_range?(line, column) do
     line
-    |> String.slice(column..-1)
+    |> String.slice(column..-1//1)
     |> String.match?(~r/^\d+\.\./)
   end
 
@@ -171,13 +171,13 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators do
     # -1 because we need to subtract the operator
     binary_pattern_end_after? =
       line
-      |> String.slice(column..-1)
+      |> String.slice(column..-1//1)
       |> String.match?(~r/\>\>/)
 
     # -1 because we need to subtract the operator
     typed_after? =
       line
-      |> String.slice(column..-1)
+      |> String.slice(column..-1//1)
       |> String.match?(~r/^\s*(integer|native|signed|unsigned|binary|size|little|float)/)
 
     # -2 because we need to subtract the operator

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -182,12 +182,12 @@ defmodule Credo.Check.Readability.LargeNumbers do
       Enum.map(allowed_trailing_digits, fn trailing_digits ->
         if String.length(string) > trailing_digits do
           base =
-            String.slice(string, 0..(-1 * trailing_digits - 1))
+            String.slice(string, 0..(-1 * trailing_digits - 1)//1)
             |> String.reverse()
             |> String.replace(~r/(\d{3})(?=\d)/, "\\1_")
             |> String.reverse()
 
-          trailing = String.slice(string, (-1 * trailing_digits)..-1)
+          trailing = String.slice(string, (-1 * trailing_digits)..-1//1)
 
           "#{base}_#{trailing}"
         end
@@ -237,7 +237,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
 
     ending_of_number =
       ~r/^([0-9_\.]+)/
-      |> Regex.run(String.slice(line, (column1 + 1)..-1))
+      |> Regex.run(String.slice(line, (column1 + 1)..-1//1))
       |> List.wrap()
       |> List.last()
       |> to_string()

--- a/lib/credo/check/readability/parentheses_on_zero_arity_defs.ex
+++ b/lib/credo/check/readability/parentheses_on_zero_arity_defs.ex
@@ -90,7 +90,7 @@ defmodule Credo.Check.Readability.ParenthesesOnZeroArityDefs do
     name_size = text |> to_string |> String.length()
     skip = (SourceFile.column(source_file, line_no, text) || -1) + name_size - 1
 
-    String.slice(line, skip..-1)
+    String.slice(line, skip..-1//1)
   end
 
   defp issue_for(issue_meta, line_no, kind) do

--- a/lib/credo/check/warning/unused_function_return_helper.ex
+++ b/lib/credo/check/warning/unused_function_return_helper.ex
@@ -132,7 +132,7 @@ defmodule Credo.Check.Warning.UnusedFunctionReturnHelper do
          when is_list(arguments) do
       # IO.inspect(ast, label: "#{unquote(op)} (#{Macro.to_string(candidate)} #{acc})")
 
-      head_expression = Enum.slice(arguments, 0..-2)
+      head_expression = Enum.slice(arguments, 0..-2//1)
 
       if Credo.Code.contains_child?(head_expression, candidate) do
         {nil, :VERIFIED}

--- a/lib/credo/cli/command/diff/task/get_git_diff.ex
+++ b/lib/credo/cli/command/diff/task/get_git_diff.ex
@@ -104,7 +104,7 @@ defmodule Credo.CLI.Command.Diff.Task.GetGitDiff do
   defp run_credo_on_dir(exec, dirname, previous_git_ref, given_ref) do
     {previous_argv, _last_arg} =
       exec.argv
-      |> Enum.slice(1..-1)
+      |> Enum.slice(1..-1//1)
       |> Enum.reduce({[], nil}, fn
         _, {argv, "--working-dir"} -> {Enum.slice(argv, 1..-2), nil}
         _, {argv, "--from-git-merge-base"} -> {Enum.slice(argv, 1..-2), nil}

--- a/lib/credo/code/interpolation_helper.ex
+++ b/lib/credo/code/interpolation_helper.ex
@@ -58,7 +58,7 @@ defmodule Credo.Code.InterpolationHelper do
     line = String.to_charlist(line)
     part1 = Enum.slice(line, 0, col_start - 1)
     part2 = String.to_charlist(String.duplicate(char, length))
-    part3 = Enum.slice(line, (col_end - 1)..-1)
+    part3 = Enum.slice(line, (col_end - 1)..-1//1)
     List.to_string(part1 ++ part2 ++ part3)
   end
 

--- a/test/credo/check/readability/large_numbers_test.exs
+++ b/test/credo/check/readability/large_numbers_test.exs
@@ -136,7 +136,7 @@ defmodule Credo.Check.Readability.LargeNumbersTest do
 
   test "check old false positive is fixed /3" do
     """
-    check all integer <- integer(-10_000..-1) do
+    check all integer <- integer(-10_000..-1//1) do
       assert is_integer(integer)
     end
     """


### PR DESCRIPTION
Lots of warnings like this one on elixir 1.16.0-rc.0:

```
warning: negative steps are not supported in Enum.slice/2, pass 0..-2//1 instead
  (elixir 1.16.0-rc.0) lib/enum.ex:2994: Enum.slice/2
  (credo 1.7.0) lib/credo/check/consistency/multi_alias_import_require_use/collector.ex:27: Credo.Check.Consistency.MultiAliasImportRequireUse.Collector.traverse/2
  (elixir 1.16.0-rc.0) lib/macro.ex:637: anonymous fn/4 in Macro.do_traverse_args/4
  (stdlib 5.1.1) lists.erl:1706: :lists.mapfoldl_1/3
  (stdlib 5.1.1) lists.erl:1707: :lists.mapfoldl_1/3
```

Thanks for all the great work! :green-heart:

![IMG_20220901_174517](https://github.com/rrrene/credo/assets/606517/d586198c-6179-4bec-8454-72bbb3d3de88)
