### PR TITLE
Credo.Check format_issue can use a custom exit_status option

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -707,7 +707,7 @@ defmodule Credo.Check do
 
     priority = Priority.to_integer(issue_priority)
 
-    exit_status_or_category = Params.exit_status(params, check) || issue_category
+    exit_status_or_category = opts[:exit_status] || Params.exit_status(params, check) || issue_category
     exit_status = Check.to_exit_status(exit_status_or_category)
 
     line_no = opts[:line_no]


### PR DESCRIPTION
### What am I doing?

Being able to use a custom `exit_status` option.

### Why?

When I try to pass a custom `:exit_status` value to the `format_issue` opts, it is never applied. Am I missing something?

```elixir
format_issue(
  issue_meta,
  message: message,
  trigger: mfa,
  exit_status: 0,
  line_no: line_no
)
# exit status is not 0
```

The tricky thing is that I am defining a Check that could generate:
- 2 types of categories.
- 2 different exit statuses (0 and 16 - warning).

### Alternative approaches

How am I bypassing this for now? I am developing a `Credo.Check` and I do it by modifying the `IssueMeta` tuple, setting these values, which is a bit "weird", compared with just giving a custom option when formatting it.

As `:exit_status` is not established when using it (`use` options), it gets it from the function generated by the macro. 

```elixir
  @doc false
  def exit_status(params, check_mod) do
    params[:__exit_status__] || params[:exit_status] || check_mod.exit_status()
  end
```

Example:

```elixir
exit_status = 0 # or the other coming from :warning
issue_meta = case issue_meta do
  {mod, source, params} -> {mod, source, Keyword.put(params, :exit_status, exit_status)
  issue_meta -> issue_meta
end
    
format_issue(issue_meta, ...)
```