### PR TITLE
Remove variable name clause for check that can't compile

### DIFF
--- a/lib/credo/check/readability/variable_names.ex
+++ b/lib/credo/check/readability/variable_names.ex
@@ -40,14 +40,6 @@ defmodule Credo.Check.Readability.VariableNames do
     {ast, issues_for_lhs(lhs, issues, issue_meta)}
   end
 
-  defp traverse(
-         {:<-, _meta, [{:|, _comp_meta, [_lhs, rhs]}, _comp_rhs]} = ast,
-         issues,
-         issue_meta
-       ) do
-    {ast, issues_for_lhs(rhs, issues, issue_meta)}
-  end
-
   defp traverse({:<-, _meta, [lhs, _rhs]} = ast, issues, issue_meta) do
     {ast, issues_for_lhs(lhs, issues, issue_meta)}
   end

--- a/test/credo/check/readability/variable_names_test.exs
+++ b/test/credo/check/readability/variable_names_test.exs
@@ -149,19 +149,6 @@ defmodule Credo.Check.Readability.VariableNamesTest do
     |> assert_issue()
   end
 
-  test "it should report a violation /10" do
-    """
-    defmodule CredoSampleModule do
-      def some_function(param, p2, p3) do
-        [someValue + v2 + v3 | {someValue} <- param, v2 <- p2, v3 <- p3]
-      end
-    end
-    """
-    |> to_source_file
-    |> run_check(@described_check)
-    |> assert_issue()
-  end
-
   test "it should report a violation /11" do
     """
     defmodule CredoSampleModule do


### PR DESCRIPTION
This clause helped a test pass, but the test is made of code that can't compile
```ex
Interactive Elixir (1.15.7) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> defmodule CredoSampleModule do
...(1)>       def some_function(param, p2, p3) do
...(1)>         [someValue + v2 + v3 | {someValue} <- param, v2 <- p2, v3 <- p3]
...(1)>       end
...(1)>     end
error: misplaced operator |/2
```