### PR TITLE
Add columns to FIXME and TODO tag checks

### DIFF
--- a/lib/credo/check/design/tag_fixme.ex
+++ b/lib/credo/check/design/tag_fixme.ex
@@ -40,11 +40,12 @@ defmodule Credo.Check.Design.TagFIXME do
     |> Enum.map(&issue_for(issue_meta, &1))
   end
 
-  defp issue_for(issue_meta, {line_no, _line, trigger}) do
+  defp issue_for(issue_meta, {line_no, column, _line, trigger}) do
     format_issue(
       issue_meta,
       message: "Found a #{@tag_name} tag in a comment: #{trigger}",
       line_no: line_no,
+      column: column,
       trigger: trigger
     )
   end

--- a/lib/credo/check/design/tag_todo.ex
+++ b/lib/credo/check/design/tag_todo.ex
@@ -39,11 +39,12 @@ defmodule Credo.Check.Design.TagTODO do
     |> Enum.map(&issue_for(issue_meta, &1))
   end
 
-  defp issue_for(issue_meta, {line_no, _line, trigger}) do
+  defp issue_for(issue_meta, {line_no, column, _line, trigger}) do
     format_issue(
       issue_meta,
       message: "Found a #{@tag_name} tag in a comment: #{trigger}",
       line_no: line_no,
+      column: column,
       trigger: trigger
     )
   end

--- a/test/credo/check/design/tag_fixme_test.exs
+++ b/test/credo/check/design/tag_fixme_test.exs
@@ -40,7 +40,10 @@ defmodule Credo.Check.Design.TagFIXMETest do
     """
     |> to_source_file
     |> run_check(@described_check)
-    |> assert_issue()
+    |> assert_issue(fn issue ->
+      assert issue.line_no == 4
+      assert issue.column == 3
+    end)
   end
 
   test "it should report an issue when lower case" do

--- a/test/credo/check/design/tag_helper_test.exs
+++ b/test/credo/check/design/tag_helper_test.exs
@@ -37,6 +37,7 @@ defmodule Credo.Check.Design.TagHelperTest do
     expected = [
       {
         4,
+        19,
         "  def some_fun do # TODO: find a better name for this",
         "# TODO: find a better name for this"
       }
@@ -62,6 +63,7 @@ defmodule Credo.Check.Design.TagHelperTest do
     expected = [
       {
         4,
+        19,
         "  def some_fun do # TODO find a better name for this",
         "# TODO find a better name for this"
       }
@@ -88,6 +90,7 @@ defmodule Credo.Check.Design.TagHelperTest do
     expected = [
       {
         4,
+        3,
         "  # todo find a better name for this",
         "# todo find a better name for this"
       }

--- a/test/credo/check/design/tag_todo_test.exs
+++ b/test/credo/check/design/tag_todo_test.exs
@@ -87,7 +87,10 @@ defmodule Credo.Check.Design.TagTODOTest do
     """
     |> to_source_file
     |> run_check(@described_check)
-    |> assert_issue()
+    |> assert_issue(fn issue ->
+      assert issue.line_no == 4
+      assert issue.column == 3
+    end)
   end
 
   test "it should report an issue for @doc tags" do


### PR DESCRIPTION
This allows text editors to correctly render the diagnostic

Before: 
![CleanShot 2025-02-28 at 14 16 15@2x](https://github.com/user-attachments/assets/3e82e3c5-2a2a-40d0-8ccd-f72b02a8e59d)

After:

![CleanShot 2025-02-28 at 14 18 20@2x](https://github.com/user-attachments/assets/41dd56d9-d958-4880-a95e-4b2515c9572c)

