### PR TITLE
Add StrictModuleDirectiveScope check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -186,6 +186,7 @@
           {Credo.Check.Readability.SinglePipe, []},
           {Credo.Check.Readability.Specs, []},
           {Credo.Check.Readability.StrictModuleLayout, []},
+          {Credo.Check.Readability.StrictModuleDirectiveScope, []},
           {Credo.Check.Readability.WithCustomTaggedTuple, []},
           {Credo.Check.Refactor.ABCSize, []},
           {Credo.Check.Refactor.AppendSingleItem, []},

--- a/lib/credo/check/readability/strict_module_directive_scope.ex
+++ b/lib/credo/check/readability/strict_module_directive_scope.ex
@@ -1,0 +1,443 @@
+defmodule Credo.Check.Readability.StrictModuleDirectiveScope do
+  use Credo.Check,
+    id: "EX5027",
+    base_priority: :low,
+    category: :readability,
+    tags: [:controversial],
+    param_defaults: [
+      directives: [:alias, :require, :import, :use],
+      allow_in_private_functions: false,
+      allow_in_test_macros: true,
+      allow_in_quote_blocks: true,
+      exclude_functions: []
+    ],
+    explanations: [
+      check: """
+      Module directives should be defined at the module level, not inside functions.
+
+      Module directives (`alias`, `require`, `import`, `use`) that appear inside
+      function bodies can make code harder to follow and obscure module dependencies.
+      By requiring all directives to be declared at the module level, readers can
+      quickly understand a module's dependencies by looking at the top of the file.
+
+      ## Preferred Style
+
+          defmodule MyModule do
+            alias MyApp.DataProcessor
+            alias MyApp.Validator
+            require Logger
+
+            def process_data(data) do
+              data
+              |> Validator.validate()
+              |> DataProcessor.process()
+              |> tap(&Logger.info("Processed: \#{inspect(&1)}"))
+            end
+          end
+
+      ## Not Preferred
+
+          defmodule MyModule do
+            def process_data(data) do
+              alias MyApp.DataProcessor
+              alias MyApp.Validator
+              require Logger
+
+              data
+              |> Validator.validate()
+              |> DataProcessor.process()
+              |> tap(&Logger.info("Processed: \#{inspect(&1)}"))
+            end
+          end
+
+      Like all `Readability` issues, this is not a technical concern.
+      But you can improve the odds of others reading and liking your code by making
+      it easier to follow.
+
+      ## Rationale
+
+      1. **Discoverability**: All module dependencies are visible at the top of the file
+      2. **Consistency**: Predictable module structure across the codebase
+      3. **Refactoring**: Easier to move code between functions
+      4. **Code Review**: Dependencies are clear in pull request diffs
+      5. **Tooling**: Better support for editor jump-to-definition
+
+      ## When to Opt-In
+
+      This check is marked as controversial and disabled by default because some teams
+      and use cases legitimately prefer inline directives:
+
+      - **Namespace scoping**: Limiting alias scope to where it's needed
+      - **Phoenix LiveView components**: Inline aliases in render functions
+      - **Test organization**: Grouping test-specific aliases with tests
+      - **Macro hygiene**: Keeping macro-internal dependencies localized
+
+      Enable this check if your team values explicit, discoverable dependencies over
+      tightly-scoped imports.
+
+      ## Configuration Example
+
+      To enable this check in your project:
+
+          # In .credo.exs
+          {Credo.Check.Readability.StrictModuleDirectiveScope, [
+            directives: [:alias, :require],  # Only check these two
+            allow_in_private_functions: true,
+            exclude_functions: [~r/^render/]  # Allow in LiveView render functions
+          ]}
+      """,
+      params: [
+        directives: """
+        List of directive types to check. Defaults to all four directives.
+
+        Supported values: `:alias`, `:require`, `:import`, `:use`
+        """,
+        allow_in_private_functions: """
+        When set to `true`, allows module directives inside private functions.
+
+        Some teams prefer to allow inline directives in private functions to keep
+        internal implementation details scoped.
+        """,
+        allow_in_test_macros: """
+        When set to `true`, allows module directives inside test macros like
+        `setup`, `describe`, and `test`.
+
+        Test code often benefits from localized imports for test-specific helpers.
+        """,
+        allow_in_quote_blocks: """
+        When set to `true`, allows module directives inside `quote` blocks.
+
+        Macros that generate code for their callers often need directives in
+        quote blocks. This should generally remain `true`.
+        """,
+        exclude_functions: """
+        List of regular expressions matching function names to exclude from checking.
+
+        Example: `[~r/^render/, ~r/_test$/]` would skip functions starting with
+        "render" or ending with "_test".
+        """
+      ]
+    ]
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    config = %{
+      directives: Params.get(params, :directives, __MODULE__),
+      allow_private: Params.get(params, :allow_in_private_functions, __MODULE__),
+      allow_test_macros: Params.get(params, :allow_in_test_macros, __MODULE__),
+      allow_quote_blocks: Params.get(params, :allow_in_quote_blocks, __MODULE__),
+      exclude_functions: Params.get(params, :exclude_functions, __MODULE__)
+    }
+
+    issue_meta = IssueMeta.for(source_file, params)
+
+    source_file
+    |> Credo.Code.prewalk(&traverse(&1, &2, config, issue_meta))
+    |> Enum.sort_by(&{&1.line_no, &1.column})
+  end
+
+  # Module definition - don't traverse into nested modules
+  defp traverse({:defmodule, _meta, _args} = ast, issues, _config, _issue_meta) do
+    {ast, issues}
+  end
+
+  # Function definitions (def, defp, defmacro, defmacrop)
+  # This is where we check for inline directives
+  defp traverse({fun_type, _meta, args} = ast, issues, config, issue_meta)
+       when fun_type in [:def, :defp, :defmacro, :defmacrop] and is_list(args) do
+    is_private = fun_type in [:defp, :defmacrop]
+    fun_name = extract_function_name(args)
+
+    # Skip if configured to allow
+    skip_private = is_private and config.allow_private
+    skip_excluded = is_excluded_function?(fun_name, config.exclude_functions)
+
+    if skip_private or skip_excluded do
+      {ast, issues}
+    else
+      # Create context for this function
+      context = %{
+        in_function: {fun_type, fun_name},
+        in_test_macro: false,
+        in_quote_block: false
+      }
+
+      # Find all directive issues in this function's body
+      new_issues = find_all_directive_issues(args, config, context, issue_meta)
+
+      # Return nil to prevent prewalk from descending (avoid duplicate detection)
+      {nil, new_issues ++ issues}
+    end
+  end
+
+  # Catch-all: continue traversing
+  defp traverse(ast, issues, _config, _issue_meta) do
+    {ast, issues}
+  end
+
+  # Extract function name from function definition args
+  defp extract_function_name([{:when, _, [{name, _, _} | _]} | _]) when is_atom(name), do: name
+  defp extract_function_name([{name, _, _} | _]) when is_atom(name), do: name
+  defp extract_function_name(_), do: :unknown
+
+  # Check if function name matches any exclusion pattern
+  defp is_excluded_function?(_fun_name, []), do: false
+
+  defp is_excluded_function?(fun_name, exclusion_patterns) when is_atom(fun_name) do
+    fun_string = Atom.to_string(fun_name)
+
+    Enum.any?(exclusion_patterns, fn
+      %Regex{} = pattern -> Regex.match?(pattern, fun_string)
+      _ -> false
+    end)
+  end
+
+  defp is_excluded_function?(_, _), do: false
+
+  # Find all directive issues in function args (handles all clause types)
+  defp find_all_directive_issues([_signature | keyword_blocks], config, context, issue_meta)
+       when is_list(keyword_blocks) do
+    keyword_blocks
+    |> List.first([])
+    |> Enum.flat_map(fn
+      {:do, body} ->
+        find_directives_in_body(body, config, context, issue_meta)
+
+      {clause_type, body} when clause_type in [:rescue, :catch, :after, :else] ->
+        find_directives_in_body(body, config, context, issue_meta)
+
+      _ ->
+        []
+    end)
+  end
+
+  defp find_all_directive_issues(_, _, _, _), do: []
+
+  # Find directives in a block of code
+  defp find_directives_in_body({:__block__, _meta, expressions}, config, context, issue_meta)
+       when is_list(expressions) do
+    Enum.flat_map(expressions, &check_expression(&1, config, context, issue_meta))
+  end
+
+  defp find_directives_in_body(expression, config, context, issue_meta) do
+    check_expression(expression, config, context, issue_meta)
+  end
+
+  # Check a single expression for directives
+  defp check_expression({directive, meta, args}, config, context, issue_meta)
+       when directive in [:alias, :require, :import, :use] do
+    # Check if we should report this directive
+    should_check =
+      directive in config.directives and
+        not context.in_test_macro and
+        not context.in_quote_block
+
+    if should_check do
+      [create_issue(directive, meta, args, context.in_function, issue_meta)]
+    else
+      []
+    end
+  end
+
+  # Recursively check nested control structures
+
+  # if/unless
+  defp check_expression({control, _meta, [_condition, clauses]}, config, context, issue_meta)
+       when control in [:if, :unless] do
+    check_clauses(clauses, config, context, issue_meta)
+  end
+
+  # case
+  defp check_expression({:case, _meta, [_value, [do: clauses]]}, config, context, issue_meta) do
+    Enum.flat_map(clauses, fn {:->, _, [_pattern, body]} ->
+      find_directives_in_body(body, config, context, issue_meta)
+    end)
+  end
+
+  # cond
+  defp check_expression({:cond, _meta, [[do: clauses]]}, config, context, issue_meta) do
+    Enum.flat_map(clauses, fn {:->, _, [_condition, body]} ->
+      find_directives_in_body(body, config, context, issue_meta)
+    end)
+  end
+
+  # with
+  defp check_expression({:with, _meta, args}, config, context, issue_meta) do
+    {clauses, do_else} = Enum.split_while(args, fn arg -> not is_list(arg) end)
+
+    do_else_issues =
+      case do_else do
+        [[do: do_body]] ->
+          find_directives_in_body(do_body, config, context, issue_meta)
+
+        [[do: do_body, else: else_clauses]] ->
+          find_directives_in_body(do_body, config, context, issue_meta) ++
+            Enum.flat_map(else_clauses, fn {:->, _, [_pattern, body]} ->
+              find_directives_in_body(body, config, context, issue_meta)
+            end)
+
+        _ ->
+          []
+      end
+
+    # Also check in with clause bodies (right side of <-)
+    clause_issues =
+      Enum.flat_map(clauses, fn
+        {:<-, _meta, [_left, right]} ->
+          find_directives_in_body(right, config, context, issue_meta)
+
+        _other ->
+          []
+      end)
+
+    clause_issues ++ do_else_issues
+  end
+
+  # try
+  defp check_expression({:try, _meta, [[do: do_body] ++ other_clauses]}, config, context, issue_meta) do
+    do_issues = find_directives_in_body(do_body, config, context, issue_meta)
+
+    other_issues =
+      Enum.flat_map(other_clauses, fn
+        {:rescue, rescue_clauses} ->
+          Enum.flat_map(rescue_clauses, fn {:->, _, [_pattern, body]} ->
+            find_directives_in_body(body, config, context, issue_meta)
+          end)
+
+        {:catch, catch_clauses} ->
+          Enum.flat_map(catch_clauses, fn {:->, _, [_pattern, body]} ->
+            find_directives_in_body(body, config, context, issue_meta)
+          end)
+
+        {:after, after_body} ->
+          find_directives_in_body(after_body, config, context, issue_meta)
+
+        {:else, else_clauses} ->
+          Enum.flat_map(else_clauses, fn {:->, _, [_pattern, body]} ->
+            find_directives_in_body(body, config, context, issue_meta)
+          end)
+
+        _ ->
+          []
+      end)
+
+    do_issues ++ other_issues
+  end
+
+  # Quote blocks - update context
+  defp check_expression({:quote, _meta, quote_args}, config, context, issue_meta) do
+    if config.allow_quote_blocks do
+      []
+    else
+      # Check inside quote with updated context
+      new_context = %{context | in_quote_block: true}
+
+      case quote_args do
+        [_opts, [do: body]] -> find_directives_in_body(body, config, new_context, issue_meta)
+        [[do: body]] -> find_directives_in_body(body, config, new_context, issue_meta)
+        _ -> []
+      end
+    end
+  end
+
+  # Test macros - update context
+  defp check_expression({test_macro, _meta, macro_args}, config, context, issue_meta)
+       when test_macro in [:setup, :setup_all, :test, :describe] do
+    if config.allow_test_macros do
+      []
+    else
+      # Check inside test macro with updated context
+      new_context = %{context | in_test_macro: true}
+
+      case macro_args do
+        [_name, [do: body]] -> find_directives_in_body(body, config, new_context, issue_meta)
+        [[do: body]] -> find_directives_in_body(body, config, new_context, issue_meta)
+        _ -> []
+      end
+    end
+  end
+
+  # Anonymous functions
+  defp check_expression({:fn, _meta, clauses}, config, context, issue_meta) do
+    Enum.flat_map(clauses, fn {:->, _, [_params, body]} ->
+      find_directives_in_body(body, config, context, issue_meta)
+    end)
+  end
+
+  # for comprehensions
+  defp check_expression({:for, _meta, args}, config, context, issue_meta) do
+    case List.last(args) do
+      [do: body] -> find_directives_in_body(body, config, context, issue_meta)
+      _ -> []
+    end
+  end
+
+  # Other expressions - don't check
+  defp check_expression(_other, _config, _context, _issue_meta) do
+    []
+  end
+
+  # Check clauses (for if/unless)
+  defp check_clauses(clauses, config, context, issue_meta) do
+    Enum.flat_map(clauses, fn
+      {:do, body} -> find_directives_in_body(body, config, context, issue_meta)
+      {:else, body} -> find_directives_in_body(body, config, context, issue_meta)
+      _ -> []
+    end)
+  end
+
+  # Create issue for a directive found in a function
+  defp create_issue(directive, meta, args, {fun_type, fun_name}, issue_meta) do
+    directive_name = directive_display_name(directive, args)
+    fun_description = function_description(fun_type, fun_name)
+
+    format_issue(issue_meta,
+      message:
+        "#{directive_name} should be defined at module level, not inside #{fun_description}",
+      line_no: meta[:line],
+      column: meta[:column],
+      trigger: Atom.to_string(directive)
+    )
+  end
+
+  # Get display name for directive (e.g., "Alias Foo.Bar" or "Require Logger")
+  defp directive_display_name(directive, args) do
+    module_name =
+      case args do
+        [{:__aliases__, _, aliases} | _] ->
+          aliases |> Enum.map(&Atom.to_string/1) |> Enum.join(".")
+
+        [{:__aliases__, _, aliases}, _opts | _] ->
+          aliases |> Enum.map(&Atom.to_string/1) |> Enum.join(".")
+
+        [atom | _] when is_atom(atom) ->
+          Atom.to_string(atom)
+
+        _ ->
+          ""
+      end
+
+    directive_str = directive |> Atom.to_string() |> String.capitalize()
+
+    if module_name != "" do
+      "#{directive_str} #{module_name}"
+    else
+      directive_str
+    end
+  end
+
+  # Get human-readable function description
+  defp function_description(fun_type, fun_name) do
+    type_str =
+      case fun_type do
+        :defp -> "private function"
+        :defmacrop -> "private macro"
+        :defmacro -> "macro"
+        :def -> "function"
+        _ -> "function"
+      end
+
+    "#{type_str} #{fun_name}"
+  end
+end

