### PR TITLE
fix missing parentheses warning in `Credo.Check.Params.category/2`

### DIFF
--- a/lib/credo/check/params.ex
+++ b/lib/credo/check/params.ex
@@ -71,7 +71,7 @@ defmodule Credo.Check.Params do
 
   @doc false
   def category(params, check_mod) do
-    params[:__category__] || params[:category] || check_mod.category
+    params[:__category__] || params[:category] || check_mod.category()
   end
 
   @doc false


### PR DESCRIPTION
```
warning: using map.field notation (without parentheses) to invoke function Credo.Check.Refactor.ModuleDependencies.category() is deprecated, you must add parentheses instead: remote.function()
  (credo 1.7.9) lib/credo/check/params.ex:74: Credo.Check.Params.category/2
  (credo 1.7.9) lib/credo/check.ex:697: Credo.Check.format_issue/3
  (credo 1.7.9) lib/credo/check/refactor/module_dependencies.ex:111: Credo.Check.Refactor.ModuleDependencies.issues_for_module/5
  (credo 1.7.9) lib/credo/check/refactor/module_dependencies.ex:89: Credo.Check.Refactor.ModuleDependencies.traverse/6
  (elixir 1.17.3) lib/macro.ex:599: Macro.traverse/4
```