### PR TITLE
Extend double boolean negation to include '! not' and 'not !'

### DIFF
--- a/test/credo/check/refactor/double_boolean_negation_test.exs
+++ b/test/credo/check/refactor/double_boolean_negation_test.exs
@@ -62,4 +62,26 @@ defmodule Credo.Check.Refactor.DoubleBooleanNegationTest do
       assert issue.trigger == "not not"
     end)
   end
+
+  test "it should report mixed violation '! not'" do
+    """
+    ! not true
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "! not"
+    end)
+  end
+
+  test "it should report mixed violation 'not !'" do
+    """
+    not ! true
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "not !"
+    end)
+  end
 end


### PR DESCRIPTION
Currently, Credo.Check.Refactor.DoubleBooleanNegation triggers on "!!foo" and "not not foo".

This extends it to trigger on "!not foo" and "not !foo" as well.
