### PR TITLE
Move regexes out of module attributes for OTP 28 compatibility

### DIFF
--- a/lib/credo/check/config_comment_finder.ex
+++ b/lib/credo/check/config_comment_finder.ex
@@ -6,8 +6,6 @@ defmodule Credo.Check.ConfigCommentFinder do
   # It traverses the given codebase to find `Credo.Check.ConfigComment`
   # compatible comments, which control Credo's behaviour.
 
-  @config_comment_format ~r/#\s*credo\:([\w-\:]+)\s*(.*)/im
-
   alias Credo.Check.ConfigComment
   alias Credo.SourceFile
 
@@ -28,10 +26,12 @@ defmodule Credo.Check.ConfigCommentFinder do
     end
   end
 
+  defp config_comment_format(), do: ~r/#\s*credo\:([\w\-\:]+)\s*(.*)/im
+
   defp find_config_comments(source_file) do
     source = SourceFile.source(source_file)
 
-    if source =~ @config_comment_format do
+    if source =~ config_comment_format() do
       source
       |> Credo.Code.clean_charlists_strings_and_sigils()
       |> Credo.Code.to_lines()
@@ -42,7 +42,7 @@ defmodule Credo.Check.ConfigCommentFinder do
   end
 
   defp find_config_comment({line_no, string}, memo) do
-    case Regex.run(@config_comment_format, string) do
+    case Regex.run(config_comment_format(), string) do
       nil ->
         memo
 

--- a/lib/credo/check/consistency/space_in_parentheses/collector.ex
+++ b/lib/credo/check/consistency/space_in_parentheses/collector.ex
@@ -3,12 +3,6 @@ defmodule Credo.Check.Consistency.SpaceInParentheses.Collector do
 
   use Credo.Check.Consistency.Collector
 
-  @regex [
-    with_space: ~r/[^\?]([\{\[\(]\s+\S|\S\s+[\)\]\}]])/,
-    without_space: ~r/[^\?]([\{\[\(]\S|\S[\)\]\}])/,
-    without_space_allow_empty_enums: ~r/[^\?](?!\{\}|\[\])([\{\[\(]\S|\S[\)\]\}])/
-  ]
-
   def collect_matches(source_file, _params) do
     source_file
     |> Credo.Code.clean_charlists_strings_sigils_and_comments("")
@@ -30,8 +24,15 @@ defmodule Credo.Check.Consistency.SpaceInParentheses.Collector do
     |> List.foldr([], &locate(actual, &1, &2))
   end
 
+  defp regexes(),
+    do: [
+      with_space: ~r/[^\?]([\{\[\(]\s+\S|\S\s+[\)\]\}]])/,
+      without_space: ~r/[^\?]([\{\[\(]\S|\S[\)\]\}])/,
+      without_space_allow_empty_enums: ~r/[^\?](?!\{\}|\[\])([\{\[\(]\S|\S[\)\]\}])/
+    ]
+
   defp spaces({_line_no, line}, acc) do
