### PR TITLE
Fix two compiler/test warnings under Elixir 1.20.0-rc.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule Credo.Mixfile do
       aliases: aliases(),
       test_ignore_filters: [
         "test/all_checks_with_ids_and_params.exs",
+        "test/diff_credo.exs",
         "test/old_credo.exs",
         "test/regression/run_older_credo_version.exs",
         ~r[test/credo/check/housekeeping_.+.exs],

--- a/test/credo/check/consistency/space_in_parentheses/collector_test.exs
+++ b/test/credo/check/consistency/space_in_parentheses/collector_test.exs
@@ -25,22 +25,6 @@ defmodule Credo.Check.Consistency.SpaceInParentheses.CollectorTest do
     end
   end
   '''
-  @with_spaces_empty_enum ~S'''
-    defmodule Credo.Sample2 do
-      defmodule InlineModule do
-        def foobar do
-          exists = File.exists?(filename)
-          { result, %{} } = File.read( filename )
-        end
-
-        def barfoo do
-          exists = File.exists?(filename)
-          { result, [] } = File.read( filename )
-        end
-      end
-    end
-  '''
-
   @heredoc_example ~S'''
   string = ~s"""
   "[]"


### PR DESCRIPTION
The following warnings are generated:

```console
❯ mix test
Compiling 150 files (.ex)
warning: the following files do not match any of the configured `:test_load_filters` / `:test_ignore_filters`:

test/diff_credo.exs

This might indicate a typo in a test file name (for example, using "foo_tests.exs" instead of "foo_test.exs").

See the configuration for `:test_pattern` under `mix help test` for more information.

Running ExUnit with seed: 769029, max_cases: 20
Excluding tags: [:slow, {:to_be_implemented, true}, {:housekeeping, true}]
Including tags: [slow: "disk_io"]

....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................**...............................................................................................    warning: module attribute @with_spaces_empty_enum was set but never used
    │
 28 │   @with_spaces_empty_enum ~S'''
    │   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ test/credo/check/consistency/space_in_parentheses/collector_test.exs:28: Credo.Check.Consistency.SpaceInParentheses.CollectorTest (module)

....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 1.4 seconds (1.3s async, 0.1s sync)

Result: 1751 passed (21 doctests, 1730 tests), 2 skipped, 56 excluded
```

This PR fixes them:

- Add `test/diff_credo.exs` to `test_ignore_filters` in mix.exs. Elixir 1.20.0-rc.4 now warns about `.exs` files in the test tree that don't match the configured test pattern. The file is a utility script (not a test suite) and was already absent from the test run, so it belongs alongside the other ignored entries.

- Remove unused `@with_spaces_empty_enum` module attribute from `collector_test.exs`. The attribute was defined but never referenced; the test that exercises the same source code inlines it directly.