### PR TITLE
Speed up exclusions when they don't need to touch the filesystem

### DIFF
--- a/lib/credo/check/params.ex
+++ b/lib/credo/check/params.ex
@@ -110,10 +110,13 @@ defmodule Credo.Check.Params do
   end
 
   @doc false
-  def files_included(params, check_mod) do
+  def files_included(params, check_mod, known_files) do
     files = get(params, :__files__, check_mod) || get(params, :files, check_mod)
 
-    List.wrap(files[:included])
+    case files[:included] do
+      nil -> known_files
+      included -> included
+    end
   end
 
   @doc false

--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -189,6 +189,9 @@ defmodule Credo.Sources do
   defp recurse_path(path) do
     paths =
       cond do
+        non_wildcard_elixir_file_path?(path) ->
+          [path]
+
         File.regular?(path) ->
           [path]
 
@@ -204,6 +207,13 @@ defmodule Credo.Sources do
       end
 
     Enum.map(paths, &Path.expand/1)
+  end
+
+  defp non_wildcard_elixir_file_path?(path) do
+    # If the path is an Elixir file and contains none of the wildcard characters
+    # documented in Path.wildcard/1, we should avoid hitting the filesystem entirely.
+    wildcard_characters = ["*", "{", "}", "?", "[", "]"]
+    String.ends_with?(path, [".ex", ".exs"]) and not String.contains?(path, wildcard_characters)
   end
 
   defp read_files(filenames, parse_timeout) do


### PR DESCRIPTION
On a large project (~3500 files), I had a check configured with some very simple exclusions like this:

```elixir
{Credo.Check.Warning.ForbiddenModule,
  files: %{
    excluded: [
      "lib/foo.ex",
      "lib/foo_test.exs"
    ]
  }
```

(Note the absence of globs or anything that might need recursive directory traversal)

When adding these exclusions, I was seeing the runtime for those individual checks balloon from a couple hundred milliseconds to nearly 3 seconds each.

Upon investigation, I discovered it was because we were hitting this code in `Credo.Check.Runner` when determining which files to include:

```
exec
|> Execution.working_dir()
|> Credo.Sources.find_in_dir(files_included, files_excluded)
```

When the included list was empty, it was doing a full, recursive directory traversal to find all `.ex` and `.exs` files in the project, and doing so took about 2.5 seconds on my M4 Max MacBook Pro.

This PR vastly improves that time by providing the list of all (already) known files, and avoiding touching the filesystem at all when the include/exclude paths contain no wildcard characters. With this change, the simple exclusion shown above takes about 50 milliseconds rather than 2.5 seconds.

This change brought the overall runtime of Credo on my system (`time mix credo`) from ~17 seconds down to ~10 (with Credo's built-in reporting going from something like "Analysis took 11.1 seconds" to "Analysis took 5.8 seconds"). (The remaining time, of course, is being spent loading the source files into memory initially, prior to any checks.)