### PR TITLE
`mix credo` fails in umbrella projects on Elixir 1.19 — transitive dependency paths not loaded

### DIFF
--- a/lib/mix/tasks/credo.ex
+++ b/lib/mix/tasks/credo.ex
@@ -3,6 +3,7 @@ defmodule Mix.Tasks.Credo do
 
   @shortdoc "Run code analysis (use `--help` for options)"
   @moduledoc @shortdoc
+  @requirements ["loadpaths"]
 
   @doc false
   def run(argv) do


### PR DESCRIPTION
## Description

Running `mix credo` in an umbrella project on Elixir 1.19.5 / OTP 28 crashes because transitive dependencies (like `bunt`) are not on the code path when the task executes.

## Steps to Reproduce

1. Create an umbrella project with `credo` and `credo_sonarqube` as root-level deps in `mix.exs`
2. Run `mix credo` on Elixir 1.19.5 / OTP 28 without running `mix compile` first

## Error

```
** (UndefinedFunctionError) function Bunt.warn/1 is undefined (module Bunt is not available)
    Bunt.warn([:red, "** (credo) ", "Plugin module `CredoSonarqube` is not available ..."])
    lib/credo/cli/output/shell.ex:89: Credo.CLI.Output.Shell.handle_call/3
```

## Root Cause

In Elixir 1.19, `Mix.Task` resolves tasks via `maybe_load_or_compile_task/2`, which first calls `Code.ensure_loaded/1` on the task module. If the module is found on the code path, it is returned immediately **without running `deps.loadpaths`** — meaning transitive dependencies (like `bunt`) are never added to the code path.

This happens because Elixir 1.19 eagerly loads direct dependency ebin paths but not transitive ones. Since `Mix.Tasks.Credo` is a direct dependency, it is found immediately, and `deps.loadpaths` is skipped entirely.

Running `mix do deps.loadpaths + credo` or `mix compile && mix credo` works because all dependency paths get loaded explicitly.

## Suggested Fix

Add `@requirements ["loadpaths"]` to `Mix.Tasks.Credo` so that transitive dependency paths are loaded before the task runs:

```elixir
defmodule Mix.Tasks.Credo do
  use Mix.Task

  @shortdoc "Run code analysis (use `--help` for options)"
  @moduledoc @shortdoc
  @requirements ["loadpaths"]

  @doc false
  def run(argv) do
    Credo.CLI.main(argv)
  end
end
```

## Workaround

Add a mix alias in the umbrella root `mix.exs`:

```elixir
defp aliases do
  [
    credo: ["deps.loadpaths", "credo"]
  ]
end
```

## Environment

- Elixir 1.19.5
- OTP 28 (erts-16.2)
- Credo 1.7.17
- macOS (Darwin 24.6.0)
- Umbrella project with `credo` defined as a root-level dep
