### PR TITLE
fix: neg steps of {Enum,String}.slice/2 are deprecated in Elixir 1.16

### DIFF
--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -237,7 +237,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
 
     ending_of_number =
       ~r/^([0-9_\.]+)/
-      |> Regex.run(Credo.Backports.String.slice(line, (column1 + 1)..-1))
+      |> Regex.run(Credo.Backports.String.slice(line, (column1 + 1)..-1//1))
       |> List.wrap()
       |> List.last()
       |> to_string()

--- a/lib/credo/check/readability/parentheses_on_zero_arity_defs.ex
+++ b/lib/credo/check/readability/parentheses_on_zero_arity_defs.ex
@@ -90,7 +90,7 @@ defmodule Credo.Check.Readability.ParenthesesOnZeroArityDefs do
     name_size = text |> to_string |> String.length()
     skip = (SourceFile.column(source_file, line_no, text) || -1) + name_size - 1
 
-    Credo.Backports.String.slice(line, skip..-1)
+    Credo.Backports.String.slice(line, skip..-1//1)
   end
 
   defp issue_for(issue_meta, line_no, kind) do

--- a/lib/credo/check/warning/unused_function_return_helper.ex
+++ b/lib/credo/check/warning/unused_function_return_helper.ex
@@ -132,7 +132,7 @@ defmodule Credo.Check.Warning.UnusedFunctionReturnHelper do
          when is_list(arguments) do
       # IO.inspect(ast, label: "#{unquote(op)} (#{Macro.to_string(candidate)} #{acc})")
 
-      head_expression = Credo.Backports.Enum.slice(arguments, 0..-2)
+      head_expression = Credo.Backports.Enum.slice(arguments, 0..-2//1)
 
       if Credo.Code.contains_child?(head_expression, candidate) do
         {nil, :VERIFIED}

--- a/lib/credo/code/interpolation_helper.ex
+++ b/lib/credo/code/interpolation_helper.ex
@@ -58,7 +58,7 @@ defmodule Credo.Code.InterpolationHelper do
     line = String.to_charlist(line)
     part1 = Enum.slice(line, 0, col_start - 1)
     part2 = String.to_charlist(String.duplicate(char, length))
-    part3 = Credo.Backports.Enum.slice(line, (col_end - 1)..-1)
+    part3 = Credo.Backports.Enum.slice(line, (col_end - 1)..-1//1)
     List.to_string(part1 ++ part2 ++ part3)
   end
 


### PR DESCRIPTION
As mentioned in Elixir 1.16's [changelog](https://hexdocs.pm/elixir/1.16.0/changelog.html):
> [Enum] Deprecate passing a range with negative step on [Enum.slice/2](https://hexdocs.pm/elixir/1.16.0/Enum.html#slice/2), give first..last//1 instead
> [String] Deprecate passing a range with negative step on [String.slice/2](https://hexdocs.pm/elixir/1.16.0/String.html#slice/2), give first..last//1 instead