### PR TITLE
Improve usage of Tasks

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -402,7 +402,8 @@ defmodule Credo.Check do
         source_files
         |> Task.async_stream(fn source -> run_on_source_file(exec, source, params) end,
           max_concurrency: exec.max_concurrent_check_runs,
-          timeout: :infinity
+          timeout: :infinity,
+          ordered: false
         )
         |> Stream.run()
 

--- a/lib/credo/check/consistency/collector.ex
+++ b/lib/credo/check/consistency/collector.ex
@@ -155,7 +155,10 @@ defmodule Credo.Check.Consistency.Collector do
       ) do
     frequencies_per_source_file =
       source_files
-      |> Task.async_stream(&{&1, collector.collect_matches(&1, params)}, timeout: :infinity, ordered: false)
+      |> Task.async_stream(&{&1, collector.collect_matches(&1, params)},
+        timeout: :infinity,
+        ordered: false
+      )
       |> Enum.map(fn {:ok, frequencies} -> frequencies end)
 
     frequencies = total_frequencies(frequencies_per_source_file)
@@ -167,7 +170,10 @@ defmodule Credo.Check.Consistency.Collector do
       result =
         frequencies_per_source_file
         |> source_files_with_issues(most_frequent_match)
-        |> Task.async_stream(&issue_formatter.(most_frequent_match, &1, params), timeout: :infinity, ordered: false)
+        |> Task.async_stream(&issue_formatter.(most_frequent_match, &1, params),
+          timeout: :infinity,
+          ordered: false
+        )
         |> Enum.flat_map(fn {:ok, issue} -> issue end)
 
       result

--- a/lib/credo/check/consistency/collector.ex
+++ b/lib/credo/check/consistency/collector.ex
@@ -155,7 +155,7 @@ defmodule Credo.Check.Consistency.Collector do
       ) do
     frequencies_per_source_file =
       source_files
-      |> Task.async_stream(&{&1, collector.collect_matches(&1, params)}, timeout: :infinity)
+      |> Task.async_stream(&{&1, collector.collect_matches(&1, params)}, timeout: :infinity, ordered: false)
       |> Enum.map(fn {:ok, frequencies} -> frequencies end)
 
     frequencies = total_frequencies(frequencies_per_source_file)
@@ -167,7 +167,7 @@ defmodule Credo.Check.Consistency.Collector do
       result =
         frequencies_per_source_file
         |> source_files_with_issues(most_frequent_match)
-        |> Task.async_stream(&issue_formatter.(most_frequent_match, &1, params), timeout: :infinity)
+        |> Task.async_stream(&issue_formatter.(most_frequent_match, &1, params), timeout: :infinity, ordered: false)
         |> Enum.flat_map(fn {:ok, issue} -> issue end)
 
       result

--- a/lib/credo/check/design/duplicated_code.ex
+++ b/lib/credo/check/design/duplicated_code.ex
@@ -88,14 +88,11 @@ defmodule Credo.Check.Design.DuplicatedCode do
   end
 
   defp duplicate_nodes(source_files, mass_threshold) do
-    chunked_nodes =
+    nodes =
       source_files
       |> Enum.chunk_every(30)
       |> Task.async_stream(&calculate_hashes_for_chunk(&1, mass_threshold), timeout: :infinity, ordered: false)