-    Enum.reduce(@regex, acc, fn {kind_of_space, regex}, space_map ->
+    Enum.reduce(regexes(), acc, fn {kind_of_space, regex}, space_map ->
       if Regex.match?(regex, line) do
         Map.update(space_map, kind_of_space, 1, &(&1 + 1))
       else
@@ -41,7 +42,7 @@ defmodule Credo.Check.Consistency.SpaceInParentheses.Collector do
   end
 
   defp locate(kind_of_space, {line_no, line}, locations) do
-    case Regex.run(@regex[kind_of_space], line) do
+    case Regex.run(regexes()[kind_of_space], line) do
       nil ->
         locations
 

--- a/lib/credo/check/design/skip_test_without_comment.ex
+++ b/lib/credo/check/design/skip_test_without_comment.ex
@@ -29,9 +29,6 @@ defmodule Credo.Check.Design.SkipTestWithoutComment do
       """
     ]
 
-  @tag_skip_regex ~r/^\s*\@tag :skip\s*$/
-  @comment_regex ~r/^\s*\#.*$/
-
   @doc false
   @impl true
   def run(source_file, params) do
@@ -46,9 +43,12 @@ defmodule Credo.Check.Design.SkipTestWithoutComment do
   end
 
   defp transform_line({line, line_number}) do
+    tag_skip_regex = ~r/^\s*\@tag :skip\s*$/
+    comment_regex = ~r/^\s*\#.*$/
+
     cond do
-      line =~ @tag_skip_regex -> {:tag_skip, line_number}
-      line =~ @comment_regex -> {:comment, line_number}
+      line =~ tag_skip_regex -> {:tag_skip, line_number}
+      line =~ comment_regex -> {:comment, line_number}
       true -> {line, line_number}
     end
   end

--- a/lib/credo/check/readability/max_line_length.ex
+++ b/lib/credo/check/readability/max_line_length.ex
@@ -37,7 +37,6 @@ defmodule Credo.Check.Readability.MaxLineLength do
   alias Credo.Code.Strings
 
   @def_ops [:def, :defp, :defmacro]
-  @url_regex ~r/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/
 
   @doc false
   @impl true
@@ -81,9 +80,11 @@ defmodule Credo.Check.Readability.MaxLineLength do
         lines
       end
 
+    url_regex = ~r/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/
+
     lines_for_comparison =
       if ignore_urls do
-        Enum.reject(lines_for_comparison, fn {_, line} -> line =~ @url_regex end)
+        Enum.reject(lines_for_comparison, fn {_, line} -> line =~ url_regex end)
       else
         lines_for_comparison
       end

--- a/lib/credo/check/readability/space_after_commas.ex
+++ b/lib/credo/check/readability/space_after_commas.ex
@@ -36,10 +36,6 @@ defmodule Credo.Check.Readability.SpaceAfterCommas do
   alias Credo.Code.Sigils
   alias Credo.Code.Strings
 
-  # Matches commas followed by non-whitespace unless preceded by
-  # a question mark that is not part of a variable or function name
-  @unspaced_commas ~r/(?<!\W\?)(\,\S)/
-
   @doc false
   @impl true
   def run(%SourceFile{} = source_file, params) do
@@ -66,7 +62,11 @@ defmodule Credo.Check.Readability.SpaceAfterCommas do
   end
 
   defp find_issues(issue_meta, {line_no, line}) do
-    @unspaced_commas
+    # Matches commas followed by non-whitespace unless preceded by
+    # a question mark that is not part of a variable or function name
+    unspaced_commas = ~r/(?<!\W\?)(\,\S)/
+
+    unspaced_commas
     |> Regex.scan(line, capture: :all_but_first, return: :index)
     |> List.flatten()
     |> Enum.map(fn {idx, len} ->

--- a/lib/credo/config_builder.ex
+++ b/lib/credo/config_builder.ex
@@ -4,8 +4,6 @@ defmodule Credo.ConfigBuilder do
   alias Credo.ConfigFile
   alias Credo.Execution
 
-  @pattern_split_regex ~r/,\s*/
-
   def parse(exec) do
     options = exec.cli_options
 
@@ -21,6 +19,8 @@ defmodule Credo.ConfigBuilder do
         error
     end
   end
+
+  defp pattern_split_regex(), do: ~r/,\s*/
 
   defp get_config_file(exec, %Options{} = options) do
     config_name = options.switches[:config_name]
@@ -233,7 +233,7 @@ defmodule Credo.ConfigBuilder do
   # add_switch_enable_disabled_checks
 
   defp add_switch_enable_disabled_checks(exec, %{enable_disabled_checks: check_pattern}) do
-    %Execution{exec | enable_disabled_checks: String.split(check_pattern, @pattern_split_regex)}
+    %Execution{exec | enable_disabled_checks: String.split(check_pattern, pattern_split_regex())}
   end
 
   defp add_switch_enable_disabled_checks(exec, _), do: exec
@@ -254,7 +254,7 @@ defmodule Credo.ConfigBuilder do
     new_config = %Execution{
       exec
       | strict: true,
-        only_checks: String.split(check_pattern, @pattern_split_regex)
+        only_checks: String.split(check_pattern, pattern_split_regex())
     }
 
     Execution.set_strict(new_config)
@@ -275,7 +275,7 @@ defmodule Credo.ConfigBuilder do
   end
 
   defp add_switch_ignore(exec, %{ignore_checks: ignore_pattern}) do
-    %Execution{exec | ignore_checks: String.split(ignore_pattern, @pattern_split_regex)}
+    %Execution{exec | ignore_checks: String.split(ignore_pattern, pattern_split_regex())}
   end
 
   defp add_switch_ignore(exec, _), do: exec


### PR DESCRIPTION
Also fix the `config_comment_format` regex, the `-` needed to be escaped.