### PR TITLE
refactor: avoid warning for slices

### DIFF
--- a/lib/credo/code/interpolation_helper.ex
+++ b/lib/credo/code/interpolation_helper.ex
@@ -58,7 +58,7 @@ defmodule Credo.Code.InterpolationHelper do
     line = String.to_charlist(line)
     part1 = Enum.slice(line, 0, col_start - 1)
     part2 = String.to_charlist(String.duplicate(char, length))
-    part3 = Credo.Backports.Enum.slice(line, (col_end - 1)..-1)
+    part3 = Credo.Backports.Enum.slice(line, (col_end - 1)..-1//1)
     List.to_string(part1 ++ part2 ++ part3)
   end
 


### PR DESCRIPTION
```
warning: negative steps are not supported in Enum.slice/2, pass 41..-1//1 instead
  (elixir 1.16.2) lib/enum.ex:2994: Enum.slice/2
  (credo 1.7.0) lib/credo/code/interpolation_helper.ex:61: Credo.Code.InterpolationHelper.replace_line/4
  (elixir 1.16.2) lib/list.ex:1351: List.do_update_at/3
  (elixir 1.16.2) lib/list.ex:1355: List.do_update_at/3
  (elixir 1.16.2) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
  (credo 1.7.0) lib/credo/code/interpolation_helper.ex:14: Credo.Code.InterpolationHelper.replace_interpolations/3

```