### PR TITLE
Check test context in `UnusedVariableNames` 

### DIFF
--- a/lib/credo/check/consistency/unused_variable_names/collector.ex
+++ b/lib/credo/check/consistency/unused_variable_names/collector.ex
@@ -27,6 +27,10 @@ defmodule Credo.Check.Consistency.UnusedVariableNames.Collector do
     {ast, reduce_unused_variables(params, callback, acc)}
   end
 
+  defp traverse(callback, {:test, _, [_name, context, [do: _] | _]} = ast, acc) do
+    {ast, reduce_unused_variables([context], callback, acc)}
+  end
+
   defp traverse(callback, {:->, _, [params | _]} = ast, acc) do
     {ast, reduce_unused_variables(params, callback, acc)}
   end

--- a/test/credo/check/consistency/unused_variable_names_test.exs
+++ b/test/credo/check/consistency/unused_variable_names_test.exs
@@ -360,6 +360,23 @@ defmodule Credo.Check.Consistency.UnusedVariableNamesTest do
     ])
   end
 
+  test "it should report a violation for a test context with a list match (expects meaningful)" do
+    [
+      ~S'''
+      defmodule Credo.SampleTest do
+        use ExUnit.Case
+
+        test "my test", %{list: [item1 | _]} do
+          assert item1
+        end
+      end
+      '''
+    ]
+    |> to_source_files()
+    |> run_check(@described_check, force: :meaningful)
+    |> assert_issue(%{line_no: 4, trigger: "_"})
+  end
+
   test "it should report a violation once" do
     [
       ~S'''


### PR DESCRIPTION
I noticed that test context variables were not being checked with `Credo.Check.Consistency.UnusedVariableNames`, so I updated the check to verify the ast of tests, including a test case for it.