### PR TITLE
Fixes counting params when a function has a guard

### DIFF
--- a/lib/credo/code/parameters.ex
+++ b/lib/credo/code/parameters.ex
@@ -15,6 +15,9 @@ defmodule Credo.Code.Parameters do
         {_atom, _meta, nil} ->
           0
 
+        {:when, _when_meta, [{_fun, _meta, args} | _guards]} ->
+          length(args || [])
+
         {_atom, _meta, list} ->
           Enum.count(list)
 

--- a/test/credo/code/parameters_test.exs
+++ b/test/credo/code/parameters_test.exs
@@ -146,6 +146,32 @@ defmodule Credo.Code.ParametersTest do
     assert 2 == Parameters.count(ast)
   end
 
+  test "returns the correct paramter counts for a function with a guard condition" do
+    {:ok, ast} =
+      """
+      def foobar(a, b, c, d) when is_integer(a), do: :ok
+      """
+      |> Code.string_to_quoted()
+
+    assert 4 == Parameters.count(ast)
+
+    {:ok, ast} =
+      """
+      def foobar(a, b, c, d, e) when is_integer(a) and is_map(b), do: :ok
+      """
+      |> Code.string_to_quoted()
+
+    assert 5 == Parameters.count(ast)
+
+    {:ok, ast} =
+      """
+      def foobar when is_integer(@a), do: :ok
+      """
+      |> Code.string_to_quoted()
+
+    assert 0 == Parameters.count(ast)
+  end
+
   test "returns the correct parameter counts for ASTs" do
     ast =
       {:def, [line: 2],


### PR DESCRIPTION
Hi René,

Counting parameters wasn't working quite right when a function hard a guard clause. I believe this fixes it.

Let me know if you want me to tweak anything or raise an associated issue.

💚