### PR TITLE
Ignore PredicateFunctionNames when is impl

### DIFF
--- a/lib/credo/check/readability/predicate_function_names.ex
+++ b/lib/credo/check/readability/predicate_function_names.ex
@@ -108,10 +108,10 @@ defmodule Credo.Check.Readability.PredicateFunctionNames do
   end
 
   defp issues_for_definition(op, [{name, meta, args} | _], issues, issue_meta, impl_list) do
-    if {name, length(args)} not in impl_list do
-      issues_for_name(op, name, meta, issues, issue_meta)
-    else
+    if {name, length(args)} in impl_list do
       issues
+    else
+      issues_for_name(op, name, meta, issues, issue_meta)
     end
   end
 

--- a/lib/credo/check/readability/predicate_function_names.ex
+++ b/lib/credo/check/readability/predicate_function_names.ex
@@ -72,23 +72,29 @@ defmodule Credo.Check.Readability.PredicateFunctionNames do
   end
 
   defp do_find_impls_in_block({:@, _, [{:impl, _, [impl]}]}, acc) when impl != false do
-    [:impl | acc]
+    [:record_next_definition | acc]
   end
 
   # def when
-  defp do_find_impls_in_block({keyword, meta, [{:when, _, def_ast} | _]}, [:impl | impls])
+  defp do_find_impls_in_block({keyword, meta, [{:when, _, def_ast} | _]}, [
+         :record_next_definition | impls
+       ])
        when keyword in @def_ops do
     do_find_impls_in_block({keyword, meta, def_ast}, [:impl | impls])
   end
 
   # def 0 arity
-  defp do_find_impls_in_block({keyword, _meta, [{name, _, nil} | _]}, [:impl | impls])
+  defp do_find_impls_in_block({keyword, _meta, [{name, _, nil} | _]}, [
+         :record_next_definition | impls
+       ])
        when keyword in @def_ops do
     [{name, 0} | impls]
   end
 
   # def n arity
-  defp do_find_impls_in_block({keyword, _meta, [{name, _, args} | _]}, [:impl | impls])
+  defp do_find_impls_in_block({keyword, _meta, [{name, _, args} | _]}, [
+         :record_next_definition | impls
+       ])
        when keyword in @def_ops do
     [{name, length(args)} | impls]
   end

--- a/test/credo/check/readability/predicate_function_names_test.exs
+++ b/test/credo/check/readability/predicate_function_names_test.exs
@@ -109,6 +109,63 @@ defmodule Credo.Check.Readability.PredicateFunctionNamesTest do
     |> refute_issues()
   end
 
+  test "it should report a violation with false negatives" do
+    """
+    defmodule FooImpl do
+      def impl(false), do: false
+      def impl(true), do: true
+      def is_bar do
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation with false negatives /2" do
+    """
+    defmodule FooImpl do
+      impl(true)
+      def is_bar do
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation with false negatives /3" do
+    """
+    defmodule Foo do
+      @impl is_bar(a)
+    end
+    defmodule FooImpl do
+      def is_bar do
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
+  test "it should report a violation with false negatives /4" do
+    """
+    defmodule Foo do
+      @impl true
+    end
+    defmodule FooImpl do
+      def is_bar do
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
   #
   # cases raising issues
   #

--- a/test/credo/check/readability/predicate_function_names_test.exs
+++ b/test/credo/check/readability/predicate_function_names_test.exs
@@ -81,6 +81,34 @@ defmodule Credo.Check.Readability.PredicateFunctionNamesTest do
     |> refute_issues()
   end
 
+  test "it should NOT report a violation with callback" do
+    """
+    defmodule Foo do
+      @callback is_bar
+      @callback is_bar(a)
+    end
+
+    defmodule FooImpl do
+      @behaviour Foo
+
+      @impl Foo
+      def is_bar do
+      end
+
+      @impl Foo
+      def is_bar(a) when is_binary(a) do
+      end
+
+      @impl Foo
+      def is_bar(a) do
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
   #
   # cases raising issues
   #


### PR DESCRIPTION
# Overview

- Closes #1108

# Impl details

If any `:def, :defp, :defmacro` is preceded with `:impl`, we ignore.

Code is mostly inspired from the impl of `Specs`
