### PR TITLE
Fix compatibility with Elixir 1.20.0-rc.4 sigil token format change

### DIFF
--- a/lib/credo/code/interpolation_helper.ex
+++ b/lib/credo/code/interpolation_helper.ex
@@ -84,7 +84,7 @@ defmodule Credo.Code.InterpolationHelper do
   # Elixir >= 1.11.0
   #
   defp map_interpolations(
-         {:sigil, {_line_no, _col_start, nil}, _, list, _empty_list, nil, _another_binary} =
+         {:sigil, {_line_no, _col_start, _end_position}, _, list, _empty_list, nil, _another_binary} =
            token,
          source
        ) do

--- a/lib/credo/code/token.ex
+++ b/lib/credo/code/token.ex
@@ -98,7 +98,7 @@ defmodule Credo.Code.Token do
   end
 
   # Elixir >= 1.10.0 tuple syntax
-  def position({:sigil, {line_no, col_start, nil}, sigil_name, charlist, modifiers, _number, _binary})
+  def position({:sigil, {line_no, col_start, _end_position}, sigil_name, charlist, modifiers, _number, _binary})
       when is_list(charlist) do
     case position_tuple_for_quoted_string(charlist, line_no, col_start) do
       {line1, col_start, line1, col_end} ->
@@ -317,7 +317,7 @@ defmodule Credo.Code.Token do
   defp convert_to_col_end(
          _,
          _,
-         {:sigil, {line_no, col_start, nil}, _, list, _modifiers, _number, _binary}
+         {:sigil, {line_no, col_start, _end_position}, _, list, _modifiers, _number, _binary}
        )
        when is_list(list) do
     Enum.reduce(list, {line_no, col_start, nil}, &reduce_to_col_end/2)

--- a/test/credo/code/token_test.exs
+++ b/test/credo/code/token_test.exs
@@ -391,7 +391,7 @@ defmodule Credo.Code.TokenTest do
                {:",", {1, 21, 0}},
                {:identifier, {1, 23, ~c"acc"}, :acc},
                {:concat_op, {1, 27, nil}, :<>},
-               {:sigil, {1, 30, nil}, :sigil_s, ["\\\"\\\"\\\""], [], nil, "("},
+               {:sigil, {1, 30, _end_position}, :sigil_s, ["\\\"\\\"\\\""], [], nil, "("},
                {:")", {1, 40, nil}},
                {:eol, {1, 41, 1}}
              ],
@@ -670,6 +670,10 @@ defmodule Credo.Code.TokenTest do
       run_check(@described_check, ignore: ~w/use import/a)
       ''')
 
+    # Elixir >= 1.20.0-rc.4 changed the sigil token's third position element
+    # from `nil` to `{end_line, end_col}`.
+    sigil_end_position = if Version.match?(System.version(), ">= 1.20.0-rc.4"), do: {1, 52}, else: nil
+
     expected = [
       {:paren_identifier, {1, 1, ~c"run_check"}, :run_check},
       {:"(", {1, 10, nil}},
@@ -677,14 +681,14 @@ defmodule Credo.Code.TokenTest do
       {:identifier, {1, 12, ~c"described_check"}, :described_check},
       {:",", {1, 27, 0}},
       {:kw_identifier, {1, 29, ~c"ignore"}, :ignore},
-      {:sigil, {1, 37, nil}, :sigil_w, ["use import"], ~c"a", nil, "/"},
+      {:sigil, {1, 37, sigil_end_position}, :sigil_w, ["use import"], ~c"a", nil, "/"},
       {:")", {1, 52, nil}},
       {:eol, {1, 53, 1}}
     ]
 
     assert tokens == expected
 
-    assert {1, 37, 1, 52} == Token.position({:sigil, {1, 37, nil}, :sigil_w, ["use import"], ~c"a", nil, "/"})
+    assert {1, 37, 1, 52} == Token.position({:sigil, {1, 37, sigil_end_position}, :sigil_w, ["use import"], ~c"a", nil, "/"})
   end
 
   test "should iterate all items as `current` in reduce" do


### PR DESCRIPTION
elixir-lang/elixir@7945446 changed the `:sigil` token's position tuple third element from `nil` to `end_position = {end_line, end_col}`. The breaking change can be found in `:elixir_tokenizer.add_sigil_token/12`.