-      |> Enum.map(fn {:ok, hashes} -> hashes end)
-
-    nodes =
-      Enum.reduce(chunked_nodes, %{}, fn current_hashes, existing_hashes ->
+      |> Enum.reduce(%{}, fn {:ok, current_hashes}, existing_hashes ->
         Map.merge(existing_hashes, current_hashes, fn _hash, node_items1, node_items2 ->
           node_items1 ++ node_items2
         end)
@@ -197,10 +194,7 @@ defmodule Credo.Check.Design.DuplicatedCode do
     else
       hash = ast |> Credo.Code.remove_metadata() |> to_hash
       node_item = %{node: ast, filename: filename, mass: nil}
-      node_items = Map.get(existing_hashes, hash, [])
-
-      updated_hashes = Map.put(existing_hashes, hash, node_items ++ [node_item])
-
+      updated_hashes = Map.update(existing_hashes, hash, [node_item], &[node_item | &1])
       {ast, updated_hashes}
     end
   end

--- a/lib/credo/check/design/duplicated_code.ex
+++ b/lib/credo/check/design/duplicated_code.ex
@@ -91,7 +91,10 @@ defmodule Credo.Check.Design.DuplicatedCode do
     nodes =
       source_files
       |> Enum.chunk_every(30)
-      |> Task.async_stream(&calculate_hashes_for_chunk(&1, mass_threshold), timeout: :infinity, ordered: false)
+      |> Task.async_stream(&calculate_hashes_for_chunk(&1, mass_threshold),
+        timeout: :infinity,
+        ordered: false
+      )
       |> Enum.reduce(%{}, fn {:ok, current_hashes}, existing_hashes ->
         Map.merge(existing_hashes, current_hashes, fn _hash, node_items1, node_items2 ->
           node_items1 ++ node_items2

--- a/lib/credo/check/design/duplicated_code.ex
+++ b/lib/credo/check/design/duplicated_code.ex
@@ -56,9 +56,10 @@ defmodule Credo.Check.Design.DuplicatedCode do
     found_hashes
     |> Task.async_stream(
       &do_append_issues_via_issue_service(&1, source_files, nodes_threshold, params, exec),
-      timeout: :infinity
+      timeout: :infinity,
+      ordered: false
     )
-    |> Enum.map(fn {:ok, result} -> result end)
+    |> Stream.run()
   end
 
   defp do_append_issues_via_issue_service(
@@ -90,7 +91,7 @@ defmodule Credo.Check.Design.DuplicatedCode do
     chunked_nodes =
       source_files
       |> Enum.chunk_every(30)
-      |> Task.async_stream(&calculate_hashes_for_chunk(&1, mass_threshold), timeout: :infinity)
+      |> Task.async_stream(&calculate_hashes_for_chunk(&1, mass_threshold), timeout: :infinity, ordered: false)
       |> Enum.map(fn {:ok, hashes} -> hashes end)
 
     nodes =

--- a/lib/credo/check/runner.ex
+++ b/lib/credo/check/runner.ex
@@ -20,12 +20,7 @@ defmodule Credo.Check.Runner do
       |> fix_deprecated_notation_for_checks_without_params()
 
     check_tuples
-    |> Task.async_stream(
-      fn check_tuple ->
-        run_check(exec, check_tuple)
-      end,
-      timeout: :infinity
-    )
+    |> Task.async_stream(&run_check(exec, &1), timeout: :infinity, ordered: false)
     |> Stream.run()
 
     :ok

--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -165,13 +165,10 @@ defmodule Credo.CLI.Output.Summary do
     Credo.Code.prewalk(source_file, &scope_count_traverse/2, 0)
   end
 
-  defp scope_count([]), do: 0
-
   defp scope_count(source_files) when is_list(source_files) do
     source_files
-    |> Enum.map(&Task.async(fn -> scope_count(&1) end))
-    |> Enum.map(&Task.await/1)
-    |> Enum.reduce(&(&1 + &2))
+    |> Task.async_stream(&scope_count/1)
+    |> Enum.reduce(0, fn {:ok, n}, sum -> n + sum end)
   end
 
   @def_ops [:defmodule, :def, :defp, :defmacro]

--- a/lib/credo/cli/output/summary.ex
+++ b/lib/credo/cli/output/summary.ex
@@ -167,7 +167,7 @@ defmodule Credo.CLI.Output.Summary do
 
   defp scope_count(source_files) when is_list(source_files) do
     source_files
-    |> Task.async_stream(&scope_count/1)
+    |> Task.async_stream(&scope_count/1, ordered: false)
     |> Enum.reduce(0, fn {:ok, n}, sum -> n + sum end)
   end
 


### PR DESCRIPTION
Similar to #1077, optimizes the use of streams of tasks in credo in a few more places.

in addition to swapping `Enum.map(&Task.async(...))` -> `Task.async_stream`, this pr also removes ordering from the streams (where possible) for more slight performance gains (h/t @milmazz)