### PR TITLE
Fix order of params in example

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -78,7 +78,7 @@ defmodule Credo.Check do
             |> do_something_crazy()
             |> do_something_crazier()
 
-          append_issues_and_timings(exec, issues)
+          append_issues_and_timings(issues, exec)
 
           :ok
         end


### PR DESCRIPTION
While implementing a custom check, I stumbled upon this error:

```elixir
** (FunctionClauseError) no function clause matching in Credo.Execution.ExecutionIssues.append/2                                                                                                                 
      (credo 1.7.12) lib/credo/execution/execution_issues.ex:17: Credo.Execution.ExecutionIssues.append([%Credo.Issue{...}], %Credo.Execution{...})
```

I figured out that there is an error in the `@doc`-comment for the `run_on_all_source_files`-callback in `Credo.Check`.

The `append_issues_and_timings` function wants the issues first and then the execution:

https://github.com/rrrene/credo/blob/55d31c2e4cefac1fdba13c0cbda09ccc7fbeddd3/lib/credo/check.ex#L460-L462