### PR TITLE
Fix deprecation for 1.17

### DIFF
--- a/lib/credo/check/params.ex
+++ b/lib/credo/check/params.ex
@@ -36,7 +36,7 @@ defmodule Credo.Check.Params do
   def get(params, field, check_mod) do
     case params[field] do
       nil ->
-        check_mod.param_defaults[field]
+        check_mod.param_defaults()[field]
 
       val ->
         val
@@ -71,12 +71,12 @@ defmodule Credo.Check.Params do
 
   @doc false
   def category(params, check_mod) do
-    params[:__category__] || params[:category] || check_mod.category
+    params[:__category__] || params[:category] || check_mod.category()
   end
 
   @doc false
   def exit_status(params, check_mod) do
-    params[:__exit_status__] || params[:exit_status] || check_mod.exit_status
+    params[:__exit_status__] || params[:exit_status] || check_mod.exit_status()
   end
 
   @doc false
@@ -95,7 +95,7 @@ defmodule Credo.Check.Params do
 
   @doc false
   def priority(params, check_mod) do
-    params[:__priority__] || params[:priority] || check_mod.base_priority
+    params[:__priority__] || params[:priority] || check_mod.base_priority()
   end
 
   @doc false

--- a/lib/credo/cli/output/formatter/sarif.ex
+++ b/lib/credo/cli/output/formatter/sarif.ex
@@ -17,21 +17,21 @@ defmodule Credo.CLI.Output.Formatter.SARIF do
 
     final_rules =
       issues
-      |> Enum.uniq_by(& &1.check.id)
+      |> Enum.uniq_by(& &1.check.id())
       |> Enum.map(fn issue ->
         %{
-          "id" => issue.check.id,
+          "id" => issue.check.id(),
           "name" => Credo.Code.Name.full(issue.check),
           "fullDescription" => %{
-            "text" => issue.check.explanation |> String.replace("`", "'"),
-            "markdown" => issue.check.explanation
+            "text" => issue.check.explanation() |> String.replace("`", "'"),
+            "markdown" => issue.check.explanation()
           },
           "properties" => %{
             "tags" => [
               issue.category
             ]
           },
-          "helpUri" => issue.check.docs_uri
+          "helpUri" => issue.check.docs_uri()
         }
       end)
 
@@ -158,21 +158,21 @@ defmodule Credo.CLI.Output.Formatter.SARIF do
 
     rule_and_issue = {
       %{
-        "id" => issue.check.id,
+        "id" => issue.check.id(),
         "name" => Credo.Code.Name.full(issue.check),
         "fullDescription" => %{
-          "text" => issue.check.explanation |> String.replace("`", "'"),
-          "markdown" => issue.check.explanation
+          "text" => issue.check.explanation() |> String.replace("`", "'"),
+          "markdown" => issue.check.explanation()
         },
         "properties" => %{
           "tags" => [
             issue.category
           ]
         },
-        "helpUri" => issue.check.docs_uri
+        "helpUri" => issue.check.docs_uri()
       },
       %{
-        "ruleId" => issue.check.id,
+        "ruleId" => issue.check.id(),
         "level" => sarif_level,
         "rank" => priority_to_sarif_rank(issue.priority),
         "message" => %{
@@ -208,7 +208,7 @@ defmodule Credo.CLI.Output.Formatter.SARIF do
     rule_and_issue
     |> remove_nil_endcolumn(!column_end)
     |> remove_warning_level(sarif_level == :warning)
-    |> remove_redundant_name(issue.check.id == Credo.Code.Name.full(issue.check))
+    |> remove_redundant_name(issue.check.id() == Credo.Code.Name.full(issue.check))
   end
 
   defp remove_nil_endcolumn(sarif, false), do: sarif

--- a/lib/credo/cli/task/prepare_checks_to_run.ex
+++ b/lib/credo/cli/task/prepare_checks_to_run.ex
@@ -83,7 +83,7 @@ defmodule Credo.CLI.Task.PrepareChecksToRun do
   end
 
   defp matches_requirement?({check}, elixir_version) do
-    Version.match?(elixir_version, check.elixir_version)
+    Version.match?(elixir_version, check.elixir_version())
   end
 
   defp to_match_regexes(nil), do: []

--- a/lib/credo/cli/task/set_relevant_issues.ex
+++ b/lib/credo/cli/task/set_relevant_issues.ex
@@ -12,7 +12,7 @@ defmodule Credo.CLI.Task.SetRelevantIssues do
       |> Filter.important(exec)
       |> Filter.valid_issues(exec)
       |> Enum.sort_by(fn issue ->
-        {issue.check.id, issue.filename, issue.line_no}
+        {issue.check.id(), issue.filename, issue.line_no}
       end)
 
     put_issues(exec, issues)

--- a/lib/credo/execution/task/initialize_command.ex
+++ b/lib/credo/execution/task/initialize_command.ex
@@ -22,7 +22,7 @@ defmodule Credo.Execution.Task.InitializeCommand do
   end
 
   defp cli_options_switches(command_mod) do
-    command_mod.cli_switches
+    command_mod.cli_switches()
     |> List.wrap()
     |> Enum.map(fn
       %{name: name, type: type} when is_binary(name) -> {String.to_atom(name), type}
@@ -31,7 +31,7 @@ defmodule Credo.Execution.Task.InitializeCommand do
   end
 
   defp cli_options_aliases(command_mod) do
-    command_mod.cli_switches
+    command_mod.cli_switches()
     |> List.wrap()
     |> Enum.map(fn
       %{name: name, alias: alias} when is_binary(name) -> {alias, String.to_atom(name)}

--- a/lib/credo/execution/task/parse_options.ex
+++ b/lib/credo/execution/task/parse_options.ex
@@ -30,7 +30,7 @@ defmodule Credo.Execution.Task.ParseOptions do
         command_name = Execution.get_command_name(exec)
         command_mod = Execution.get_command(exec, command_name)
 
-        command_mod.treat_unknown_args_as_files?
+        command_mod.treat_unknown_args_as_files?()
       else
         false
       end

--- a/lib/credo/execution/task/validate_config.ex
+++ b/lib/credo/execution/task/validate_config.ex
@@ -67,7 +67,7 @@ defmodule Credo.Execution.Task.ValidateConfig do
   end
 
   defp do_warn_if_check_params_invalid({check, params}) do
-    valid_param_names = check.param_names ++ Params.builtin_param_names()
+    valid_param_names = check.param_names() ++ Params.builtin_param_names()
     check = check |> to_string |> String.to_existing_atom()
 
     Enum.each(params, fn {param_name, _param_value} ->


### PR DESCRIPTION
1.17 deprecates calling remote functions without parentheses, which
means that calls like `Foo.Bar.run` and `foo = %{bar: Foo}; foo.bar.run`
should instead be formatted like
`Foo.Bar.run()` and `foo = %{bar: Foo}; foo.bar.run()`

This show up as runtime warnings.
