### PR TITLE
Add CondInsteadOfIfElse check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -191,6 +191,7 @@
           {Credo.Check.Readability.WithCustomTaggedTuple, []},
           {Credo.Check.Refactor.ABCSize, []},
           {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.CondInsteadOfIfElse, [allow_one_liners: true]},
           {Credo.Check.Refactor.DoubleBooleanNegation, []},
           {Credo.Check.Refactor.FilterReject, []},
           {Credo.Check.Refactor.IoPuts, []},

--- a/lib/credo/check/refactor/cond_instead_of_if_else.ex
+++ b/lib/credo/check/refactor/cond_instead_of_if_else.ex
@@ -1,0 +1,84 @@
+defmodule Credo.Check.Refactor.CondInsteadOfIfElse do
+  use Credo.Check,
+    id: "EX4033",
+    base_priority: :low,
+    param_defaults: [allow_one_liners: false],
+    explanations: [
+      check: """
+      Prefer `cond` over `if/else` blocks.
+
+      So while this is fine:
+
+          if allowed? do
+            :ok
+          end
+
+      The use of `else` could impact readability:
+
+          if allowed? do
+            :ok
+          else
+            :error
+          end
+
+      and could be improved to:
+
+          cond do
+            allowed? -> :ok
+            true -> :error
+          end
+
+      There's no technical reason for this; it's a matter of preferred code style.
+
+      NOTE: This check is mutually exclusive with `Credo.Check.Refactor.CondStatements`,
+      which recommends the opposite. Enable only one of these checks.
+      """,
+      params: [
+        allow_one_liners: "Allow one-liner `if/else` expressions (e.g., `if x, do: y, else: z`)."
+      ]
+    ]
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    ctx = Context.build(source_file, params, __MODULE__)
+    result = Credo.Code.prewalk(source_file, &walk/2, ctx)
+    result.issues
+  end
+
+  defp walk({:@, _, [{:if, _, _}]}, ctx) do
+    {nil, ctx}
+  end
+
+  defp walk({:if, meta, _arguments} = ast, %{params: %{allow_one_liners: true}} = ctx) do
+    if Credo.Code.Block.else_block?(ast) and block_if?(meta) do
+      {ast, put_issue(ctx, issue_for(ctx, meta))}
+    else
+      {ast, ctx}
+    end
+  end
+
+  defp walk({:if, meta, _arguments} = ast, ctx) do
+    if Credo.Code.Block.else_block?(ast) do
+      {ast, put_issue(ctx, issue_for(ctx, meta))}
+    else
+      {ast, ctx}
+    end
+  end
+
+  defp walk(ast, ctx) do
+    {ast, ctx}
+  end
+
+  # Block if/else has :end key in metadata, inline does not
+  defp block_if?(meta), do: Keyword.has_key?(meta, :end)
+
+  defp issue_for(ctx, meta) do
+    format_issue(
+      ctx,
+      message: "Consider using `cond` instead of `if/else`.",
+      trigger: "if",
+      line_no: meta[:line]
+    )
+  end
+end

--- a/lib/credo/check/refactor/cond_statements.ex
+++ b/lib/credo/check/refactor/cond_statements.ex
@@ -25,6 +25,8 @@ defmodule Credo.Check.Refactor.CondStatements do
             1
           end
 