--- a/test/credo/check/readability/strict_module_directive_scope_test.exs
+++ b/test/credo/check/readability/strict_module_directive_scope_test.exs
@@ -1,0 +1,1024 @@
+defmodule Credo.Check.Readability.StrictModuleDirectiveScopeTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Readability.StrictModuleDirectiveScope
+
+  describe "module-level directives" do
+    test "allows directives at module level" do
+      """
+      defmodule CredoSampleModule do
+        alias Foo.Bar
+        require Logger
+        import Enum
+        use GenServer
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "allows nested module with its own directives" do
+      """
+      defmodule CredoSampleModule do
+        alias Foo
+
+        defmodule Nested do
+          alias Bar
+          require Logger
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+  end
+
+  describe "basic function-level directives" do
+    test "reports alias in public function" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def process do
+            alias Foo.Bar
+            Bar.do_something()
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Alias Foo.Bar should be defined at module level, not inside function process"
+      assert issue.trigger == "alias"
+      assert issue.line_no == 3
+    end
+
+    test "reports require in public function" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def log_it do
+            require Logger
+            Logger.info("test")
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Require Logger should be defined at module level, not inside function log_it"
+    end
+
+    test "reports import in public function" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def process(list) do
+            import Enum
+            map(list, & &1 * 2)
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Import Enum should be defined at module level, not inside function process"
+    end
+
+    test "reports use in public function" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def setup do
+            use MyBehaviour
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Use MyBehaviour should be defined at module level, not inside function setup"
+    end
+
+    test "reports alias in private function by default" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          defp helper do
+            alias Foo.Bar
+            Bar.help()
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message ==
+               "Alias Foo.Bar should be defined at module level, not inside private function helper"
+    end
+
+    test "reports directive in macro" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          defmacro create_thing do
+            require Logger
+            Logger.info("creating")
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Require Logger should be defined at module level, not inside macro create_thing"
+    end
+
+    test "reports multiple directives in same function" do
+      assert [issue1, issue2] =
+               """
+               defmodule CredoSampleModule do
+                 def process do
+                   alias Foo.Bar
+                   require Logger
+                   Logger.info("processing")
+                   Bar.process()
+                 end
+               end
+               """
+               |> to_source_file()
+               |> run_check(@described_check)
+               |> assert_issues()
+
+      assert issue1.message == "Alias Foo.Bar should be defined at module level, not inside function process"
+      assert issue2.message == "Require Logger should be defined at module level, not inside function process"
+    end
+  end
+
+  describe "nested control structures" do
+    test "reports alias in if block" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def check(x) do
+            if x > 10 do
+              alias Foo.Bar
+              Bar.process(x)
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Alias Foo.Bar should be defined at module level, not inside function check"
+    end
+
+    test "reports alias in else block" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def check(x) do
+            if x > 10 do
+              :ok
+            else
+              alias Foo.Bar
+              Bar.process(x)
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Alias Foo.Bar should be defined at module level, not inside function check"
+    end
+
+    test "reports alias in case clause" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def handle(msg) do
+            case msg do
+              :ok ->
+                alias Foo.Success
+                Success.handle()
+
+              :error ->
+                :error
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Alias Foo.Success should be defined at module level, not inside function handle"
+    end
+
+    test "reports alias in cond clause" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def check(x) do
+            cond do
+              x > 10 ->
+                alias Foo.Big
+                Big.process(x)
+
+              true ->
+                :small
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Alias Foo.Big should be defined at module level, not inside function check"
+    end
+
+    test "reports alias in with statement do block" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def process(data) do
+            with {:ok, value} <- fetch(data) do
+              alias Foo.Processor
+              Processor.process(value)
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Alias Foo.Processor should be defined at module level, not inside function process"
+    end
+
+    test "reports alias in with statement else block" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def process(data) do
+            with {:ok, value} <- fetch(data) do
+              :ok
+            else
+              :error ->
+                alias Foo.ErrorHandler
+                ErrorHandler.handle()
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Alias Foo.ErrorHandler should be defined at module level, not inside function process"
+    end
+
+    test "reports alias in try-rescue block" do
+      assert [issue1, issue2] =
+               """
+               defmodule CredoSampleModule do
+                 def process do
+                   try do
+                     alias Foo.Worker
+                     Worker.do_risky_thing()
+                   rescue
+                     e in RuntimeError ->
+                       alias Foo.ErrorHandler
+                       ErrorHandler.handle(e)
+                   end
+                 end
+               end
+               """
+               |> to_source_file()
+               |> run_check(@described_check)
+               |> assert_issues()
+
+      assert issue1.message == "Alias Foo.Worker should be defined at module level, not inside function process"
+      assert issue2.message == "Alias Foo.ErrorHandler should be defined at module level, not inside function process"
+    end
+
+    test "reports alias in try-catch block" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def process do
+            try do
+              risky_thing()
+            catch
+              :error, reason ->
+                alias Foo.ErrorHandler
+                ErrorHandler.handle(reason)
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Alias Foo.ErrorHandler should be defined at module level, not inside function process"
+    end
+
+    test "reports alias in try-after block" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def process do
+            try do
+              risky_thing()
+            after
+              alias Foo.Cleanup
+              Cleanup.cleanup()
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Alias Foo.Cleanup should be defined at module level, not inside function process"
+    end
+  end
+
+  describe "multi-clause functions" do
+    test "reports alias in multiple clauses" do
+      assert [issue1, issue2] =
+               """
+               defmodule CredoSampleModule do
+                 def handle(:ok) do
+                   alias Foo.Success
+                   Success.handle()
+                 end
+
+                 def handle(:error) do
+                   alias Foo.Failure
+                   Failure.handle()
+                 end
+               end
+               """
+               |> to_source_file()
+               |> run_check(@described_check)
+               |> assert_issues()
+
+      assert issue1.message == "Alias Foo.Success should be defined at module level, not inside function handle"
+      assert issue2.message == "Alias Foo.Failure should be defined at module level, not inside function handle"
+    end
+
+    test "reports alias in when guards" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def handle(x) when is_integer(x) do
+            alias Foo.Bar
+            Bar.handle(x)
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message == "Alias Foo.Bar should be defined at module level, not inside function handle"
+    end
+  end
+
+  describe "configuration: directives" do
+    test "only checks specified directives" do
+      """
+      defmodule CredoSampleModule do
+        def process do
+          alias Foo.Bar
+          require Logger
+          import Enum
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check, directives: [:alias])
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Alias Foo.Bar"
+      end)
+    end
+
+    test "checks multiple specified directives" do
+      assert [issue1, issue2] =
+               """
+               defmodule CredoSampleModule do
+                 def process do
+                   alias Foo.Bar
+                   require Logger
+                   import Enum
+                   use GenServer
+                 end
+               end
+               """
+               |> to_source_file()
+               |> run_check(@described_check, directives: [:alias, :use])
+               |> assert_issues()
+
+      assert issue1.message =~ "Alias Foo.Bar"
+      assert issue2.message =~ "Use GenServer"
+    end
+
+    test "ignores directives not in the list" do
+      """
+      defmodule CredoSampleModule do
+        def process do
+          require Logger
+          import Enum
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check, directives: [:alias, :use])
+      |> refute_issues()
+    end
+  end
+
+  describe "configuration: allow_in_private_functions" do
+    test "allows directives in private functions when configured" do
+      """
+      defmodule CredoSampleModule do
+        defp helper do
+          alias Foo.Bar
+          require Logger
+          Bar.help()
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check, allow_in_private_functions: true)
+      |> refute_issues()
+    end
+
+    test "still checks public functions when private allowed" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def public_fun do
+            alias Foo.Bar
+            Bar.help()
+          end
+
+          defp private_fun do
+            alias Foo.Baz
+            Baz.help()
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check, allow_in_private_functions: true)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias Foo.Bar"
+      assert issue.message =~ "function public_fun"
+    end
+
+    test "allows directives in private macros when configured" do
+      """
+      defmodule CredoSampleModule do
+        defmacrop helper do
+          alias Foo.Bar
+          quote do: Bar.help()
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check, allow_in_private_functions: true)
+      |> refute_issues()
+    end
+  end
+
+  describe "configuration: allow_in_test_macros" do
+    test "allows directives in setup block by default" do
+      """
+      defmodule CredoSampleModuleTest do
+        use ExUnit.Case
+
+        setup do
+          alias MyApp.Factory
+          {:ok, user: Factory.insert(:user)}
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "allows directives in test block by default" do
+      """
+      defmodule CredoSampleModuleTest do
+        use ExUnit.Case
+
+        test "something works" do
+          alias MyApp.Helper
+          assert Helper.works?()
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "allows directives in describe block by default" do
+      """
+      defmodule CredoSampleModuleTest do
+        use ExUnit.Case
+
+        describe "feature" do
+          alias MyApp.Feature
+
+          test "works" do
+            assert Feature.works?()
+          end
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "reports directives in test blocks when configured strict" do
+      [issue] =
+        """
+        defmodule CredoSampleModuleTest do
+          use ExUnit.Case
+
+          test "something works" do
+            alias MyApp.Helper
+            assert Helper.works?()
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check, allow_in_test_macros: false)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias MyApp.Helper"
+    end
+  end
+
+  describe "configuration: allow_in_quote_blocks" do
+    test "allows directives in quote blocks by default" do
+      """
+      defmodule CredoSampleModule do
+        defmacro create_thing do
+          quote do
+            alias Foo.Bar
+            Bar.create()
+          end
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "reports directives outside quote in macro" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          defmacro create_thing do
+            alias Foo.Helper
+            Helper.validate()
+
+            quote do
+              create_the_thing()
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias Foo.Helper"
+      assert issue.message =~ "macro create_thing"
+    end
+
+    test "reports directives in quote blocks when configured strict" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          defmacro create_thing do
+            quote do
+              alias Foo.Bar
+              Bar.create()
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check, allow_in_quote_blocks: false)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias Foo.Bar"
+    end
+  end
+
+  describe "configuration: exclude_functions" do
+    test "excludes functions matching regex pattern" do
+      """
+      defmodule CredoSampleModule do
+        def render_form do
+          alias MyAppWeb.Components
+          Components.form()
+        end
+
+        def process do
+          alias Foo.Bar
+          Bar.process()
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check, exclude_functions: [~r/^render/])
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Alias Foo.Bar"
+        assert issue.message =~ "function process"
+      end)
+    end
+
+    test "excludes multiple function patterns" do
+      """
+      defmodule CredoSampleModule do
+        def render_form do
+          alias MyAppWeb.Components
+          Components.form()
+        end
+
+        def helper_test do
+          alias Test.Helper
+          Helper.help()
+        end
+
+        def process do
+          alias Foo.Bar
+          Bar.process()
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check, exclude_functions: [~r/^render/, ~r/_test$/])
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Alias Foo.Bar"
+        assert issue.message =~ "function process"
+      end)
+    end
+
+    test "handles empty exclusion list" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def render do
+            alias Foo
+            Foo.bar()
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check, exclude_functions: [])
+        |> assert_issue()
+
+      assert issue.message =~ "Alias Foo"
+    end
+  end
+
+  describe "edge cases" do
+    test "handles functions with no body" do
+      """
+      defmodule CredoSampleModule do
+        def foo
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "handles functions with single expression body" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def foo, do: (alias Foo; Foo.bar())
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias Foo"
+    end
+
+    test "handles empty modules" do
+      """
+      defmodule CredoSampleModule do
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "handles modules with only module attributes" do
+      """
+      defmodule CredoSampleModule do
+        @moduledoc "docs"
+        @foo 42
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "reports directive without explicit module name" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def foo do
+            alias __MODULE__.Bar
+            Bar.baz()
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias"
+      assert issue.trigger == "alias"
+    end
+  end
+
+  describe "anonymous functions and comprehensions" do
+    test "reports alias in anonymous function" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def process(data) do
+            Enum.map(data, fn x ->
+              alias Foo.Processor
+              Processor.process(x)
+            end)
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias Foo.Processor"
+      assert issue.message =~ "function process"
+    end
+
+    test "reports alias in for comprehension" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def process(items) do
+            for x <- items do
+              alias Foo.Processor
+              Processor.process(x)
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias Foo.Processor"
+      assert issue.message =~ "function process"
+    end
+
+    test "reports alias in unless block" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def check(x) do
+            unless x > 10 do
+              alias Foo.Small
+              Small.process(x)
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias Foo.Small"
+      assert issue.message =~ "function check"
+    end
+
+    test "reports alias in nested anonymous function" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def transform(data) do
+            Enum.map(data, fn item ->
+              Enum.map(item.children, fn child ->
+                alias Foo.Transform
+                Transform.apply(child)
+              end)
+            end)
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias Foo.Transform"
+    end
+
+    test "reports multiple directives in for comprehension" do
+      assert [issue1, issue2] =
+               """
+               defmodule CredoSampleModule do
+                 def process(items) do
+                   for x <- items do
+                     alias Foo.Validator
+                     require Logger
+                     Logger.debug("Processing")
+                     Validator.validate(x)
+                   end
+                 end
+               end
+               """
+               |> to_source_file()
+               |> run_check(@described_check)
+               |> assert_issues()
+
+      assert issue1.message =~ "Alias Foo.Validator"
+      assert issue2.message =~ "Require Logger"
+    end
+  end
+
+  describe "alias with options" do
+    test "reports alias with :as option" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def process do
+            alias Foo.Bar, as: Baz
+            Baz.process()
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias Foo.Bar"
+      assert issue.message =~ "function process"
+    end
+
+    test "reports import with :only option" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def process(list) do
+            import Enum, only: [map: 2]
+            map(list, & &1 * 2)
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Import Enum"
+      assert issue.message =~ "function process"
+    end
+
+    test "reports require with :as option" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def log do
+            require Logger, as: L
+            L.info("test")
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Require Logger"
+      assert issue.message =~ "function log"
+    end
+  end
+
+  describe "real-world patterns" do
+    test "LiveView component with inline aliases" do
+      [issue] =
+        """
+        defmodule MyAppWeb.UserComponent do
+          use Phoenix.LiveComponent
+
+          def render(assigns) do
+            alias MyAppWeb.Components.Avatar
+
+            ~H\"\"\"
+            <div>
+              <Avatar.render user={@user} />
+            </div>
+            \"\"\"
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Alias MyAppWeb.Components.Avatar"
+    end
+
+    test "allows LiveView render when excluded" do
+      """
+      defmodule MyAppWeb.UserComponent do
+        use Phoenix.LiveComponent
+
+        def render(assigns) do
+          alias MyAppWeb.Components.Avatar
+
+          ~H\"\"\"
+          <div>
+            <Avatar.render user={@user} />
+          </div>
+          \"\"\"
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check, exclude_functions: [~r/^render/])
+      |> refute_issues()
+    end
+
+    test "test helper with setup block" do
+      """
+      defmodule MyAppTest do
+        use ExUnit.Case
+
+        setup do
+          alias MyApp.Factory
+          alias MyApp.Repo
+
+          {:ok, user: Factory.insert(:user), repo: Repo}
+        end
+
+        test "creates user" do
+          alias MyApp.Users
+          assert Users.create(%{name: "John"})
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "conditional requires in function" do
+      [issue] =
+        """
+        defmodule CredoSampleModule do
+          def maybe_log(condition, msg) do
+            if condition do
+              require Logger
+              Logger.info(msg)
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(@described_check)
+        |> assert_issue()
+
+      assert issue.message =~ "Require Logger"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds a new opt-in readability check `StrictModuleDirectiveScope` that encourages declaring module directives (`alias`, `require`, `import`, `use`) at the module level rather than inside function bodies.

