### PR TITLE
Use latest Elixir and OTP versions in CI

### DIFF
--- a/.github/workflows/code-scan-sarif.yml
+++ b/.github/workflows/code-scan-sarif.yml
@@ -37,8 +37,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26.2
-          elixir-version: 1.17.3
+          otp-version: 27.3
+          elixir-version: 1.18.3
       - run: mix deps.get
       - run: mix deps.compile
       - run: mix compile

--- a/.github/workflows/housekeeping-bugfix-reproducer.yml
+++ b/.github/workflows/housekeeping-bugfix-reproducer.yml
@@ -14,8 +14,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26.2
-          elixir-version: 1.18.1
+          otp-version: 27.3
+          elixir-version: 1.18.3
 
       - run: git fetch origin master:master
 

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -18,8 +18,8 @@ jobs:
           fetch-depth: 0
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26.2
-          elixir-version: 1.17.3
+          otp-version: 27.3
+          elixir-version: 1.18.3
       - run: mix deps.get
       - run: mix compile
       - run: ./test/check_formatted.sh
@@ -33,8 +33,8 @@ jobs:
           fetch-depth: 0
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26.2
-          elixir-version: 1.17.3
+          otp-version: 27.3
+          elixir-version: 1.18.3
       - run: mix deps.get
       - run: mix test test/credo/check/housekeeping_trigger.exs
 
@@ -47,8 +47,8 @@ jobs:
           fetch-depth: 0
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26.2
-          elixir-version: 1.17.3
+          otp-version: 27.3
+          elixir-version: 1.18.3
       - run: mix deps.get
       - run: mix test test/credo/check/housekeeping_params.exs
 
@@ -61,8 +61,8 @@ jobs:
           fetch-depth: 0
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26.2
-          elixir-version: 1.17.3
+          otp-version: 27.3
+          elixir-version: 1.18.3
       - run: mix deps.get
       - run: ASSERT_TRIGGERS=1 mix test
 
@@ -75,8 +75,8 @@ jobs:
           fetch-depth: 0
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26.2
-          elixir-version: 1.17.3
+          otp-version: 27.3
+          elixir-version: 1.18.3
       - run: mix deps.get
       - run: mix deps.compile 2>&1 | ./test/error_if_warnings.sh
 
@@ -89,8 +89,8 @@ jobs:
           fetch-depth: 0
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26.2
-          elixir-version: 1.17.3
+          otp-version: 27.3
+          elixir-version: 1.18.3
       - run: mix deps.get
       - run: mix credo --mute-exit-status
       - run: mkdir tmp


### PR DESCRIPTION
Got format error in CI I didn't see using Elixir 1.18 in #1190. I'm updating everything in CI here to use the latest elixir/otp versions.