### PR TITLE
fixes for ABCSize check

### DIFF
--- a/lib/credo/check/refactor/abc_size.ex
+++ b/lib/credo/check/refactor/abc_size.ex
@@ -154,7 +154,22 @@ defmodule Credo.Check.Refactor.ABCSize do
     {nil, acc}
   end
 
+  # ignore unquote calls
+  defp traverse_abc({:unquote, _, [arg]}, acc, _excluded_functions) do
+    {arg, acc}
+  end
+
   # A - assignments
+
+  # always count module attribute call as 1
+  defp traverse_abc(
+         {:@, _meta, _args},
+         [a: a, b: b, c: c, var_names: var_names],
+         _excluded_functions
+       ) do
+    {nil, [a: a + 1, b: b, c: c, var_names: var_names]}
+  end
+
   defp traverse_abc(
          {:=, _meta, [lhs | rhs]},
          [a: a, b: b, c: c, var_names: var_names],

--- a/test/credo/check/refactor/abc_size_test.exs
+++ b/test/credo/check/refactor/abc_size_test.exs
@@ -218,6 +218,33 @@ defmodule Credo.Check.Refactor.ABCSizeTest do
     |> Float.round(2)
   end
 
+  test "it should return the same ABC size with and without unquote call" do
+    with_unquote_source = """
+    def foo do
+      some_var = unquote(5)
+    end
+    """
+
+    without_unquote_source = """
+    def foo do
+      some_var = 5
+    end
+    """
+
+    assert abc_size(with_unquote_source) == abc_size(without_unquote_source)
+  end
+
+  @tag :current
+  test "module attributs should always be counted as 1" do
+    source = """
+    def foo do
+      @attr_name
+    end
+    """
+
+    assert abc_size(source) == 1.0
+  end
+
   test "it should return the correct ABC size for nullary function calls" do
     source = """
     def foo() do


### PR DESCRIPTION
- ignore unquote() calls (used in macros)
- always count module attribute call as 1

fixes #1172