### PR TITLE
Ignore FunctionNames when sigil is private

### DIFF
--- a/lib/credo/check/readability/function_names.ex
+++ b/lib/credo/check/readability/function_names.ex
@@ -66,7 +66,7 @@ defmodule Credo.Check.Readability.FunctionNames do
            _issue_meta,
            _allow_acronyms?
          )
-         when op in [:def, :defmacro] do
+         when op in [:def, :defp, :defmacro, :defmacrop] do
       {ast, issues}
     end
 
@@ -77,7 +77,7 @@ defmodule Credo.Check.Readability.FunctionNames do
            _issue_meta,
            _allow_acronyms?
          )
-         when op in [:def, :defmacro] do
+         when op in [:def, :defp, :defmacro, :defmacrop] do
       {ast, issues}
     end
   end

--- a/test/credo/check/readability/function_names_test.exs
+++ b/test/credo/check/readability/function_names_test.exs
@@ -115,7 +115,7 @@ defmodule Credo.Check.Readability.FunctionNamesTest do
     |> refute_issues()
   end
 
-  test "it should NOT report expected code for private multi letter sigils /2" do
+  test "it should NOT report expected code for private multi letter sigils" do
     """
     defp sigil_ZZO(input, args) do
       # ...

--- a/test/credo/check/readability/function_names_test.exs
+++ b/test/credo/check/readability/function_names_test.exs
@@ -63,6 +63,9 @@ defmodule Credo.Check.Readability.FunctionNamesTest do
     def sigil_O(input, args) do
       # ...
     end
+    def sigil_o(input, args) do
+      # ...
+    end
     defmacro sigil_U({:<<>>, _, [string]}, []) do
       # ...
     end
@@ -75,7 +78,27 @@ defmodule Credo.Check.Readability.FunctionNamesTest do
     |> refute_issues()
   end
 
-  test "it should NOT report expected code for multi letter sigils /5" do
+  test "it should NOT report expected code /6" do
+    """
+    defp sigil_O(input, args) do
+      # ...
+    end
+    defp sigil_p(input, args) do
+      # ...
+    end
+    defmacrop sigil_U({:<<>>, _, [string]}, []) do
+      # ...
+    end
+    defmacrop sigil_U({:<<>>, _, [string]}, []) when is_binary(string) do
+      # ...
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report expected code for multi letter sigils" do
     """
     def sigil_ZZO(input, args) do
       # ...
@@ -84,6 +107,23 @@ defmodule Credo.Check.Readability.FunctionNamesTest do
       # ...
     end
     defmacro sigil_ZZU({:<<>>, _, [string]}, []) when is_binary(string) do
+      # ...
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report expected code for private multi letter sigils /2" do
+    """
+    defp sigil_ZZO(input, args) do
+      # ...
+    end
+    defmacrop sigil_ZZU({:<<>>, _, [string]}, []) do
+      # ...
+    end
+    defmacrop sigil_ZZU({:<<>>, _, [string]}, []) when is_binary(string) do
       # ...
     end
     """


### PR DESCRIPTION
This pull request updates the `Credo.Check.Readability.FunctionNames` module to ignore function names when the sigil is private. It also includes test cases to ensure the expected behavior.