### PR TITLE
Explicitly support UnusedOperation checking all functions in a given module

### DIFF
--- a/test/credo/check/warning/unused_enum_operation_test.exs
+++ b/test/credo/check/warning/unused_enum_operation_test.exs
@@ -716,7 +716,9 @@ defmodule Credo.Check.Warning.UnusedEnumOperationTest do
     '''
     |> to_source_file
     |> run_check(@described_check)
-    |> assert_issue()
+    |> assert_issue(fn issue ->
+      assert issue.message =~ "There should be no unused return values for Enum functions."
+    end)
   end
 
   test "it should report a violation when end of pipe" do

--- a/test/credo/check/warning/unused_operation_test.exs
+++ b/test/credo/check/warning/unused_operation_test.exs
@@ -22,13 +22,23 @@ defmodule Credo.Check.Warning.UnusedOperationTest do
         Enum.each(Map.get(MyAgent.get(:after_hooks), task, []),
           fn([module, fnref]) -> apply(module, fnref, []) end)
       end
+
+      def other_function(param) do
+        MyModule.transform(param)
+      end
+
+      def other_function do
+        OtherModule.do_the_thing()
+      end
     end
     '''
     |> to_source_file
     |> run_check(@described_check,
       modules: [
         {Map, [:get, :fetch]},
-        {Keywords, [:get, :fetch], "My special issue message"}
+        {Keywords, [:get, :fetch], "My special issue message"},
+        MyModule,
+        {OtherModule, "My special issue message"}
       ]
     )
     |> refute_issues()
@@ -58,5 +68,32 @@ defmodule Credo.Check.Warning.UnusedOperationTest do
       ]
     )
     |> assert_issue(%{trigger: "Map.take", message: ~r/special/})
+  end
+
+  test "it should report violations when using module-only config" do
+    ~S'''
+    defmodule CredoSampleModule do
+      def some_function(parameter1, parameter2) do
+        MyModule.transform(parameter1)
+        OtherModule.do_something(parameter3)
+
+        :ok
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check, modules: [MyModule, {OtherModule, "My special issue message"}])
+    |> assert_issues(fn issues ->
+      assert [
+               %{
+                 trigger: "MyModule.transform",
+                 message: "There should be no unused return values for MyModule" <> _
+               },
+               %{
+                 trigger: "OtherModule.do_something",
+                 message: "My special issue message"
+               }
+             ] = Enum.sort_by(issues, & &1.trigger)
+    end)
   end
 end


### PR DESCRIPTION
This expands the `UnusedOperation` check to (explicitly) support checking all functions in the module by omitting the list of functions. I say "explicitly" because, digging into the implementation, it turns out one could already have passed `nil` for the list of function names, but that was both undocumented and rather obtuse as a public API (naively, if I saw a config that said we'd warn about unused results from the functions `nil`, I would assume that alert never fired).

This updates the configuration for UnusedOperation to explicitly allow passing just a module, or a module plus a string to use as the message, in addition to the variants that pass an explicit list of functions.