### PR TITLE
Add `ignore_definition_args` param to `MaxLineLength` check

### DIFF
--- a/test/credo/check/readability/max_line_length_test.exs
+++ b/test/credo/check/readability/max_line_length_test.exs
@@ -69,6 +69,27 @@ defmodule Credo.Check.Readability.MaxLineLengthTest do
     |> refute_issues()
   end
 
+  test "it should NOT report expected code if function definition arguments are excluded" do
+    ~S'''
+    defmodule CredoSampleModule do
+      use ExUnit.Case
+
+      def some_fun(
+            %{"name" => name, "value" => value, "timestamp" => timestamp} = map_variable,
+            %MyStruct{some_id: MyConst.some_id(:some_long_atom_name), other_id: MyConst.other_id(:another_long_name)} =
+              struct_variable,
+            other_arguments
+          )
+          when name in @some_attributes do
+        assert 1 + 1 == 2
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check, max_length: 80, ignore_definition_args: true)
+    |> refute_issues()
+  end
+
   test "it should NOT report expected code if @spec's are excluded" do
     ~S'''
     defmodule CredoSampleModule do


### PR DESCRIPTION
Even with `ignore_definitions` being set to `true`, there are some cases where the Elixir formatter won't split a long line if it's one of the arguments of a function definition. This will cause the `MaxLineLength` Credo check to fail when it maybe shouldn't. To address this, I figured a new default-false flag would be an easier addition. 🙏 