### PR TITLE
Add ** operator

### DIFF
--- a/lib/credo/check/readability/function_names.ex
+++ b/lib/credo/check/readability/function_names.ex
@@ -35,7 +35,7 @@ defmodule Credo.Check.Readability.FunctionNames do
   @all_sigil_atoms Enum.map(@all_sigil_chars, &:"sigil_#{&1}")
 
   # all non-special-form operators
-  @all_nonspecial_operators ~W(! && ++ -- .. <> =~ @ |> || != !== * + - / < <= == === > >= ||| &&& <<< >>> <<~ ~>> <~ ~> <~> <|> ^^^ ~~~ +++ ---)a
+  @all_nonspecial_operators ~W(! && ++ -- .. <> =~ @ |> || != !== * + - / ** < <= == === > >= ||| &&& <<< >>> <<~ ~>> <~ ~> <~> <|> ^^^ ~~~ +++ ---)a
 
   @doc false
   @impl true

--- a/test/credo/check/readability/function_names_test.exs
+++ b/test/credo/check/readability/function_names_test.exs
@@ -152,6 +152,10 @@ defmodule Credo.Check.Readability.FunctionNamesTest do
     def left --- right do
       # ++ code
     end
+
+    def left ** right do
+      # ...
+    end
     """
     |> to_source_file
     |> run_check(@described_check)


### PR DESCRIPTION
This stops e.g. the following code from showing a readability warning:

```
defmodule CredoTest do
  @moduledoc """
  An example of the snakecase test failing
  """
  def a ** b do
    nil
  end
end
```