### PR TITLE
perf (UnusedOperation): Only walk the full AST once

### DIFF
--- a/lib/credo/check/warning/unused_function_return_helper.ex
+++ b/lib/credo/check/warning/unused_function_return_helper.ex
@@ -39,7 +39,7 @@ defmodule Credo.Check.Warning.UnusedFunctionReturnHelper do
          required_mod_list,
          nil
        ) do
-    if mods == required_mod_list do
+    if mods == required_mod_list or mods in required_mod_list do
       {ast, [ast | acc]}
     else
       {ast, acc}
@@ -52,7 +52,7 @@ defmodule Credo.Check.Warning.UnusedFunctionReturnHelper do
          required_mod_list,
          restrict_fun_names
        ) do
-    if mods == required_mod_list and fun_name in restrict_fun_names do
+    if (mods == required_mod_list or mods in required_mod_list) and fun_name in restrict_fun_names do
       {ast, [ast | acc]}
     else
       {ast, acc}

--- a/lib/credo/check/warning/unused_operation.ex
+++ b/lib/credo/check/warning/unused_operation.ex
@@ -36,15 +36,8 @@ defmodule Credo.Check.Warning.UnusedOperation do
     ctx = Context.build(source_file, params, __MODULE__)
 
     ctx = %{ctx | params: normalize_params(ctx.params)}
-
-    Enum.flat_map(ctx.params.modules, fn {mod, fun_list, issue_message} ->
-      issues = run(source_file, params, mod, fun_list, &format_issue/2)
-
-      case issue_message do
-        "" <> message -> Enum.map(issues, fn %Issue{} = issue -> %{issue | message: message} end)
-        nil -> issues
-      end
-    end)
+    relevant_modules = Enum.map(ctx.params.modules, fn {mod, _fun_list, _message} -> mod end)
+    run(source_file, params, relevant_modules, ctx.params.modules, &format_issue/2)
   end
 
   defp normalize_params(params) do
@@ -69,56 +62,73 @@ defmodule Credo.Check.Warning.UnusedOperation do
   alias Credo.IssueMeta
 
   @doc false
-  def run(source_file, params \\ [], checked_module, funs_with_return_value, format_issue_fun)
+  def run(source_file, params \\ [], relevant_module_or_modules, single_mod_funs_or_module_configs, format_issue_fun)
 
-  def run(%SourceFile{} = source_file, params, checked_module, :all, format_issue_fun) do
-    run(source_file, params, checked_module, nil, format_issue_fun)
+  # Matches calls like:
+  #   run(source_file, params, :Enum, [:map, :filter], &format_issue/2)
+  #
+  # This is what related checks like Credo.Check.Warning.UnusedStringOperation call us directly with.
+  def run(source_file, params, single_module, funs, format_issue_fun) when is_atom(single_module) do
+    run(source_file, params, [single_module], [{List.wrap(single_module), funs, nil}], format_issue_fun)
   end
 
-  def run(%SourceFile{} = source_file, params, checked_module, funs_with_return_value, format_issue_fun) do
+  # Matches calls like:
+  #   run(source_file, params, [:Enum, :Map], [{:Enum, [:map, :filter]}, {:Map, [:take, :put]}], &format_issue/2)
+  #
+  # or even:
+  #   run(source_file, params, [MyApp.MyModule], [{MyApp.MyModule, [:my_fun]}], &format_issue/2)
+  #
+  # This is what this check's `run/2` calls us with.
+  def run(%SourceFile{} = source_file, params, relevant_modules, module_configs, format_issue_fun) do
     issue_meta = IssueMeta.for(source_file, params)
-
-    relevant_funs =
-      if params[:ignore] do
-        ignored_funs = List.wrap(params[:ignore])
-
-        funs_with_return_value -- ignored_funs
-      else
-        funs_with_return_value
-      end
 
     all_unused_calls =
       UnusedFunctionReturnHelper.find_unused_calls(
         source_file,
         params,
-        List.wrap(checked_module),
-        relevant_funs
+        relevant_modules,
+        nil
       )
 
