### PR TITLE
Add `ignore_comments` param to `MaxLineLength` check

### DIFF
--- a/lib/credo/check/readability/max_line_length.ex
+++ b/lib/credo/check/readability/max_line_length.ex
@@ -7,6 +7,7 @@ defmodule Credo.Check.Readability.MaxLineLength do
       max_length: 120,
       ignore_definitions: true,
       ignore_heredocs: true,
+      ignore_comments: false,
       ignore_specs: false,
       ignore_sigils: true,
       ignore_strings: true,
@@ -26,6 +27,7 @@ defmodule Credo.Check.Readability.MaxLineLength do
         max_length: "The maximum number of characters a line may consist of.",
         ignore_definitions: "Set to `true` to ignore lines including function definitions.",
         ignore_specs: "Set to `true` to ignore lines including `@spec`s.",
+        ignore_comments: "Set to `true` to ignore lines that are purely comments.",
         ignore_sigils: "Set to `true` to ignore lines that are sigils, e.g. regular expressions.",
         ignore_strings: "Set to `true` to ignore lines that are strings or in heredocs.",
         ignore_urls: "Set to `true` to ignore lines that contain urls."
@@ -47,6 +49,7 @@ defmodule Credo.Check.Readability.MaxLineLength do
     ignore_definitions = Params.get(params, :ignore_definitions, __MODULE__)
 
     ignore_specs = Params.get(params, :ignore_specs, __MODULE__)
+    ignore_comments = Params.get(params, :ignore_comments, __MODULE__)
     ignore_sigils = Params.get(params, :ignore_sigils, __MODULE__)
     ignore_strings = Params.get(params, :ignore_strings, __MODULE__)
     ignore_heredocs = Params.get(params, :ignore_heredocs, __MODULE__)
@@ -85,6 +88,13 @@ defmodule Credo.Check.Readability.MaxLineLength do
     lines_for_comparison =
       if ignore_urls do
         Enum.reject(lines_for_comparison, fn {_, line} -> line =~ url_regex end)
+      else
+        lines_for_comparison
+      end
+
+    lines_for_comparison =
+      if ignore_comments do
+        Enum.reject(lines_for_comparison, fn {_, line} -> line =~ ~r/^\s*#/ end)
       else
         lines_for_comparison
       end

--- a/test/credo/check/readability/max_line_length_test.exs
+++ b/test/credo/check/readability/max_line_length_test.exs
@@ -213,6 +213,22 @@ defmodule Credo.Check.Readability.MaxLineLengthTest do
     |> refute_issues()
   end
 
+  test "it should NOT report a violation if comments are excluded" do
+    ~S'''
+    defmodule CredoSampleModule do
+      use ExUnit.Case
+
+      def some_fun do
+        # This is a very long comment line that should definitely be ignored if the ignore_comments parameter is set to true.
+        assert 1 + 1 == 2
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check, max_length: 80, ignore_comments: true)
+    |> refute_issues()
+  end
+
   #
   # cases raising issues
   #
@@ -245,6 +261,22 @@ defmodule Credo.Check.Readability.MaxLineLengthTest do
     |> to_source_file
     |> run_check(@described_check, max_length: 80)
     |> assert_issue(%{column: 81, message: ~r/max is 80, was 112/})
+  end
+
+  test "it should report a violation if comments are NOT excluded" do
+    ~S'''
+    defmodule CredoSampleModule do
+      use ExUnit.Case
+
+      def some_fun do
+        # This is a very long comment line that should definitely NOT be ignored if the ignore_comments parameter is set to false.
+        assert 1 + 1 == 2
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check, max_length: 80, ignore_comments: false)
+    |> assert_issue()
   end
 
   test "it should report a violation /3" do


### PR DESCRIPTION
Long story short, a lot of projects I work with sometimes have very long comment lines and I want to ignore them in a opt-in fashion for this Credo check. 🙏 