+      NOTE: This check is mutually exclusive with `Credo.Check.Refactor.CondInsteadOfIfElse`,
+      which recommends the opposite. Enable only one of these checks.
       """
     ]
 

--- a/test/credo/check/refactor/cond_instead_of_if_else_test.exs
+++ b/test/credo/check/refactor/cond_instead_of_if_else_test.exs
@@ -1,0 +1,268 @@
+defmodule Credo.Check.Refactor.CondInsteadOfIfElseTest do
+  use Credo.Test.Case
+
+  @described_check Credo.Check.Refactor.CondInsteadOfIfElse
+
+  #
+  # cases NOT raising issues
+  #
+
+  test "it should NOT report if without else" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        if allowed? do
+          :ok
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report inline if without else" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        if allowed?, do: :ok
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report cond statement" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        cond do
+          x < y -> -1
+          x == y -> 0
+          true -> 1
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report multiple if statements without else" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        if condition1 do
+          action1()
+        end
+
+        if condition2 do
+          action2()
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should NOT report module attribute named @if" do
+    """
+    defmodule CredoSampleModule do
+      @if true
+
+      def some_fun do
+        @if
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  #
+  # cases raising issues
+  #
+
+  test "it should report basic if/else block" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        if allowed? do
+          :ok
+        else
+          :error
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{trigger: "if"})
+  end
+
+  test "it should report inline if/else" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        if allowed?, do: :ok, else: :error
+
+        cond do
+          allowed? -> :ok
+          true -> :error
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{trigger: "if"})
+  end
+
+  test "it should report if/else with complex condition" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun(x, y, z) do
+        if x > y and y < z or z == 0 do
+          :complex
+        else
+          :simple
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{trigger: "if"})
+  end
+
+  test "it should report nested if/else within function" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        result = if condition do
+          :yes
+        else
+          :no
+        end
+        result
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{trigger: "if"})
+  end
+
+  test "it should report multiple if/else blocks" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        if condition1 do
+          :a
+        else
+          :b
+        end
+
+        if condition2 do
+          :c
+        else
+          :d
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issues()
+  end
+
+  test "it should report correct line number" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        if allowed? do
+          :ok
+        else
+          :error
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{line_no: 3})
+  end
+
+  #
+  # cases with allow_one_liners: true
+  #
+
+  test "it should NOT report inline if/else when allow_one_liners is true" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        if allowed?, do: :ok, else: :error
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, allow_one_liners: true)
+    |> refute_issues()
+  end
+
+  test "it should still report block if/else when allow_one_liners is true" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        if allowed? do
+          :ok
+        else
+          :error
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, allow_one_liners: true)
+    |> assert_issue(%{trigger: "if"})
+  end
+
+  test "it should report inline if/else when allow_one_liners is false (default)" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        if allowed?, do: :ok, else: :error
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, allow_one_liners: false)
+    |> assert_issue(%{trigger: "if"})
+  end
+
+  test "it should report only block if/else when allow_one_liners is true with mixed code" do
+    """
+    defmodule CredoSampleModule do
+      def some_fun do
+        x = if inline?, do: :a, else: :b
+
+        if block? do
+          :c
+        else
+          :d
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check, allow_one_liners: true)
+    |> assert_issue(%{line_no: 5})
+  end
+end


### PR DESCRIPTION
# Add `CondInsteadOfIfElse` check

Solve #1250.

## Summary

Adds a new refactoring check that suggests using `cond` instead of `if/else` blocks. This provides an alternative style preference to the existing `CondStatements` check.

## Changes

### New files
- `lib/credo/check/refactor/cond_instead_of_if_else.ex` - The new check (ID: EX4033)
- `test/credo/check/refactor/cond_instead_of_if_else_test.exs` - Test coverage (15 tests)

### Modified files
- `lib/credo/check/refactor/cond_statements.ex` - Added note about mutual exclusivity
- `.credo.exs` - Added new check to disabled section

## Check Details

**ID:** EX4033
**Category:** Refactor
**Priority:** Low
**Default:** Disabled

### Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `allow_one_liners` | `false` | Allow one-liner `if/else` expressions (e.g., `if x, do: y, else: z`) |

### Example

```elixir
# Flagged by check
if allowed? do
  :ok
else
  :error
end

# Suggested refactoring
cond do
  allowed? -> :ok
  true -> :error
end
```

### Configuration

```elixir
# Enable the check
{Credo.Check.Refactor.CondInsteadOfIfElse, []}

# Enable but allow one-liners
{Credo.Check.Refactor.CondInsteadOfIfElse, [allow_one_liners: true]}
```

## Notes

- Mutually exclusive with `Credo.Check.Refactor.CondStatements` (EX4005) - enable only one
- Skips module attributes named `@if`
- Disabled by default as it represents an opinionated style preference

## Test Plan

- [x] All 15 new tests pass
- [x] Full test suite passes (1665 tests)
- [x] Check correctly identifies block `if/else`
- [x] Check correctly identifies one-liner `if/else`
- [x] `allow_one_liners: true` skips one-liners
- [x] Module attributes `@if` are ignored
