### PR TITLE
Fix default :excluded_paths regex in ModuleDependencies check to exclude first-level test files

### DIFF
--- a/lib/credo/check/refactor/module_dependencies.ex
+++ b/lib/credo/check/refactor/module_dependencies.ex
@@ -7,7 +7,7 @@ defmodule Credo.Check.Refactor.ModuleDependencies do
       max_deps: 10,
       dependency_namespaces: [],
       excluded_namespaces: [],
-      excluded_paths: [~r"/test/", ~r"^test/"]
+      excluded_paths: [~r"/test/", ~r"^test"]
     ],
     explanations: [
       check: """

--- a/test/credo/check/refactor/module_dependencies_test.exs
+++ b/test/credo/check/refactor/module_dependencies_test.exs
@@ -56,6 +56,31 @@ defmodule Credo.Check.Refactor.ModuleDependenciesTest do
     |> refute_issues()
   end
 
+  test "it should NOT report a violation on test path" do
+    """
+    defmodule CredoSampleModule do
+      def some_function() do
+        [
+          DateTime,
+          Kernel,
+          GenServer,
+          GenEvent,
+          File,
+          Time,
+          IO,
+          Logger,
+          URI,
+          Path,
+          String
+        ]
+      end
+    end
+    """
+    |> to_source_file("test/my_test.exs")
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
   test "it should NOT report a violation on umbrella test path" do
     """
     defmodule CredoSampleModule do


### PR DESCRIPTION
The `ModuleDependencies` check was incorrectly triggered on code under the `test`
folder with default settings.

Example:

```shell
mix credo test/supex_test.exs
... 
[F] → Module has too many dependencies: 11 (max is 10)
test/supex_test.exs:1:11 #(SupexTest)
```

Cause: `Path.dirname/1` does not return a trailing `/`, so first-level test files
(e.g. `test/foo_test.exs`) were not excluded
(`lib/credo/check/refactor/module_dependencies.ex:65`).

Fix: Adjusted the default `:excluded_paths` regex to also match first-level test
files.
Added a test to confirm files in `test/` are excluded.

PS: Thanks for this awesome project :)