### PR TITLE
Fix infinite recursion on broken symlinks

### DIFF
--- a/lib/credo/sources.ex
+++ b/lib/credo/sources.ex
@@ -200,9 +200,16 @@ defmodule Credo.Sources do
           |> Path.wildcard()
 
         true ->
-          path
-          |> Path.wildcard()
-          |> Enum.flat_map(&recurse_path/1)
+          expanded = Path.wildcard(path)
+
+          if expanded == [path] do
+            # If the path not a regular file, nor a directory, nor does its
+            # wildcard expansion match any additional files, it is probably
+            # a broken symlink.
+            expanded
+          else
+            Enum.flat_map(expanded, &recurse_path/1)
+          end
       end
 
     Enum.map(paths, &Path.expand/1)


### PR DESCRIPTION
I had created a symlink from `CLAUDE.md` to `AGENTS.md` in my project, then later deleted `AGENTS.md`. This caused `recurse_path/1` to recurse infinitely on the `CLAUDE.md` symlink. While normally `File.regular?/1` and `File.dir?/1` treat symlinks invisibly, if the symlink is broken, both will return false.

With this fix, we stop recursing in such scenarios. (Of course, you may get an error somewhere else in your Credo checks about the broken symlink, but that's not really this function's job.)