### PR TITLE
Make MatchInCondition warn on matches that contain conditionals

### DIFF
--- a/test/credo/check/refactor/match_in_condition_test.exs
+++ b/test/credo/check/refactor/match_in_condition_test.exs
@@ -131,6 +131,21 @@ defmodule Credo.Check.Refactor.MatchInConditionTest do
     |> assert_issue()
   end
 
+  test "it should report a violation /4" do
+    """
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        if contents = parameter1.contents && parameter2 do
+          do_something()
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
   test "it should report a violation when wrapped in parens" do
     """
     defmodule CredoSampleModule do


### PR DESCRIPTION
Hi René!

Not sure if this is something you'd want in mainline Credo, but I figured I'd open the PR to start a conversation. Maybe you'd want it, but wrapped in a config?

This makes MatchInCondition slightly more restrictive in response to a bug we ran into at work.

The problematic code started out looking like this:

```elixir
if user_id = post.user_id do
  do_stuff(user_id, post)
end
```

...but was then modified with the intent that we should `do_stuff` only if we both had a user ID _and_ the post was already published:

```elixir
if user_id = post.user_id && post.published? do
  do_stuff(user_id, post)
end
```

That is, of course, not what the code actually does, but neither I, the author, nor two other reviewers caught that `user_id` was going to get assigned the value `true` when we entered the block.

With this change, `MatchInCondition` will be persnickety about cases like these and require you to extract the match out of the conditional.