### PR TITLE
Fix the path for included files in umbrella apps

### DIFF
--- a/lib/credo/check/design/skip_test_without_comment.ex
+++ b/lib/credo/check/design/skip_test_without_comment.ex
@@ -3,7 +3,7 @@ defmodule Credo.Check.Design.SkipTestWithoutComment do
     id: "EX2003",
     base_priority: :normal,
     param_defaults: [
-      files: %{included: ["test/**/*_test.exs"]}
+      files: %{included: ["**/*_test.exs"]}
     ],
     explanations: [
       check: """

--- a/lib/credo/check/refactor/pass_async_in_test_cases.ex
+++ b/lib/credo/check/refactor/pass_async_in_test_cases.ex
@@ -3,7 +3,7 @@ defmodule Credo.Check.Refactor.PassAsyncInTestCases do
     id: "EX4031",
     base_priority: :normal,
     param_defaults: [
-      files: %{included: ["test/**/*_test.exs"]}
+      files: %{included: ["**/*_test.exs"]}
     ],
     explanations: [
       check: """

--- a/lib/credo/check/warning/wrong_test_file_extension.ex
+++ b/lib/credo/check/warning/wrong_test_file_extension.ex
@@ -3,7 +3,7 @@ defmodule Credo.Check.Warning.WrongTestFileExtension do
     id: "EX5025",
     base_priority: :high,
     param_defaults: [
-      files: %{included: ["test/**/*_test.ex"]}
+      files: %{included: ["**/*_test.ex"]}
     ],
     explanations: [
       check: """


### PR DESCRIPTION
Hello! I ran into an issue where `Credo.Check.Refactor.PassAsyncInTestCases` would not flag issues when running `mix credo` from the root of an umbrella application, but `cd`-ing into `apps/app_web` and running it from there would correctly flag the missing `async` option.

We only have a single `.credo.exs` config at the root and I replicated the issue with the barebones config:

```elixir
%{
  configs: [
    %{
      name: "default",
      checks: %{
        enabled: [{Credo.Check.Refactor.PassAsyncInTestCases, []}]
      }
    }
  ]
}
```

Before this change, inside the `Credo.Sources.find_in_dir` the value for `included_patterns` would compile down to:

```
["/Users/tom/my_umbrella_app/test/**/*_test.exs"]
```

But that would skip everything that was under `my_umbrella_app/apps/**/test`

I see this was intentionally changed in https://github.com/rrrene/credo/commit/ac76775a37bceea6afe66c00d1647fe60c46d755 so maybe I'm wrong to submit this PR and would appreciate feedback! Changing this locally did make the check work from both the root and the individual umbrella app directories though.