### PR TITLE
fix incorrect call with Inspect.Algebra.format/2 result

### DIFF
--- a/lib/credo/check/design/duplicated_code.ex
+++ b/lib/credo/check/design/duplicated_code.ex
@@ -210,7 +210,7 @@ defmodule Credo.Check.Design.DuplicatedCode do
       ast
       |> Inspect.Algebra.to_doc(%Inspect.Opts{})
       |> Inspect.Algebra.format(80)
-      |> Enum.join("")
+      |> IO.iodata_to_binary()
 
     :sha256
     |> :crypto.hash(string)


### PR DESCRIPTION
According to docs the result of the `Inspect.Algebra.format/2` call could be a list or binary. Therefore `Enum` functions should not be used directly on it.