### PR TITLE
Fixes unused function warning in MixEnv check

### DIFF
--- a/lib/credo/check/warning/mix_env.ex
+++ b/lib/credo/check/warning/mix_env.ex
@@ -53,7 +53,7 @@ defmodule Credo.Check.Warning.MixEnv do
 
   for op <- @def_ops do
     # catch variables named e.g. `defp`
-    defp traverse({unquote(op), _, nil} = ast, issues, _issue_meta, _parens?) do
+    defp traverse({unquote(op), _, nil} = ast, issues, _issue_meta) do
       {ast, issues}
     end
 

--- a/test/credo/check/warning/mix_env_test.exs
+++ b/test/credo/check/warning/mix_env_test.exs
@@ -124,4 +124,18 @@ defmodule Credo.Check.Warning.MixEnvTest do
     |> run_check(@described_check)
     |> assert_issue()
   end
+
+  test "it should report violations from variables named like def operations" do
+    """
+    defmodule CredoSampleModule do
+      def some_function do
+        def = Mix.env()
+        defp = &Mix.env/0
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issues()
+  end
 end


### PR DESCRIPTION
Hi! 🖖 

There is a warning getting logged when compiling `Credo.Check.Warning.MixEnv`:
```shell
❯ mix compile lib/credo/check/warning/mix_env.ex
Compiling 1 file (.ex)
    warning: function traverse/4 is unused
    │
 56 │     defp traverse({unquote(op), _, nil} = ast, issues, _issue_meta, _parens?) do
    │          ~
    │
    └─ lib/credo/check/warning/mix_env.ex:56:10: Credo.Check.Warning.MixEnv (module)
```

This pull request fixes it by removing the extra `parens?` argument from the `traverse` function and adds a little test to ensure nothing is broken.  