### PR TITLE
refactoring opp: [F] ↗  is more efficient than

### DIFF
--- a/lib/credo/check/consistency/space_around_operators.ex
+++ b/lib/credo/check/consistency/space_around_operators.ex
@@ -194,8 +194,7 @@ defmodule Credo.Check.Consistency.SpaceAroundOperators do
         typed_after?,
         typed_before?
       ]
-      |> Enum.filter(& &1)
-      |> Enum.count()
+      |> Enum.count(& &1)
 
     heuristics_met_count >= 2
   end

--- a/lib/credo/cli/command/diff/diff_summary.ex
+++ b/lib/credo/cli/command/diff/diff_summary.ex
@@ -133,8 +133,7 @@ defmodule Credo.CLI.Command.Diff.DiffSummary do
 
   defp category_count(issues, category) do
     issues
-    |> Enum.filter(&(&1.category == category))
-    |> Enum.count()
+    |> Enum.count(&(&1.category == category))
   end
 
   defp summary_parts_new(_source_files, issues) do

--- a/lib/credo/cli/output/first_run_hint.ex
+++ b/lib/credo/cli/output/first_run_hint.ex
@@ -24,8 +24,7 @@ defmodule Credo.CLI.Output.FirstRunHint do
 
     readability_issue_count =
       issues
-      |> Enum.filter(&(&1.category == :readability))
-      |> Enum.count()
+      |> Enum.count(&(&1.category == :readability))
 
     relative_issue_count_per_category = div(issue_count, @category_count)
 

--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -120,8 +120,7 @@ defmodule Credo.CLI.Output.Summary do
 
   defp category_count(issues, category) do
     issues
-    |> Enum.filter(&(&1.category == category))
-    |> Enum.count()
+    |> Enum.count(&(&1.category == category))
   end
 
   defp summary_parts(source_files, issues) do

--- a/test/credo/config_file_test.exs
+++ b/test/credo/config_file_test.exs
@@ -457,8 +457,7 @@ defmodule Credo.ConfigFileTest do
 
     config_subdir_count =
       dirs
-      |> Enum.filter(&String.ends_with?(&1, "config"))
-      |> Enum.count()
+      |> Enum.count(&String.ends_with?(&1, "config"))
 
     assert config_subdir_count > 1
   end


### PR DESCRIPTION
Changed Enum.filter/2 |> Enum.count/1 to Enum.count/2 as recommended by credo.