### PR TITLE
fix: MultiAliasImportRequireUse collection and false positive

### DIFF
--- a/test/credo/check/consistency/multi_alias_import_require_use_test.exs
+++ b/test/credo/check/consistency/multi_alias_import_require_use_test.exs
@@ -24,6 +24,32 @@ defmodule Credo.Check.Consistency.MultiAliasImportRequireUseTest do
     require Foo.Quux
   end
   """
+  @multi_module_same_file """
+  defmodule CredoMultiAliasExample.SetMultiAliasToSingles do
+    @moduledoc "This modules does many aliases to set the consistency to multi-alias"
+
+    alias Credo.CLI.{Command, Output}
+    alias Config.{Reader, Provider}
+  end
+
+  defmodule CredoMultiAliasExample.Foo do
+    @moduledoc "This module has a function"
+
+    def test, do: :ok
+  end
+
+  defmodule CredoMultiAliasExample.Bar do
+    @moduledoc "This module aliases another module"
+
+    alias CredoMultiAliasExample.Foo
+  end
+
+  defmodule CredoMultiAliasExample.Baz do
+    @moduledoc "This module aliases a different module under the same parent"
+
+    alias CredoMultiAliasExample.Bar
+  end
+  """
 
   #
   # cases NOT raising issues
@@ -31,6 +57,13 @@ defmodule Credo.Check.Consistency.MultiAliasImportRequireUseTest do
 
   test "it should NOT report errors when the multi syntax is used consistently" do
     [@multi]
+    |> to_source_files
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report errors when there are multiple modules in the same file when the multi syntax is used consistently" do
+    [@multi_module_same_file]
     |> to_source_files
     |> run_check(@described_check)
     |> refute_issues()
@@ -50,6 +83,13 @@ defmodule Credo.Check.Consistency.MultiAliasImportRequireUseTest do
     |> refute_issues()
   end
 
+  test "it should not report errors when the single syntax is used consistently" do
+    [@single]
+    |> to_source_files
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
   #
   # cases raising issues
   #
@@ -61,10 +101,10 @@ defmodule Credo.Check.Consistency.MultiAliasImportRequireUseTest do
     |> assert_issue()
   end
 
-  test "it should not report errors when the single syntax is used consistently" do
-    [@single]
+  test "it should report errors when the multi and single syntaxes are mixed (two files, one multi-module)" do
+    [@single, @multi_module_same_file]
     |> to_source_files
     |> run_check(@described_check)
-    |> refute_issues()
+    |> assert_issue()
   end
 end


### PR DESCRIPTION
Fixes #1023 

When you have files that contain multiple modules this rule will raise a false positive and force a user to disable the rule for the file. These changes solve that, but they _do not_ solve the issue where you have mixed usage in just a single file. We could do that, but the scope was increase quite a bit and most likely isn't super important.