### PR TITLE
fix: negated_is_nil when nested in guards

### DIFF
--- a/lib/credo/check/refactor/negated_is_nil.ex
+++ b/lib/credo/check/refactor/negated_is_nil.ex
@@ -68,7 +68,7 @@ defmodule Credo.Check.Refactor.NegatedIsNil do
     {_, first_op_issues} = traverse({:when, meta, [fun, first_op]}, [], issue_meta)
     {_, second_op_issues} = traverse({:when, meta, [fun, second_op]}, [], issue_meta)
 
-    {ast, first_op_issues ++ second_op_issues ++ issues}
+    {ast, (first_op_issues ++ (second_op_issues -- issues))}
   end
 
   defp traverse(ast, issues, _), do: {ast, issues}

--- a/test/credo/check/refactor/negated_is_nil_test.exs
+++ b/test/credo/check/refactor/negated_is_nil_test.exs
@@ -57,6 +57,37 @@ defmodule Credo.Check.Refactor.NegatedIsNilTest do
     |> assert_issue()
   end
 
+  test "it should report multiple violations with guards - `when not is_nil and guard not is nil`" do
+    """
+    defmodule CredoSampleModule do
+      defguard my_guard(value) when not is_nil(value)
+
+      def some_function(parameter1, parameter2, parameter3) when not is_nil(parameter1) and my_guard(parameter2) and my_guard(parameter3) do
+        something
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issues(fn issues ->
+      assert Enum.count(issues) == 2
+    end)
+  end
+
+  test "it should report one violation - `when not is_nil and not is nil`" do
+    # This is due to the way the check works, and is probably fine since it will fail if the first one is removed
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2, parameter3) when not is_nil(parameter2) and not is_nil(parameter3) and is_nil(parameter3) do
+        something
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
   test "it should report a violation - `when not is_nil is part of a multi clause guard`" do
     """
     defmodule CredoSampleModule do


### PR DESCRIPTION
If a custom guard uses `not is_nil(foo)`, the number of issues reported by `Credo.Check.Refactor.NegatedIsNil` increases significantly.

For instance, this would report three violations.

```elixir
defguard custom_guard(value) when not is_nil(value)

def bar(foo, baz) when not is_nil(foo) and custom_guard(baz) do
end
```

This change ensures only a maximum of one issue per part of the guard will be reported. See the added tests for examples.