### PR TITLE
Fix type check issue after 'apply/3' got type checking

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -384,16 +384,19 @@ defmodule Credo.Check do
       @impl true
       def run_on_all_source_files(exec, source_files, params \\ [])
 
-      @impl true
-      def run_on_all_source_files(exec, source_files, params) do
-        if function_exported?(__MODULE__, :run, 3) do
+      if function_exported?(__MODULE__, :run, 3) do
+        @impl true
+        def run_on_all_source_files(exec, source_files, params) do
           IO.warn(
             "Defining `run(source_files, exec, params)` for checks that run on all source files is deprecated. " <>
               "Define `run_on_all_source_files(exec, source_files, params)` instead."
           )
 
           apply(__MODULE__, :run, [source_files, exec, params])
-        else
+        end
+      else
+        @impl true
+        def run_on_all_source_files(exec, source_files, params) do
           do_run_on_all_source_files(exec, source_files, params)
         end
       end


### PR DESCRIPTION
After [this commit](https://github.com/elixir-lang/elixir/commit/bf1a2071e94b66c8016ebd4bc5852179414a8172) in elixir `main` branch, type checking was added to the `apply` function. This has started causing these warnings for us:
```
warning: Credo.Check.Warning.NoProcessDictionary.run/3 is undefined or private. Did you mean:

          * run/2
```

This PR hopefully fixes it.