-    Enum.reduce(all_unused_calls, [], fn invalid_call, issues ->
-      {{:., _, [{:__aliases__, meta, _}, _fun_name]}, _, _} = invalid_call
+    ignored = List.wrap(params[:ignore])
 
-      trigger =
-        invalid_call
-        |> Macro.to_string()
-        |> String.split("(")
-        |> List.first()
+    all_unused_calls
+    |> Enum.reject(fn {{:., _, [{:__aliases__, _, _}, fun_name]}, _, _} -> fun_name in ignored end)
+    |> Enum.reduce([], fn invalid_call, issues ->
+      {{:., _, [{:__aliases__, meta, module}, fun_name]}, _, _} = invalid_call
 
-      [issue_for(format_issue_fun, issue_meta, meta, trigger, checked_module) | issues]
+      found_config =
+        Enum.find(module_configs, fn {mod, fun_list, _issue_message} ->
+          mod == module and (fun_list in [:all, nil] or fun_name in fun_list)
+        end)
+
+      case found_config do
+        {_, _fun_list, issue_message} ->
+          trigger =
+            invalid_call
+            |> Macro.to_string()
+            |> String.split("(")
+            |> List.first()
+
+          [issue_for(format_issue_fun, issue_meta, meta, trigger, module, issue_message) | issues]
+
+        nil ->
+          issues
+      end
     end)
   end
 
-  defp issue_for(format_issue_fun, issue_meta, meta, trigger, checked_module)
+  defp issue_for(format_issue_fun, issue_meta, meta, trigger, checked_module, message)
        when is_list(checked_module) do
-    issue_for(format_issue_fun, issue_meta, meta, trigger, Module.concat(checked_module))
+    issue_for(format_issue_fun, issue_meta, meta, trigger, Module.concat(checked_module), message)
   end
 
-  defp issue_for(format_issue_fun, issue_meta, meta, trigger, checked_module) do
+  defp issue_for(format_issue_fun, issue_meta, meta, trigger, checked_module, message) do
     module_name = Credo.Code.Name.full(checked_module)
 
     format_issue_fun.(
       issue_meta,
-      message: "There should be no unused return values for `#{module_name}` functions.",
+      message: message || "There should be no unused return values for `#{module_name}` functions.",
       trigger: trigger,
       line_no: meta[:line],
       column: meta[:column]

--- a/test/credo/check/warning/unused_operation_test.exs
+++ b/test/credo/check/warning/unused_operation_test.exs
@@ -76,6 +76,7 @@ defmodule Credo.Check.Warning.UnusedOperationTest do
       def some_function(parameter1, parameter2) do
         MyModule.transform(parameter1)
         OtherModule.do_something(parameter3)
+        My.Nested.Module.my_fun(parameter4)
 
         :ok
       end
@@ -85,10 +86,11 @@ defmodule Credo.Check.Warning.UnusedOperationTest do
     |> run_check(@described_check,
       modules: [
         {MyModule, :all},
-        {OtherModule, :all, "My special issue message"}
+        {OtherModule, :all, "My special issue message"},
+        {My.Nested.Module, [:my_fun]}
       ]
     )
-    |> assert_issues(2)
+    |> assert_issues(3)
     |> assert_issues_match([
       %{
         trigger: "MyModule.transform",
@@ -97,6 +99,10 @@ defmodule Credo.Check.Warning.UnusedOperationTest do
       %{
         trigger: "OtherModule.do_something",
         message: "My special issue message"
+      },
+      %{
+        trigger: "My.Nested.Module.my_fun",
+        message: ~r/My\.Nested\.Module/
       }
     ])
   end


### PR DESCRIPTION
Prior to this, if UnusedOperation was given a list of custom modules like this:

```
{Credo.Check.Warning.UnusedOperation,
  modules: [
    {DateTime, :all},
    {Keyword, :all},
    {List, :all},
    {Map, :all},
    {MapSet, :all},
    {Path, :all}
  ]}
```

...it would walk each file's AST once per item in the `:modules` list. This could be quite slow.

With this change, we first collect _all_ unused calls to _all_ the specified modules in a single pass over the AST, then filter from there to get down to just the function calls the user is interested in.

At Jump, we had 39 such `:modules` configured, so the total runtime of the check was over 30 seconds. With this change, it's down to 1.5-2 seconds, which is right on par with the runtime for `UnusedEnumOperation` and `UnusedFileOperation` (each of which specify just a single module to search for). The runtime for the particular `Unused*Operation` checks appears unchanged in my testing.

It's *conceivable* that this would actually be a performance _pessimization_, if you had tons and tons of calls to a module in your `:modules` config, and wanted to only filter down to one or two such calls. However, I'm having trouble imagining a scenario where a module is so heavily used across the _entire_ codebase that the filtering would take more time on average than the AST walking.