### PR TITLE
Remove deprecated module.function() notation

### DIFF
--- a/lib/credo/check/params.ex
+++ b/lib/credo/check/params.ex
@@ -71,7 +71,7 @@ defmodule Credo.Check.Params do
 
   @doc false
   def category(params, check_mod) do
-    params[:__category__] || params[:category] || check_mod.category()
+    params[:__category__] || params[:category] || check_mod.category
   end
 
   @doc false

--- a/lib/credo/cli/output.ex
+++ b/lib/credo/cli/output.ex
@@ -33,7 +33,7 @@ defmodule Credo.CLI.Output do
   end
 
   def check_tag(check_mod, in_parens) do
-    check_mod.category()
+    check_mod.category
     |> to_string
     |> check_tag(in_parens)
   end


### PR DESCRIPTION
Avoids this warning for elixir 1.17+

```
warning: using module.function() notation (with parentheses) to fetch map field :category is deprecated, you must remove the parentheses: map.field
  (credo 1.7.7) lib/credo/cli/output.ex:36: Credo.CLI.Output.check_tag/2
  (credo 1.7.7) lib/credo/cli/output/formatter/flycheck.ex:26: Credo.CLI.Output.Formatter.Flycheck.to_flycheck/1
  (credo 1.7.7) lib/credo/cli/output/formatter/flycheck.ex:12: anonymous fn/1 in Credo.CLI.Output.Formatter.Flycheck.print_issues/1
  (elixir 1.17.2) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
  (credo 1.7.7) lib/credo/cli/command/suggest/suggest_command.ex:77: Credo.CLI.Command.Suggest.SuggestCommand.PrintResultsAndSummary.call/1
```