### PR TITLE
Fix `--all` command line flag

### DIFF
--- a/lib/credo/execution.ex
+++ b/lib/credo/execution.ex
@@ -307,6 +307,8 @@ defmodule Credo.Execution do
 
   @all_min_priority -99
 
+  def show_all?(%__MODULE__{cli_options: %{switches: %{all: true}}}), do: true
+
   def show_all?(%__MODULE__{} = exec) do
     exec.config.min_priority <= @all_min_priority
   end

--- a/test/credo/execution_test.exs
+++ b/test/credo/execution_test.exs
@@ -1,10 +1,16 @@
 defmodule Credo.ExecutionTest do
   use ExUnit.Case
 
+  alias Credo.CLI.Options
   alias Credo.Execution
 
   setup do
     [exec: %Execution{config: %Execution.RuntimeConfig{}, private: %Execution.Private{}}]
+  end
+
+  test "show_all? should be true when --all was given" do
+    exec = %Execution{cli_options: %Options{switches: %{all: true}}}
+    assert Execution.show_all?(exec)
   end
 
   test "it should work for put_assign & get_assign", %{exec: exec} do


### PR DESCRIPTION
Commit 2e53ab5a broke the `--all` option to `mix credo`, causing the truncation message, like:

```
┃  ...  (17 more, use `--all` to show them)
```

to be shown even when `--all` was supplied. With this change, `--all` is restored to listing all issues.