### PR TITLE
Fix error message when `PassAsyncInTestCases`'s `:force_comment_on_explicit_false` produces issues

### DIFF
--- a/lib/credo/check/refactor/pass_async_in_test_cases.ex
+++ b/lib/credo/check/refactor/pass_async_in_test_cases.ex
@@ -66,7 +66,7 @@ defmodule Credo.Check.Refactor.PassAsyncInTestCases do
 
   defp handle_explicit_async_false({:use, meta, _} = ast, ctx) do
     if ctx.params.force_comment_on_explicit_false and not has_comment?(ctx, meta[:line]) do
-      {ast, put_issue(ctx, issue_for(ctx, meta))}
+      {ast, put_issue(ctx, missing_comment_issue_for(ctx, meta))}
     else
       {ast, ctx}
     end
@@ -88,6 +88,16 @@ defmodule Credo.Check.Refactor.PassAsyncInTestCases do
     format_issue(
       ctx,
       message: "Pass an `:async` boolean option to `use` a test case module.",
+      trigger: "use",
+      line_no: meta[:line]
+    )
+  end
+
+  defp missing_comment_issue_for(ctx, meta) do
+    format_issue(
+      ctx,
+      message:
+        "Tests with `async: false` need a comment explaining why they can't be run asynchronously.",
       trigger: "use",
       line_no: meta[:line]
     )

--- a/test/credo/check/refactor/pass_async_in_test_cases_test.exs
+++ b/test/credo/check/refactor/pass_async_in_test_cases_test.exs
@@ -94,7 +94,10 @@ defmodule Credo.Check.Refactor.PassAsyncInTestCasesTest do
       '''
       |> to_source_file()
       |> run_check(@described_check, force_comment_on_explicit_false: true)
-      |> assert_issue(%{line_no: 2, trigger: "use"})
+      |> assert_issue(fn issue ->
+        assert %{line_no: 2, trigger: "use"} = issue
+        assert issue.message =~ "comment explaining why"
+      end)
     end
   end
 end


### PR DESCRIPTION
This improves the error messages produced when using the new `:force_comment_on_explicit_false` option in `PassAsyncInTestCases`.

Prior to this change, if you had:

```elixir
defmodule MyTest do
  use ExUnit.Case, async: false
  ...
end
```

...you would get the rather misleading Credo report:

```
┃ [F] → Pass an `:async` boolean option to `use` a test case module.
┃       lib/my_app.exs:2:3 #(MyTest)
```

With this change, you'll get the more precise error "Tests with `async: false` need a comment explaining why they can't be run asynchronously."