### PR TITLE
Parallelize ConfigCommentFinder to significantly reduce runtime on large projects

### DIFF
--- a/lib/credo/check/config_comment_finder.ex
+++ b/lib/credo/check/config_comment_finder.ex
@@ -12,7 +12,8 @@ defmodule Credo.Check.ConfigCommentFinder do
   @doc false
   def run(source_files) when is_list(source_files) do
     source_files
-    |> Enum.map(&find_and_set_in_source_file/1)
+    |> Task.async_stream(&find_and_set_in_source_file/1, ordered: false, timeout: :infinity)
+    |> Enum.map(fn {:ok, value} -> value end)
     |> Enum.reject(&is_nil/1)
   end
 


### PR DESCRIPTION
On my project with ~3,500 source files running on my M4 Max MacBook Pro, I was seeing `ConfigCommentFinder` take about 14 seconds to run (roughly half of the overall ~30 second runtime of `mix credo`).

With this PR, rather than processing each file individually, Credo will parallelize this processing across all schedulers. With this change, the runtime for this step dropped to about 2.5 seconds on my machine, reducing the overall runtime of `mix credo` by about 40%.