### PR TITLE
Change to not warn on calls to IO.inspect/3

### DIFF
--- a/lib/credo/check/warning/io_inspect.ex
+++ b/lib/credo/check/warning/io_inspect.ex
@@ -16,23 +16,24 @@ defmodule Credo.Check.Warning.IoInspect do
   @impl true
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
-
     Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
   end
 
   defp traverse(
-         {{:., _, [{:__aliases__, meta, [:"Elixir", :IO]}, :inspect]}, _, _arguments} = ast,
+         {{:., _, [{:__aliases__, meta, [:"Elixir", :IO]}, :inspect]}, _, args} = ast,
          issues,
          issue_meta
-       ) do
+       )
+       when length(args) < 3 do
     {ast, issues_for_call(meta, "Elixir.IO.inspect", issues, issue_meta)}
   end
 
   defp traverse(
-         {{:., _, [{:__aliases__, meta, [:IO]}, :inspect]}, _meta, _arguments} = ast,
+         {{:., _, [{:__aliases__, meta, [:IO]}, :inspect]}, _, args} = ast,
          issues,
          issue_meta
-       ) do
+       )
+       when length(args) < 3 do
     {ast, issues_for_call(meta, "IO.inspect", issues, issue_meta)}
   end
 

--- a/test/credo/check/warning/io_inspect_test.exs
+++ b/test/credo/check/warning/io_inspect_test.exs
@@ -20,6 +20,19 @@ defmodule Credo.Check.Warning.IoInspectTest do
     |> refute_issues()
   end
 
+  test "it should NOT report Inspect/3" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1) do
+        IO.inspect(:stderr, parameter1, [])
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
   #
   # cases raising issues
   #


### PR DESCRIPTION
It seems unlikely that an inspect call with a specific file handler passed in would be from a debugging session, so it makes sense to exclude these calls.

Thoughts?