Closes #1222

## Motivation

Inline directives can make code harder to follow and obscure module dependencies. By requiring all directives at the module level, readers can quickly understand a module's dependencies by looking at the top of the file.

This addresses the need described in #1222 for teams that value explicit, discoverable dependencies over tightly-scoped imports.

## Implementation

The check detects directives in:
- All function types (def, defp, defmacro, defmacrop)
- All control structures (if/unless/case/cond/with/try)
- Anonymous functions
- For comprehensions

## Configuration Options

- `directives` - List of directive types to check (default: all four)
- `allow_in_private_functions` - Skip checking private functions (default: false)
- `allow_in_test_macros` - Skip checking test blocks (default: true)
- `allow_in_quote_blocks` - Skip checking quote blocks (default: true)
- `exclude_functions` - Regex patterns to exclude specific functions

## Example

```elixir
# Will trigger issue
defmodule MyModule do
  def process_data(data) do
    alias MyApp.DataProcessor
    DataProcessor.process(data)
  end
end

# Preferred style
defmodule MyModule do
  alias MyApp.DataProcessor
  
  def process_data(data) do
    DataProcessor.process(data)
  end
end
```

## Configuration Example

```elixir
# In .credo.exs
{Credo.Check.Readability.StrictModuleDirectiveScope, [
  directives: [:alias, :require],  # Only check these two
  allow_in_private_functions: true,
  exclude_functions: [~r/^render/]  # Allow in LiveView render functions
]}
```

## Test Coverage

- 37 test cases covering all directive types, control structures, and configuration options
- Tests for real-world patterns (LiveView, ExUnit test blocks)
- Edge case handling (anonymous functions, comprehensions, nested structures)

## Checklist

- [x] Implementation follows Credo check patterns
- [x] Comprehensive test suite with 37+ test cases
- [x] Check registered in .credo.exs as disabled/opt-in
- [x] Extensive documentation with rationale and examples
- [x] Marked as controversial (disabled by default)
- [x] Configuration examples provided