### PR TITLE
Fix multi-alias violation description

### DIFF
--- a/lib/credo/check/readability/alias_order.ex
+++ b/lib/credo/check/readability/alias_order.ex
@@ -79,15 +79,25 @@ defmodule Credo.Check.Readability.AliasOrder do
   end
 
   defp walk(
-         {:alias, _, [{{:., _, [{:__aliases__, _, base_mod_list}, :{}]}, meta, multi_mod_list}]},
+         {:alias, _, [{{:., _, [{:__aliases__, base_meta, base_mod_list}, :{}]}, meta, multi_mod_list}]},
          %{params: %{sort_method: sort_method}} = ctx
        ) do
     candidates = multi_candidates(base_mod_list, multi_mod_list, sort_method)
     line = meta[:line]
     {{compare, _, _}, _} = List.first(candidates)
 
+    base_name = Credo.Code.Name.full(base_mod_list)
+
+    sub_names =
+      Enum.map(multi_mod_list, fn {:__aliases__, _, mod_list} ->
+        Credo.Code.Name.full(mod_list)
+      end)
+
+    multi_alias_name = "#{base_name}.{#{Enum.join(sub_names, ", ")}}"
+
     candidate =
-      {{compare, line, meta[:closing][:line]}, [multi_aliases: candidates]}
+      {{compare, line, meta[:closing][:line]},
+       multi_aliases: candidates, module: multi_alias_name, trigger: multi_alias_name, column: base_meta[:column]}
 
     {nil, extract_group_and_add_candidate(ctx, candidate, line)}
   end

--- a/test/credo/check/readability/alias_order_test.exs
+++ b/test/credo/check/readability/alias_order_test.exs
@@ -278,6 +278,18 @@ defmodule Credo.Check.Readability.AliasOrderTest do
     |> assert_issue(%{trigger: "Sorter"})
   end
 
+  test "it should report a violation with multi-alias /4" do
+    """
+    defmodule MyApp.MyModule do
+      alias Phoenix.{Controller, LiveView}
+      alias MyApp.Core.{Account, User}
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{trigger: "Phoenix.{Controller, LiveView}"})
+  end
+
   test "it should report a violation with case-sensitive sorting" do
     ~S'''
     defmodule Test do


### PR DESCRIPTION
The following case
```elixir
defmodule MyApp.MyModule do
  alias Phoenix.{Controller, LiveView}
  alias MyApp.Core.{Account, User}
end
```
results in the following description:
```
The alias `` is not alphabetically ordered among its group.
```
Fixed so it looks like this
```
The alias Phoenix.{Controller, LiveView} is not alphabetically ordered among its group.
```