### PR TITLE
Removing map.field notation and x..-y warnings

### DIFF
--- a/lib/credo/backports.ex
+++ b/lib/credo/backports.ex
@@ -1,7 +1,7 @@
 defmodule Credo.Backports do
   defmodule Enum do
     if Version.match?(System.version(), ">= 1.12.0-rc") do
-      def slice(a, x..y) do
+      def slice(a, x..y//_) do
         Elixir.Enum.slice(a, x..y//1)
       end
     end
@@ -13,7 +13,7 @@ defmodule Credo.Backports do
 
   defmodule String do
     if Version.match?(System.version(), ">= 1.12.0-rc") do
-      def slice(a, x..y) do
+      def slice(a, x..y//_) do
         Elixir.String.slice(a, x..y//1)
       end
     end

--- a/lib/credo/check/config_comment.ex
+++ b/lib/credo/check/config_comment.ex
@@ -135,7 +135,7 @@ defmodule Credo.Check.ConfigComment do
   defp value_for(param_string) do
     if regex_value?(param_string) do
       param_string
-      |> Credo.Backports.String.slice(1..-2//-1)
+      |> Credo.Backports.String.slice(Range.new(1, -2, -1))
       |> Regex.compile!("i")
     else
       String.to_atom("Elixir.#{param_string}")

--- a/lib/credo/check/config_comment.ex
+++ b/lib/credo/check/config_comment.ex
@@ -135,7 +135,7 @@ defmodule Credo.Check.ConfigComment do
   defp value_for(param_string) do
     if regex_value?(param_string) do
       param_string
-      |> Credo.Backports.String.slice(1..-2)
+      |> Credo.Backports.String.slice(1..-2//-1)
       |> Regex.compile!("i")
     else
       String.to_atom("Elixir.#{param_string}")

--- a/lib/credo/check/consistency/multi_alias_import_require_use/collector.ex
+++ b/lib/credo/check/consistency/multi_alias_import_require_use/collector.ex
@@ -38,7 +38,7 @@ defmodule Credo.Check.Consistency.MultiAliasImportRequireUse.Collector do
     aliases =
       case arguments do
         [{:__aliases__, _, nested_modules}] when length(nested_modules) > 1 ->
-          base_name = Credo.Backports.Enum.slice(nested_modules, 0..-2)
+          base_name = Credo.Backports.Enum.slice(nested_modules, 0..-2//-1)
           {:single, base_name}
 
         [{{:., _, [{:__aliases__, _, _namespaces}, :{}]}, _, _nested_aliases}] ->

--- a/lib/credo/check/consistency/multi_alias_import_require_use/collector.ex
+++ b/lib/credo/check/consistency/multi_alias_import_require_use/collector.ex
@@ -38,7 +38,7 @@ defmodule Credo.Check.Consistency.MultiAliasImportRequireUse.Collector do
     aliases =
       case arguments do
         [{:__aliases__, _, nested_modules}] when length(nested_modules) > 1 ->
-          base_name = Credo.Backports.Enum.slice(nested_modules, 0..-2//-1)
+          base_name = Credo.Backports.Enum.slice(nested_modules, Range.new(0, -2, -1))
           {:single, base_name}
 
         [{{:., _, [{:__aliases__, _, _namespaces}, :{}]}, _, _nested_aliases}] ->

--- a/lib/credo/check/params.ex
+++ b/lib/credo/check/params.ex
@@ -71,12 +71,12 @@ defmodule Credo.Check.Params do
 
   @doc false
   def category(params, check_mod) do
-    params[:__category__] || params[:category] || check_mod.category
+    params[:__category__] || params[:category] || check_mod.category()
   end
 
   @doc false
   def exit_status(params, check_mod) do
-    params[:__exit_status__] || params[:exit_status] || check_mod.exit_status
+    params[:__exit_status__] || params[:exit_status] || check_mod.exit_status()
   end
 
   @doc false
@@ -95,7 +95,7 @@ defmodule Credo.Check.Params do
 
   @doc false
   def priority(params, check_mod) do
-    params[:__priority__] || params[:priority] || check_mod.base_priority
+    params[:__priority__] || params[:priority] || check_mod.base_priority()
   end
 
   @doc false

--- a/lib/credo/check/readability/large_numbers.ex
+++ b/lib/credo/check/readability/large_numbers.ex
@@ -181,7 +181,7 @@ defmodule Credo.Check.Readability.LargeNumbers do
       Enum.map(allowed_trailing_digits, fn trailing_digits ->
         if String.length(string) > trailing_digits do
           base =
-            Credo.Backports.String.slice(string, 0..(-1 * trailing_digits - 1))
+            Credo.Backports.String.slice(string, Range.new(0, -1 * trailing_digits - 1, -1))
             |> String.reverse()
             |> String.replace(~r/(\d{3})(?=\d)/, "\\1_")
             |> String.reverse()

--- a/lib/credo/check/warning/unused_function_return_helper.ex
+++ b/lib/credo/check/warning/unused_function_return_helper.ex
@@ -132,7 +132,7 @@ defmodule Credo.Check.Warning.UnusedFunctionReturnHelper do
          when is_list(arguments) do
       # IO.inspect(ast, label: "#{unquote(op)} (#{Macro.to_string(candidate)} #{acc})")
 
-      head_expression = Credo.Backports.Enum.slice(arguments, 0..-2//-1)
+      head_expression = Credo.Backports.Enum.slice(arguments, Range.new(0, -2, -1))
 
       if Credo.Code.contains_child?(head_expression, candidate) do
         {nil, :VERIFIED}

--- a/lib/credo/check/warning/unused_function_return_helper.ex
+++ b/lib/credo/check/warning/unused_function_return_helper.ex
@@ -132,7 +132,7 @@ defmodule Credo.Check.Warning.UnusedFunctionReturnHelper do
          when is_list(arguments) do
       # IO.inspect(ast, label: "#{unquote(op)} (#{Macro.to_string(candidate)} #{acc})")
 
-      head_expression = Credo.Backports.Enum.slice(arguments, 0..-2)
+      head_expression = Credo.Backports.Enum.slice(arguments, 0..-2//-1)
 
       if Credo.Code.contains_child?(head_expression, candidate) do
         {nil, :VERIFIED}

--- a/lib/credo/cli/command/diff/task/get_git_diff.ex
+++ b/lib/credo/cli/command/diff/task/get_git_diff.ex
@@ -104,17 +104,31 @@ defmodule Credo.CLI.Command.Diff.Task.GetGitDiff do
   defp run_credo_on_dir(exec, dirname, previous_git_ref, given_ref) do
     {previous_argv, _last_arg} =
       exec.argv
-      |> Credo.Backports.Enum.slice(1..-1//-1)
+      |> Credo.Backports.Enum.slice(Range.new(1, -1, -1))
       |> Enum.reduce({[], nil}, fn
-        _, {argv, "--working-dir"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
-        _, {argv, "--from-git-merge-base"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
-        _, {argv, "--from-git-ref"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
-        _, {argv, "--from-dir"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
-        _, {argv, "--since"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
-        "--show-fixed", {argv, _last_arg} -> {argv, nil}
-        "--show-kept", {argv, _last_arg} -> {argv, nil}
-        ^previous_git_ref, {argv, _last_arg} -> {argv, nil}
-        arg, {argv, _last_arg} -> {argv ++ [arg], arg}
+        _, {argv, "--working-dir"} ->
+          {Credo.Backports.Enum.slice(argv, Range.new(1, -2, -1)), nil}
+
+        _, {argv, "--from-git-merge-base"} ->
+          {Credo.Backports.Enum.slice(argv, Range.new(1, -2, -1)), nil}
+
+        _, {argv, "--from-git-ref"} ->
+          {Credo.Backports.Enum.slice(argv, Range.new(1, -2, -1)), nil}
+
+        _, {argv, "--from-dir"} ->
+          {Credo.Backports.Enum.slice(argv, Range.new(1, -2, -1)), nil}
+
+        _, {argv, "--since"} ->
+          {Credo.Backports.Enum.slice(argv, Range.new(1, -2, -1)), nil}
+
+        "--show-kept", {argv, _last_arg} ->
+          {argv, nil}
+
+        ^previous_git_ref, {argv, _last_arg} ->
+          {argv, nil}
+
+        arg, {argv, _last_arg} ->
+          {argv ++ [arg], arg}
       end)
 
     run_credo(exec, previous_git_ref, dirname, previous_argv, given_ref)

--- a/lib/credo/cli/command/diff/task/get_git_diff.ex
+++ b/lib/credo/cli/command/diff/task/get_git_diff.ex
@@ -104,7 +104,7 @@ defmodule Credo.CLI.Command.Diff.Task.GetGitDiff do
   defp run_credo_on_dir(exec, dirname, previous_git_ref, given_ref) do
     {previous_argv, _last_arg} =
       exec.argv
-      |> Credo.Backports.Enum.slice(1..-1)
+      |> Credo.Backports.Enum.slice(1..-1//-1)
       |> Enum.reduce({[], nil}, fn
         _, {argv, "--working-dir"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}
         _, {argv, "--from-git-merge-base"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}

--- a/lib/credo/cli/command/diff/task/get_git_diff.ex
+++ b/lib/credo/cli/command/diff/task/get_git_diff.ex
@@ -106,11 +106,11 @@ defmodule Credo.CLI.Command.Diff.Task.GetGitDiff do
       exec.argv
       |> Credo.Backports.Enum.slice(1..-1//-1)
       |> Enum.reduce({[], nil}, fn
-        _, {argv, "--working-dir"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}
-        _, {argv, "--from-git-merge-base"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}
-        _, {argv, "--from-git-ref"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}
-        _, {argv, "--from-dir"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}
-        _, {argv, "--since"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}
+        _, {argv, "--working-dir"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
+        _, {argv, "--from-git-merge-base"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
+        _, {argv, "--from-git-ref"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
+        _, {argv, "--from-dir"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
+        _, {argv, "--since"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
         "--show-fixed", {argv, _last_arg} -> {argv, nil}
         "--show-kept", {argv, _last_arg} -> {argv, nil}
         ^previous_git_ref, {argv, _last_arg} -> {argv, nil}

--- a/lib/credo/cli/command/explain/output/default.ex
+++ b/lib/credo/cli/command/explain/output/default.ex
@@ -269,7 +269,7 @@ defmodule Credo.CLI.Command.Explain.Output.Default do
     |> String.trim()
     |> String.split("\n")
     |> Enum.flat_map(&format_explanation(&1, outer_color))
-    |> Credo.Backports.Enum.slice(0..-2//-1)
+    |> Credo.Backports.Enum.slice(Range.new(0, -2, -1))
     |> UI.puts()
 
     UI.puts_edge([outer_color, :faint])

--- a/lib/credo/cli/command/explain/output/default.ex
+++ b/lib/credo/cli/command/explain/output/default.ex
@@ -269,7 +269,7 @@ defmodule Credo.CLI.Command.Explain.Output.Default do
     |> String.trim()
     |> String.split("\n")
     |> Enum.flat_map(&format_explanation(&1, outer_color))
-    |> Credo.Backports.Enum.slice(0..-2)
+    |> Credo.Backports.Enum.slice(0..-2//-1)
     |> UI.puts()
 
     UI.puts_edge([outer_color, :faint])

--- a/lib/credo/cli/command/suggest/output/default.ex
+++ b/lib/credo/cli/command/suggest/output/default.ex
@@ -240,7 +240,7 @@ defmodule Credo.CLI.Command.Suggest.Output.Default do
       UI.edge(outer_color),
       outer_color,
       tag_style,
-      Output.check_tag(check.category),
+      Output.check_tag(check.category()),
       " ",
       priority |> Output.priority_arrow(),
       :normal,

--- a/lib/credo/cli/output/formatter/sarif.ex
+++ b/lib/credo/cli/output/formatter/sarif.ex
@@ -17,21 +17,21 @@ defmodule Credo.CLI.Output.Formatter.SARIF do
 
     final_rules =
       issues
-      |> Enum.uniq_by(& &1.check.id)
+      |> Enum.uniq_by(& &1.check.id())
       |> Enum.map(fn issue ->
         %{
-          "id" => issue.check.id,
+          "id" => issue.check.id(),
           "name" => Credo.Code.Name.full(issue.check),
           "fullDescription" => %{
-            "text" => issue.check.explanation |> String.replace("`", "'"),
-            "markdown" => issue.check.explanation
+            "text" => issue.check.explanation() |> String.replace("`", "'"),
+            "markdown" => issue.check.explanation()
           },
           "properties" => %{
             "tags" => [
               issue.category
             ]
           },
-          "helpUri" => issue.check.docs_uri
+          "helpUri" => issue.check.docs_uri()
         }
       end)
 
@@ -151,21 +151,21 @@ defmodule Credo.CLI.Output.Formatter.SARIF do
 
     rule_and_issue = {
       %{
-        "id" => issue.check.id,
+        "id" => issue.check.id(),
         "name" => Credo.Code.Name.full(issue.check),
         "fullDescription" => %{
-          "text" => issue.check.explanation |> String.replace("`", "'"),
-          "markdown" => issue.check.explanation
+          "text" => issue.check.explanation() |> String.replace("`", "'"),
+          "markdown" => issue.check.explanation()
         },
         "properties" => %{
           "tags" => [
             issue.category
           ]
         },
-        "helpUri" => issue.check.docs_uri
+        "helpUri" => issue.check.docs_uri()
       },
       %{
-        "ruleId" => issue.check.id,
+        "ruleId" => issue.check.id(),
         "level" => sarif_level,
         "rank" => priority_to_sarif_rank(issue.priority),
         "message" => %{
@@ -201,7 +201,7 @@ defmodule Credo.CLI.Output.Formatter.SARIF do
     rule_and_issue
     |> remove_nil_endcolumn(!column_end)
     |> remove_warning_level(sarif_level == :warning)
-    |> remove_redundant_name(issue.check.id == Credo.Code.Name.full(issue.check))
+    |> remove_redundant_name(issue.check.id() == Credo.Code.Name.full(issue.check))
   end
 
   defp remove_nil_endcolumn(sarif, false), do: sarif

--- a/lib/credo/cli/task/prepare_checks_to_run.ex
+++ b/lib/credo/cli/task/prepare_checks_to_run.ex
@@ -83,7 +83,7 @@ defmodule Credo.CLI.Task.PrepareChecksToRun do
   end
 
   defp matches_requirement?({check}, elixir_version) do
-    Version.match?(elixir_version, check.elixir_version)
+    Version.match?(elixir_version, check.elixir_version())
   end
 
   defp to_match_regexes(nil), do: []

--- a/lib/credo/cli/task/set_relevant_issues.ex
+++ b/lib/credo/cli/task/set_relevant_issues.ex
@@ -12,7 +12,7 @@ defmodule Credo.CLI.Task.SetRelevantIssues do
       |> Filter.important(exec)
       |> Filter.valid_issues(exec)
       |> Enum.sort_by(fn issue ->
-        {issue.check.id, issue.filename, issue.line_no}
+        {issue.check.id(), issue.filename, issue.line_no}
       end)
 
     put_issues(exec, issues)

--- a/lib/credo/execution/task/initialize_command.ex
+++ b/lib/credo/execution/task/initialize_command.ex
@@ -22,7 +22,7 @@ defmodule Credo.Execution.Task.InitializeCommand do
   end
 
   defp cli_options_switches(command_mod) do
-    command_mod.cli_switches
+    command_mod.cli_switches()
     |> List.wrap()
     |> Enum.map(fn
       %{name: name, type: type} when is_binary(name) -> {String.to_atom(name), type}
@@ -31,7 +31,7 @@ defmodule Credo.Execution.Task.InitializeCommand do
   end
 
   defp cli_options_aliases(command_mod) do
-    command_mod.cli_switches
+    command_mod.cli_switches()
     |> List.wrap()
     |> Enum.map(fn
       %{name: name, alias: alias} when is_binary(name) -> {alias, String.to_atom(name)}

--- a/lib/credo/execution/task/parse_options.ex
+++ b/lib/credo/execution/task/parse_options.ex
@@ -30,7 +30,7 @@ defmodule Credo.Execution.Task.ParseOptions do
         command_name = Execution.get_command_name(exec)
         command_mod = Execution.get_command(exec, command_name)
 
-        command_mod.treat_unknown_args_as_files?
+        command_mod.treat_unknown_args_as_files?()
       else
         false
       end

--- a/lib/credo/execution/task/validate_config.ex
+++ b/lib/credo/execution/task/validate_config.ex
@@ -67,7 +67,7 @@ defmodule Credo.Execution.Task.ValidateConfig do
   end
 
   defp do_warn_if_check_params_invalid({check, params}) do
-    valid_param_names = check.param_names ++ Params.builtin_param_names()
+    valid_param_names = check.param_names() ++ Params.builtin_param_names()
     check = check |> to_string |> String.to_existing_atom()
 
     Enum.each(params, fn {param_name, _param_value} ->


### PR DESCRIPTION
There are two warnings showing up that I worked on removing:

warning: using map.field notation (without parentheses) to invoke function Credo.Check.Refactor.MatchInCondition.param_defaults() is deprecated, you must add parentheses instead: remote.function()



There's still one warning at:   (credo 1.7.2) lib/credo/check/params.ex:39: Credo.Check.Params.get/3 but I think it is a mistake.

I also went through and added an explicit step value to descending ranges