### PR TITLE
Use explicit negative ranges

### DIFF
--- a/lib/credo/check/config_comment.ex
+++ b/lib/credo/check/config_comment.ex
@@ -135,7 +135,7 @@ defmodule Credo.Check.ConfigComment do
   defp value_for(param_string) do
     if regex_value?(param_string) do
       param_string
-      |> Credo.Backports.String.slice(1..-2)
+      |> Credo.Backports.String.slice(1..-2//-1)
       |> Regex.compile!("i")
     else
       String.to_atom("Elixir.#{param_string}")

--- a/lib/credo/check/consistency/multi_alias_import_require_use/collector.ex
+++ b/lib/credo/check/consistency/multi_alias_import_require_use/collector.ex
@@ -42,7 +42,7 @@ defmodule Credo.Check.Consistency.MultiAliasImportRequireUse.Collector do
     aliases =
       case arguments do
         [{:__aliases__, _, nested_modules}] when length(nested_modules) > 1 ->
-          base_name = Credo.Backports.Enum.slice(nested_modules, 0..-2)
+          base_name = Credo.Backports.Enum.slice(nested_modules, 0..-2//-1)
           {:single, base_name}
 
         [{{:., _, [{:__aliases__, _, _namespaces}, :{}]}, _, _nested_aliases}] ->

--- a/lib/credo/check/warning/unused_function_return_helper.ex
+++ b/lib/credo/check/warning/unused_function_return_helper.ex
@@ -132,7 +132,7 @@ defmodule Credo.Check.Warning.UnusedFunctionReturnHelper do
          when is_list(arguments) do
       # IO.inspect(ast, label: "#{unquote(op)} (#{Macro.to_string(candidate)} #{acc})")
 
-      head_expression = Credo.Backports.Enum.slice(arguments, 0..-2)
+      head_expression = Credo.Backports.Enum.slice(arguments, 0..-2//-1)
 
       if Credo.Code.contains_child?(head_expression, candidate) do
         {nil, :VERIFIED}

--- a/lib/credo/cli/command/diff/task/get_git_diff.ex
+++ b/lib/credo/cli/command/diff/task/get_git_diff.ex
@@ -104,13 +104,13 @@ defmodule Credo.CLI.Command.Diff.Task.GetGitDiff do
   defp run_credo_on_dir(exec, dirname, previous_git_ref, given_ref) do
     {previous_argv, _last_arg} =
       exec.argv
-      |> Credo.Backports.Enum.slice(1..-1)
+      |> Credo.Backports.Enum.slice(1..-1//-1)
       |> Enum.reduce({[], nil}, fn
-        _, {argv, "--working-dir"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}
-        _, {argv, "--from-git-merge-base"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}
-        _, {argv, "--from-git-ref"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}
-        _, {argv, "--from-dir"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}
-        _, {argv, "--since"} -> {Credo.Backports.Enum.slice(argv, 1..-2), nil}
+        _, {argv, "--working-dir"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
+        _, {argv, "--from-git-merge-base"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
+        _, {argv, "--from-git-ref"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
+        _, {argv, "--from-dir"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
+        _, {argv, "--since"} -> {Credo.Backports.Enum.slice(argv, 1..-2//-1), nil}
         "--show-fixed", {argv, _last_arg} -> {argv, nil}
         "--show-kept", {argv, _last_arg} -> {argv, nil}
         ^previous_git_ref, {argv, _last_arg} -> {argv, nil}

--- a/lib/credo/cli/command/explain/output/default.ex
+++ b/lib/credo/cli/command/explain/output/default.ex
@@ -269,7 +269,7 @@ defmodule Credo.CLI.Command.Explain.Output.Default do
     |> String.trim()
     |> String.split("\n")
     |> Enum.flat_map(&format_explanation(&1, outer_color))
-    |> Credo.Backports.Enum.slice(0..-2)
+    |> Credo.Backports.Enum.slice(0..-2//-1)
     |> UI.puts()
 
     UI.puts_edge([outer_color, :faint])


### PR DESCRIPTION
In Elixir 1.17-rc.0 we get these warnings:

```elixir
==> credo
Compiling 253 files (.ex)
warning: x..y inside match is deprecated, you must always match on the step: x..y//var or x..y//_ if you want to ignore it
  (credo 1.7.4) lib/credo/backports.ex:4: Credo.Backports.Enum.slice/2

warning: x..y inside match is deprecated, you must always match on the step: x..y//var or x..y//_ if you want to ignore it
  (credo 1.7.4) lib/credo/backports.ex:16: Credo.Backports.String.slice/2

warning: 0..-2 has a default step of -1, please write 0..-2//-1 instead
  (credo 1.7.4) lib/credo/cli/command/explain/output/default.ex:272: Credo.CLI.Command.Explain.Output.Default.print_check_explanation/2

warning: 1..-1 has a default step of -1, please write 1..-1//-1 instead
  (credo 1.7.4) lib/credo/cli/command/diff/task/get_git_diff.ex:107: Credo.CLI.Command.Diff.Task.GetGitDiff.run_credo_on_dir/4

warning: 1..-2 has a default step of -1, please write 1..-2//-1 instead
  (credo 1.7.4) lib/credo/cli/command/diff/task/get_git_diff.ex:109: Credo.CLI.Command.Diff.Task.GetGitDiff.run_credo_on_dir/4

warning: 1..-2 has a default step of -1, please write 1..-2//-1 instead
  (credo 1.7.4) lib/credo/cli/command/diff/task/get_git_diff.ex:110: Credo.CLI.Command.Diff.Task.GetGitDiff.run_credo_on_dir/4

warning: 1..-2 has a default step of -1, please write 1..-2//-1 instead
  (credo 1.7.4) lib/credo/cli/command/diff/task/get_git_diff.ex:111: Credo.CLI.Command.Diff.Task.GetGitDiff.run_credo_on_dir/4

warning: 1..-2 has a default step of -1, please write 1..-2//-1 instead
  (credo 1.7.4) lib/credo/cli/command/diff/task/get_git_diff.ex:112: Credo.CLI.Command.Diff.Task.GetGitDiff.run_credo_on_dir/4

warning: 1..-2 has a default step of -1, please write 1..-2//-1 instead
  (credo 1.7.4) lib/credo/cli/command/diff/task/get_git_diff.ex:113: Credo.CLI.Command.Diff.Task.GetGitDiff.run_credo_on_dir/4

warning: 1..-2 has a default step of -1, please write 1..-2//-1 instead
  (credo 1.7.4) lib/credo/check/config_comment.ex:138: Credo.Check.ConfigComment.value_for/1

warning: 0..-2 has a default step of -1, please write 0..-2//-1 instead
  (credo 1.7.4) lib/credo/check/consistency/multi_alias_import_require_use/collector.ex:41: Credo.Check.Consistency.MultiAliasImportRequireUse.Collector.traverse/2

warning: 0..-2 has a default step of -1, please write 0..-2//-1 instead
  (credo 1.7.4) lib/credo/check/warning/unused_function_return_helper.ex:135: Credo.Check.Warning.UnusedFunctionReturnHelper.verify_candidate/3

warning: 0..-2 has a default step of -1, please write 0..-2//-1 instead
  (credo 1.7.4) lib/credo/check/warning/unused_function_return_helper.ex:135: Credo.Check.Warning.UnusedFunctionReturnHelper.verify_candidate/3

warning: 0..-2 has a default step of -1, please write 0..-2//-1 instead
  (credo 1.7.4) lib/credo/check/warning/unused_function_return_helper.ex:135: Credo.Check.Warning.UnusedFunctionReturnHelper.verify_candidate/3

warning: 0..-2 has a default step of -1, please write 0..-2//-1 instead
  (credo 1.7.4) lib/credo/check/warning/unused_function_return_helper.ex:135: Credo.Check.Warning.UnusedFunctionReturnHelper.verify_candidate/3

warning: 0..-2 has a default step of -1, please write 0..-2//-1 instead
  (credo 1.7.4) lib/credo/check/warning/unused_function_return_helper.ex:135: Credo.Check.Warning.UnusedFunctionReturnHelper.verify_candidate/3
```

This PR fixes them