### PR TITLE
Link to the credo docs when app is not credo

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -339,7 +339,7 @@ defmodule Credo.Check do
         end
       end
 
-    module_doc = moduledoc(opts, __CALLER__.module)
+    module_doc = moduledoc(opts, __CALLER__.module, Mix.Project.config()[:app])
 
     quote do
       @moduledoc unquote(module_doc)
@@ -503,7 +503,7 @@ defmodule Credo.Check do
     end
   end
 
-  defp moduledoc(opts, module) do
+  defp moduledoc(opts, module, app) do
     explanations = opts[:explanations]
 
     base_priority = opts_to_string(opts[:base_priority]) || 0
@@ -526,13 +526,13 @@ defmodule Credo.Check do
         """
         > #### This check is enabled by default. {: .tip}
         >
-        > [Learn how to disable it](config_file.html#checks) via `.credo.exs`.
+        > [Learn how to disable it](#{credo_docs_uri(app, "config_file.html#checks")}) via `.credo.exs`.
         """
       else
         """
         > #### This check is disabled by default. {: .neutral}
         >
-        > [Learn how to enable it](config_file.html#checks) via `.credo.exs`.
+        > [Learn how to enable it](#{credo_docs_uri(app, "config_file.html#checks")}) via `.credo.exs`.
         """
       end
 
@@ -613,11 +613,14 @@ defmodule Credo.Check do
 
     ## General Parameters
 
-    Like with all checks, [general params](check_params.html) can be applied.
+    Like with all checks, [general params](#{credo_docs_uri(app, "check_params.html")}) can be applied.
 
-    Parameters can be configured via the [`.credo.exs` config file](config_file.html).
+    Parameters can be configured via the [`.credo.exs` config file](#{credo_docs_uri(app, "config_file.html")}).
     """
   end
+
+  defp credo_docs_uri(:credo, path), do: path
+  defp credo_docs_uri(_other_app, path), do: "`e:credo:#{path}`"
 
   defp opts_to_string(value) do
     {result, _} =


### PR DESCRIPTION
The docs didn't link correctly with Credo checks in other libraries because there's just a relative ref to the extra page. This PR will autolink the Credo extra pages references as per: https://hexdocs.pm/ex_doc/readme.html#auto-linking

Unfortunately it doesn't seem that ExDoc understands how to link `e:credo:EXTRA_PAGE.html` correctly when used in the same library. The link just becomes `credo/EXTRA_PAGE.html` instead of `EXTRA_PAGE.html` properly because there's nothing in the deps. So I'm only using the autolink when outside Credo.