### PR TITLE
Fix false positive sigil-prefixed function names

### DIFF
--- a/lib/credo/check/readability/function_names.ex
+++ b/lib/credo/check/readability/function_names.ex
@@ -155,17 +155,21 @@ defmodule Credo.Check.Readability.FunctionNames do
          meta,
          issues,
          issue_meta,
-         _allow_acronyms?
+         allow_acronyms?
        ) do
-    multi_letter_sigil? = String.match?(sigil_letters, ~r/^[A-Z]+$/)
+    cond do
+      # multi-letter sigil
+      String.match?(sigil_letters, ~r/^[A-Z]+$/) ->
+        issues
 
-    if multi_letter_sigil? do
-      issues
-    else
-      issue = issue_for(issue_meta, meta[:line], name)
-      arity = length(args || [])
+      Name.snake_case?(name, allow_acronyms?) ->
+        issues
 
-      add_issue(issues, name, arity, issue)
+      true ->
+        issue = issue_for(issue_meta, meta[:line], name)
+        arity = length(args || [])
+
+        add_issue(issues, name, arity, issue)
     end
   end
 

--- a/test/credo/check/readability/function_names_test.exs
+++ b/test/credo/check/readability/function_names_test.exs
@@ -134,6 +134,17 @@ defmodule Credo.Check.Readability.FunctionNamesTest do
     |> refute_issues()
   end
 
+  test "it should NOT report snake case sigil-prefixed functions" do
+    """
+    defp sigil_z_support_fun(input, args) do
+      # ...
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
   test "it should NOT report expected code (for operators) /6" do
     """
     defmacro @expr2
@@ -346,6 +357,17 @@ defmodule Credo.Check.Readability.FunctionNamesTest do
     |> run_check(@described_check)
     |> assert_issue(fn issue ->
       assert issue.trigger == "clean_HTTP_url"
+    end)
+  end
+
+  test "it should report a violation /16" do
+    """
+    def sigil_sampleSigil(0), do: :ok
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "sigil_sampleSigil"
     end)
   end
 end


### PR DESCRIPTION
My take on a fix for #1164

For functions that aren't sigils but begin with "sigil_" it checks the names as it would any other function.