### PR TITLE
Upgrade CI (Test against OTP 26, 24.3 instead of 24, 1.16 rc)

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [23.3, 24.2, 25.3]
+        otp: [23.3, 24.3, 25.3]
         elixir: [1.11.4, 1.12.3, 1.13.4, 1.14.5, 1.15.7]
         exclude:
           - elixir: 1.11.4
@@ -27,7 +27,7 @@ jobs:
           - elixir: 1.15.7
             otp: 23.3
           - elixir: 1.15.7
-            otp: 24.2
+            otp: 24.3
         include:
           - elixir: 1.15.7
             otp: 26.1

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,11 +25,12 @@ jobs:
           - elixir: 1.14.5
             otp: 25.3
           - elixir: 1.15.7
-            otp: 26.1
-          - elixir: 1.15.7
             otp: 23.3
           - elixir: 1.15.7
             otp: 24.2
+        include:
+          - elixir: 1.15.7
+            otp: 26.1
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -31,6 +31,8 @@ jobs:
         include:
           - elixir: 1.15.7
             otp: 26.1
+          - elixir: 1.16.0-rc.0
+            otp: 26.1
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -29,6 +29,8 @@ jobs:
         include:
           - elixir: 1.15.7
             otp: 26.1
+          - elixir: 1.16.0-rc.0
+            otp: 26.1
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
         repo_branch: ["v1.13", "main"]
     steps:

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -23,11 +23,12 @@ jobs:
           - elixir: 1.14.5
             otp: 25.3
           - elixir: 1.15.7
-            otp: 26.1
-          - elixir: 1.15.7
             otp: 23.3
           - elixir: 1.15.7
             otp: 24.2
+        include:
+          - elixir: 1.15.7
+            otp: 26.1
         repo_url: ["https://github.com/elixir-lang/elixir.git"]
         repo_branch: ["v1.13", "main"]
     steps:

--- a/.github/workflows/compatibility-elixir.yml
+++ b/.github/workflows/compatibility-elixir.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [23.3, 24.2, 25.3]
+        otp: [23.3, 24.3, 25.3]
         elixir: [1.11.4, 1.12.3, 1.13.4, 1.14.5, 1.15.7]
         exclude:
           - elixir: 1.11.4
@@ -25,7 +25,7 @@ jobs:
           - elixir: 1.15.7
             otp: 23.3
           - elixir: 1.15.7
-            otp: 24.2
+            otp: 24.3
         include:
           - elixir: 1.15.7
             otp: 26.1

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -22,11 +22,12 @@ jobs:
           - elixir: 1.14.5
             otp: 25.3
           - elixir: 1.15.7
-            otp: 26.1
-          - elixir: 1.15.7
             otp: 23.3
           - elixir: 1.15.7
             otp: 24.2
+        include:
+          - elixir: 1.15.7
+            otp: 26.1
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
         repo_branch: ["v1.6", "main"]
     steps:

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [23.3, 24.2, 25.3]
+        otp: [23.3, 24.3, 25.3]
         elixir: [1.11.4, 1.12.3, 1.13.4, 1.14.5, 1.15.7]
         exclude:
           - elixir: 1.11.4
@@ -24,7 +24,7 @@ jobs:
           - elixir: 1.15.7
             otp: 23.3
           - elixir: 1.15.7
-            otp: 24.2
+            otp: 24.3
         include:
           - elixir: 1.15.7
             otp: 26.1
@@ -48,10 +48,10 @@ jobs:
     name: "[${{matrix.otp}}/${{matrix.elixir}}] new Phoenix app analysed by Credo [OTP/Elixir]"
     strategy:
       matrix:
-        otp: [21.3, 22.3, 23.3, 24.2]
+        otp: [21.3, 22.3, 23.3, 24.3]
         elixir: [1.10.4, 1.11.4, 1.12.3, 1.13.4, 1.14.5, 1.15.7]
         exclude:
-          - otp: 24.2
+          - otp: 24.3
             elixir: 1.10.4
           - otp: 21.3
             elixir: 1.12.3

--- a/.github/workflows/compatibility-phoenix.yml
+++ b/.github/workflows/compatibility-phoenix.yml
@@ -28,6 +28,8 @@ jobs:
         include:
           - elixir: 1.15.7
             otp: 26.1
+          - elixir: 1.16.0-rc.0
+            otp: 26.1
         repo_url: ["https://github.com/phoenixframework/phoenix.git"]
         repo_branch: ["v1.6", "main"]
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 26.0
-elixir 1.16.0-rc.0
+erlang 26.1.2
+elixir 1.16.0-rc.0-otp-26


### PR DESCRIPTION
Commits mostly stand by themselves and should include rational, I can spin off more PRs if wanted but they were _somehow_ related