### PR TITLE
Re-enable WrongTestFileExtension check by default

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -165,7 +165,8 @@
           {Credo.Check.Warning.UnusedRegexOperation, []},
           {Credo.Check.Warning.UnusedStringOperation, []},
           {Credo.Check.Warning.UnusedTupleOperation, []},
-          {Credo.Check.Warning.WrongTestFilename, []}
+          {Credo.Check.Warning.WrongTestFilename, []},
+          {Credo.Check.Warning.WrongTestFileExtension, []}
         ],
         disabled: [
           #


### PR DESCRIPTION
I think it was disabled by mistake in https://github.com/rrrene/credo/commit/ab67e975e2f1ab7e3ebe0f1662789fcea6e443cc 

Closes https://github.com/rrrene/credo/issues/1268