### PR TITLE
Fix comment regarding how `credo:disable-for-lines` works

### DIFF
--- a/guides/configuration/config_comments.md
+++ b/guides/configuration/config_comments.md
@@ -107,7 +107,7 @@ end
 
 ## `credo:disable-for-lines:<count>`
 
-This config comment can be used to disable Credo for the preceding line of source code:
+This config comment can be used to disable Credo for the following `<count>` lines of source code:
 
 ```elixir
 # credo:disable-for-lines:3


### PR DESCRIPTION
"preceding" refers to something before the statement.  The correct word is `following` here.