### PR TITLE
fix: NegatedIsNil memory leak

### DIFF
--- a/lib/credo/check/refactor/negated_is_nil.ex
+++ b/lib/credo/check/refactor/negated_is_nil.ex
@@ -65,8 +65,8 @@ defmodule Credo.Check.Refactor.NegatedIsNil do
   end
 
   defp traverse({:when, meta, [fun, {_, _, [first_op | second_op]}]} = ast, issues, issue_meta) do
-    {_, first_op_issues} = traverse({:when, meta, [fun, first_op]}, issues, issue_meta)
-    {_, second_op_issues} = traverse({:when, meta, [fun, second_op]}, issues, issue_meta)
+    {_, first_op_issues} = traverse({:when, meta, [fun, first_op]}, [], issue_meta)
+    {_, second_op_issues} = traverse({:when, meta, [fun, second_op]}, [], issue_meta)
 
     {ast, first_op_issues ++ second_op_issues ++ issues}
   end

--- a/test/credo/check/refactor/negated_is_nil_test.exs
+++ b/test/credo/check/refactor/negated_is_nil_test.exs
@@ -108,4 +108,32 @@ defmodule Credo.Check.Refactor.NegatedIsNilTest do
     |> run_check(@described_check)
     |> refute_issues()
   end
+
+  test "it should report only one violation in a module with multiple functions when only one is problematic" do
+    """
+    defmodule CredoSampleModule do
+      def hello(a) when not is_nil(a), do: a
+      def foo1(x) when is_integer(x), do: x
+      def foo2(x) when is_integer(x), do: x
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report two violations in a module with multiple functions when two are problematic" do
+    """
+    defmodule CredoSampleModule do
+      def hello(a) when not is_nil(a), do: a
+      def foo1(x) when is_integer(x), do: x
+      def foo2(x) when is_integer(x), do: x
+      def hello2(a) when not is_nil(a), do: a
+      def foo3(x) when is_integer(x), do: x
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issues(fn issues -> assert length(issues) == 2 end)
+  end
 end


### PR DESCRIPTION
Fixes #1056.

Prior to this, this example test would raise 9 issues:

```elixir
test "regression test for issue list duplication" do
  """
  defmodule CredoSampleModule do
    def hello(a) when not is_nil(a), do: a
    def foo1(x) when is_integer(x), do: x
    def foo2(x) when is_integer(x), do: x
    def foo3(x) when is_integer(x), do: x
  end
  """
  |> to_source_file()
  |> run_check(@described_check)
  |> assert_issue()
end
```