### PR TITLE
New Check:  OpenBrowser

### DIFF
--- a/lib/credo/check/warning/open_browser.ex
+++ b/lib/credo/check/warning/open_browser.ex
@@ -1,0 +1,46 @@
+defmodule Credo.Check.Warning.OpenBrowser do
+  @moduledoc """
+  Check for tests containing open_browser calls.
+  """
+
+  use Credo.Check,
+    base_priority: :high,
+    category: :consistency,
+    param_defaults: [
+      files: %{included: ["test/**/*_test.exs", "apps/**/test/**/*_test.exs"]}
+    ],
+    explanations: [
+      check: """
+      Remove calls to open_browser. These support local development and should not be committed.
+      """
+    ]
+
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  # This matches on the AST structure of a open_browser function call
+  defp traverse(
+         {:open_browser, meta, _} = ast,
+         issues,
+         issue_meta
+       ) do
+    {ast, issues ++ [issue_for("open_browser", meta[:line], issue_meta)]}
+  end
+
+  # For all AST nodes not matching the pattern above, we simply do nothing:
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issue_for(trigger, line_no, issue_meta) do
+    format_issue(
+      issue_meta,
+      message: "There should be no calls to open_browser.",
+      trigger: trigger,
+      line_no: line_no
+    )
+  end
+end

--- a/test/credo/check/warning/open_browser_test.exs
+++ b/test/credo/check/warning/open_browser_test.exs
@@ -1,0 +1,31 @@
+defmodule Credo.Check.Warning.OpenBrowserTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Warning.OpenBrowser
+
+  test "it should NOT report expected code" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(_view) do
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should report code that includes open_browser" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(view) do
+        open_browser(view)
+        # open_browser(view)
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issues()
+  end
+end


### PR DESCRIPTION
* add `open_browser.ex` as a warning with associated tests
* default params only have this check running on test files