### PR TITLE
Fix ExpensiveEnumCheck suggestion when the trigger is within a guard

### DIFF
--- a/test/credo/check/warning/expensive_empty_enum_check_test.exs
+++ b/test/credo/check/warning/expensive_empty_enum_check_test.exs
@@ -598,4 +598,19 @@ defmodule Credo.Check.Warning.ExpensiveEmptyEnumCheckTest do
       |> refute_issues()
     end
   end
+
+  test "finds issues in both guards and function body" do
+    """
+    defmodule Test do
+      def test(enum) when length(enum) == 0 do
+        length(enum) > 0
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issues(fn issues ->
+      assert length(issues) == 2
+    end)
+  end
 end


### PR DESCRIPTION
This PR makes the suggestions given by ExpensiveEnumCheck more specific to the context:

- When a `length/1` call is in a guard, it says "Using `length/1` is expensive, prefer comparing against the empty list."
- When it's in the body of a function, it says "Using `length/1` is expensive, prefer `Enum.empty?/1`.

I've also significantly beefed up the tests around guards to make sure we're covering all the desired cases.

Resolves #1229