### PR TITLE
Add improved check for detecting misnamed test files

### DIFF
--- a/lib/credo/check/warning/wrong_test_file_name.ex
+++ b/lib/credo/check/warning/wrong_test_file_name.ex
@@ -1,0 +1,72 @@
+defmodule Credo.Check.Warning.WrongTestFileName do
+  @moduledoc """
+  Ensures that `use ExUnit.Case` and related test cases are only used in test files.
+  """
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    param_defaults: [
+      files: %{excluded: ["test/**/*_test.exs", "apps/**/test/**/*_test.exs"]}
+    ],
+    explanations: [
+      check: """
+      Ensures that `use ExUnit.Case` and related test cases are only used in files ending with `_test.exs`.
+
+      ExUnit.Case is designed for test modules and provides test-specific functionality
+      like database sandboxing and test macros. Using it in non-test files is likely a
+      mistake in the file name and will cause the tests in that module not to be run.
+
+      ExUnit's docs say:
+
+      > Invoking mix test from the command line will run the tests in each file
+      > matching the pattern `*_test.exs` found in the test directory of your project.
+
+      If you have a file named differently (say, `test_my_module.exs`), you will be able to
+      run `mix test test/test_my_module.exs` and see the tests run. This can mislead you
+      into believing that subsequently running the full test suite (`mix test`) will also
+      test your file.
+      """
+    ]
+
+  @doc false
+  @impl Credo.Check
+  def run(%SourceFile{filename: filename} = source_file, params \\ []) do
+    # Only check non-test files, excluding custom case modules which may invoke
+    # `use ExUnit.Case` themselves.
+    if String.ends_with?(filename, ["_test.exs", "_case.ex"]) do
+      []
+    else
+      issue_meta = IssueMeta.for(source_file, params)
+      Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+    end
+  end
+
+  defp traverse({:use, meta, [{:__aliases__, _, module_parts} | _]} = node, issues, issue_meta) do
+    case parse_test_case_module(module_parts) do
+      {:ok, module_name} -> {node, issues ++ [create_issue(module_name, issue_meta, meta[:line])]}
+      {:error, :not_a_test_case_module} -> {node, issues}
+    end
+  end
+
+  defp traverse(node, issues, _issue_meta), do: {node, issues}
+
+  defp create_issue(module_name, issue_meta, line_no) do
+    format_issue(
+      issue_meta,
+      message: "Test files that `use #{module_name}` should end with `_test.exs`.",
+      trigger: "use #{module_name}",
+      line_no: line_no
+    )
+  end
+
+  defp parse_test_case_module(module_parts) do
+    last_part = module_parts |> List.last() |> to_string()
+
+    if String.ends_with?(last_part, "Case") do
+      # Use inspect(), not to_string(), to get MyApp.MyModule instead of Elixir.MyApp.MyModule
+      {:ok, module_parts |> Module.concat() |> inspect()}
+    else
+      {:error, :not_a_test_case_module}
+    end
+  end
+end

--- a/test/credo/check/warning/wrong_test_file_name_test.exs
+++ b/test/credo/check/warning/wrong_test_file_name_test.exs
@@ -1,0 +1,88 @@
+defmodule Credo.Check.Warning.WrongTestFileNameTest do
+  use Credo.Test.Case, async: true
+
+  alias Credo.Check.Warning.WrongTestFileName
+
+  for test_module <- [ExUnit.Case, MyApp.ConnCase, MyApp.TestCases.DataCase, MyApp.E2ECase] do
+    test "alerts on `use #{test_module}` in a non-test file" do
+      """
+      defmodule MyModule do
+        use #{unquote(test_module)}
+
+        def some_function do
+          :ok
+        end
+      end
+      """
+      |> to_source_file("lib/my_module.ex")
+      |> run_check(WrongTestFileName)
+      |> assert_issue()
+    end
+
+    test "alerts on `use #{test_module}` with options in a non-test file" do
+      """
+      defmodule MyModule do
+        use #{unquote(test_module)}, async: true
+
+        def some_function do
+          :ok
+        end
+      end
+      """
+      |> to_source_file("lib/my_module.ex")
+      |> run_check(WrongTestFileName)
+      |> assert_issue()
+    end
+
+    test "alerts on `use #{test_module}` with multiple options in a non-test file" do
+      """
+      defmodule MyModule do
+        use #{unquote(test_module)}, async: false, group: :some_group
+
+        def some_function do
+          :ok
+        end
+      end
+      """
+      |> to_source_file("lib/my_module.ex")
+      |> run_check(WrongTestFileName)
+      |> assert_issue()
+    end
+
+    test "does not alert on `use #{test_module}` in a properly named test file" do
+      for opts <- ["", ", async: true", ", async: false, group: :some_group"] do
+        """
+        defmodule MyModuleTest do
+          use #{unquote(test_module)}#{opts}
+
+          test "some test" do
+            assert true
+          end
+        end
+        """
+        |> to_source_file("lib/my_module_test.exs")
+        |> run_check(WrongTestFileName)
+        |> refute_issues()
+      end
+    end
+  end
+
+  test "does not alert on other use statements in non-test files" do
+    """
+    defmodule MyModule do
+      use GenServer
+      use Phoenix.LiveView
+      use MyApp.Cases
+      use MyApp.Cases, async: true
+      use MyApp.Cases, async: true, group: :some_group
+
+      def some_function do
+        :ok
+      end
+    end
+    """
+    |> to_source_file("lib/my_module.ex")
+    |> run_check(WrongTestFileName)
+    |> refute_issues()
+  end
+end


### PR DESCRIPTION
A colleague and I recently spent more hours than I'd care to admit tracking down why a test file which failed when run individually did not fail the full test suite. Even once we determined conclusively that `mix test` didn't run the file at all, we couldn't figure out why.

The answer turned out to be a one-character typo in the file name: `_text.exs` versus `_test.exs`.

This check is essentially a broader version of the existing `Credo.Check.Warning.WrongTestFileExtension`. It warns on any mis-named test file which appears to represent a test case (it includes `use *.Case`). Beyond my poor colleague and I, I can imagine this helping an Elixir newbie who got the naming convention wrong and named their file something like `test/test_my_module.exs`.

I'm not sure whether this should fully replace `WrongTestFileExtension`. It _does_ make that check fully redundant, but keeping the same name would be slightly misleading.