### PR TITLE
Fix TrailingWhiteSpace false positive on \\ at the end of sigils

### DIFF
--- a/lib/credo/code/heredocs.ex
+++ b/lib/credo/code/heredocs.ex
@@ -248,7 +248,7 @@ defmodule Credo.Code.Heredocs do
          ) do
       parse_non_removable_normal_sigil(
         t,
-        acc,
+        ["\\\\" | acc],
         unquote(sigil_end),
         replacement,
         empty_line_replacement

--- a/test/credo/code/heredocs_test.exs
+++ b/test/credo/code/heredocs_test.exs
@@ -770,4 +770,14 @@ defmodule Credo.Code.HeredocsTest do
 
     assert expected == source |> Heredocs.replace_with_spaces(".", ".", ".")
   end
+
+  test "should preserve `\\\\` token in non-removable sigils" do
+    source = ~S'''
+    @x = ~w(
+      a b \\
+    )a
+    '''
+
+    assert source == source |> Heredocs.replace_with_spaces()
+  end
 end


### PR DESCRIPTION
`Credo.Code.Heredocs.parse_non_removable_normal_sigil/5` matches `\\` inside a non-removable sigil like `~w(...)` but drops it from the accumulator, so the post-strip view loses both backslashes. When `\\` ends a line, `TrailingWhiteSpace` sees what looks like trailing whitespace and warns.

## Reproduction

```elixir
defmodule Repro do
  @moduledoc false
  @x ~w(
    a b \\
  )a
end
```

```
$ mix credo --strict
[R] There should be no trailing white-space at the end of a line.
      lib/repro.ex:4:8
```

## Fix

Mirror `Credo.Code.Strings.parse_removable_sigil/5`, which already keeps `"\\\\"` in the accumulator:

```diff
 defp parse_non_removable_normal_sigil(<<"\\\\"::utf8, t::binary>>, acc, ...) do
-  parse_non_removable_normal_sigil(t, acc, ...)
+  parse_non_removable_normal_sigil(t, ["\\\\" | acc], ...)
 end
```