### PR TITLE
Support enabling check via {Credo.Check.*, true}

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -64,6 +64,10 @@
       #
       #     {Credo.Check.Design.DuplicatedCode, false}
       #
+      # To enable a check with default params put `true` or `[]` as second element:
+      #
+      #     {Credo.Check.Readability.StrictModuleLayout, true}
+      #
       checks: %{
         enabled: [
           #

--- a/guides/configuration/check_params.md
+++ b/guides/configuration/check_params.md
@@ -45,6 +45,12 @@ All checks are configured using a two-element tuple:
 {Credo.Check.Design.AliasUsage, if_nested_deeper_than: 2}
 ```
 
+Passing `true` is equivalent to passing an empty list of parameters:
+
+```elixir
+{Credo.Check.Readability.StrictModuleLayout, true}
+```
+
 ## General params
 
 While `params` are defined by each check individually, there are a couple of general params provided by Credo, which work the same for each check.

--- a/lib/credo/config_file.ex
+++ b/lib/credo/config_file.ex
@@ -388,11 +388,12 @@ defmodule Credo.ConfigFile do
         checks: %{enabled: checks_other_enabled} = checks_other
       })
       when is_list(checks_other_enabled) do
-    disabled = disable_check_tuples(checks_other[:disabled])
+    other_disabled = normalize_check_tuples(checks_other[:disabled])
+    disabled = disable_check_tuples(other_disabled)
 
     %{
       enabled: checks_other_enabled |> normalize_check_tuples() |> Keyword.merge(disabled),
-      disabled: checks_other[:disabled] || []
+      disabled: other_disabled
     }
   end
 
@@ -426,7 +427,9 @@ defmodule Credo.ConfigFile do
   end
 
   def merge_checks(base, other) when is_list(base) and is_list(other) do
-    Keyword.merge(base, other)
+    base
+    |> normalize_check_tuples()
+    |> Keyword.merge(normalize_check_tuples(other))
   end
 
   #
@@ -445,6 +448,7 @@ defmodule Credo.ConfigFile do
   end
 
   defp normalize_check_tuple({name}), do: {name, []}
+  defp normalize_check_tuple({name, true}), do: {name, []}
   defp normalize_check_tuple(tuple), do: tuple
 
   defp disable_check_tuples(nil), do: []

--- a/test/credo/config_file_test.exs
+++ b/test/credo/config_file_test.exs
@@ -562,6 +562,87 @@ defmodule Credo.ConfigFileTest do
            ]
   end
 
+  test "merge_checks treats true as default params" do
+    base = %ConfigFile{
+      checks: %{
+        enabled: [
+          {Credo.Check.Consistency.ExceptionNames, []},
+          {Credo.Check.Consistency.LineEndings, []}
+        ],
+        disabled: [
+          {Credo.Check.Readability.StrictModuleLayout, []}
+        ]
+      }
+    }
+
+    other = %ConfigFile{
+      checks: %{
+        enabled: [
+          {Credo.Check.Readability.StrictModuleLayout, true}
+        ]
+      }
+    }
+
+    expected = %{
+      enabled: [
+        {Credo.Check.Readability.StrictModuleLayout, []}
+      ],
+      disabled: []
+    }
+
+    assert_sorted_equality(expected, ConfigFile.merge_checks(base, other))
+  end
+
+  test "merge_checks treats true as default params for disabled checks" do
+    base = %ConfigFile{
+      checks: %{
+        enabled: [
+          {Credo.Check.Consistency.ExceptionNames, []}
+        ]
+      }
+    }
+
+    other = %ConfigFile{
+      checks: %{
+        enabled: [
+          {Credo.Check.Consistency.LineEndings, []}
+        ],
+        disabled: [
+          {Credo.Check.Readability.StrictModuleLayout, true}
+        ]
+      }
+    }
+
+    expected = %{
+      enabled: [
+        {Credo.Check.Consistency.LineEndings, []},
+        {Credo.Check.Readability.StrictModuleLayout, false}
+      ],
+      disabled: [
+        {Credo.Check.Readability.StrictModuleLayout, []}
+      ]
+    }
+
+    assert_sorted_equality(expected, ConfigFile.merge_checks(base, other))
+  end
+
+  test "merge_checks treats true as default params when merging check lists" do
+    base = [
+      {Credo.Check.Consistency.ExceptionNames, []},
+      {Credo.Check.Consistency.LineEndings, true}
+    ]
+
+    other = [
+      {Credo.Check.Readability.StrictModuleLayout, true}
+    ]
+
+    assert ConfigFile.merge_checks(base, other) == [
+             {Credo.Check.Consistency.ExceptionNames, []},
+             {Credo.Check.Consistency.LineEndings, []},
+             {Credo.Check.Readability.StrictModuleLayout, []}
+           ]
+  end
+
   test "loads .credo.exs from ./config subdirs in ascending directories as well" do
     dirs = ConfigFile.relevant_directories(".")
 


### PR DESCRIPTION
A common mistake I see a lot is folks (including myself) thinking you can modify a disabled check line in the config like:

```elixir
{Credo.Check.Readability.ModuleDoc, false},
```

...by simply changing the `true` to `false`. If you do this on mainline Credo, it will crash with a fairly cryptic error (you can't tell from the stacktrace which check caused the problem):

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for Atom

Got value:

    true

    (elixir 1.19.4) lib/enum.ex:5: Enumerable.impl_for!/1
    (elixir 1.19.4) lib/enum.ex:170: Enumerable.reduce/3
    (elixir 1.19.4) lib/enum.ex:4570: Enum.each/2
    (elixir 1.19.4) lib/enum.ex:961: Enum."-each/2-lists^foreach/1-0-"/2
    (credo 1.8.0-dev) lib/credo/execution/task/validate_config.ex:75: Credo.Execution.Task.ValidateConfig.validate_checks/1
    (credo 1.8.0-dev) lib/credo/execution/task/validate_config.ex:12: Credo.Execution.Task.ValidateConfig.call/2
    (credo 1.8.0-dev) lib/credo/execution/task.ex:132: Credo.Execution.Task.do_run/3
    (elixir 1.19.4) lib/enum.ex:2520: Enum."-reduce/3-lists^foldl/2-0-"/3
```

With this change, the inferred behavior ("I should be able to change false to true to enable it") will now "just work."