### PR TITLE
feat: add allow_lists and allow_maps params to single pipe check

### DIFF
--- a/lib/credo/check/readability/single_pipe.ex
+++ b/lib/credo/check/readability/single_pipe.ex
@@ -3,7 +3,12 @@ defmodule Credo.Check.Readability.SinglePipe do
     id: "EX3023",
     base_priority: :high,
     tags: [:controversial],
-    param_defaults: [allow_0_arity_functions: false, allow_blocks: true],
+    param_defaults: [
+      allow_0_arity_functions: false,
+      allow_blocks: true,
+      allow_lists: false,
+      allow_maps: false
+    ],
     explanations: [
       check: """
       Pipes (`|>`) should only be used when piping data through multiple calls.
@@ -33,7 +38,9 @@ defmodule Credo.Check.Readability.SinglePipe do
       """,
       params: [
         allow_0_arity_functions: "Allow 0-arity functions",
-        allow_blocks: "Allow block functions/macro like `for`, `if` or `case`"
+        allow_blocks: "Allow block functions/macro like `for`, `if` or `case`",
+        allow_lists: "Allow single pipes where the value being piped is a list literal",
+        allow_maps: "Allow single pipes where the value being piped is a map literal (including structs)"
       ]
     ]
 
@@ -46,6 +53,22 @@ defmodule Credo.Check.Readability.SinglePipe do
   end
 
   defp walk({:|>, _, [{:|>, _, _} | _]} = ast, ctx) do
+    {ast, %{ctx | continue: false}}
+  end
+
+  defp walk(
+         {:|>, _, [lhs, _]} = ast,
+         %{continue: true, params: %{allow_maps: true}} = ctx
+       )
+       when is_tuple(lhs) and elem(lhs, 0) in [:%{}, :%] do
+    {ast, %{ctx | continue: false}}
+  end
+
+  defp walk(
+         {:|>, _, [lhs, _]} = ast,
+         %{continue: true, params: %{allow_lists: true}} = ctx
+       )
+       when is_list(lhs) do
     {ast, %{ctx | continue: false}}
   end
 

--- a/test/credo/check/readability/single_pipe_test.exs
+++ b/test/credo/check/readability/single_pipe_test.exs
@@ -96,6 +96,40 @@ defmodule Credo.Check.Readability.SinglePipeTest do
     |> refute_issues()
   end
 
+  test "it should NOT report violation when piping a map or a struct and :allow_maps is true" do
+    ~S'''
+    defmodule CredoSampleModule do
+      def some_fun do
+        %{a: 1, b: 2}
+        |> Map.put(:c, 3)
+
+        %MyStruct{name: "x"}
+        |> MyStruct.process()
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check, allow_maps: true)
+    |> refute_issues()
+  end
+
+  test "it should NOT report violation when piping a list and :allow_lists is true" do
+    ~S'''
+    defmodule CredoSampleModule do
+      def some_fun do
+        [key: :value, other: 1]
+        |> Keyword.get(:key)
+
+        [1, 2, 3]
+        |> Enum.sum()
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check, allow_lists: true)
+    |> refute_issues()
+  end
+
   #
   # cases raising issues
   #
@@ -213,5 +247,61 @@ defmodule Credo.Check.Readability.SinglePipeTest do
     |> to_source_file
     |> run_check(@described_check, allow_blocks: false)
     |> assert_issue()
+  end
+
+  test "it should report a violation when piping a map and :allow_maps is not set" do
+    ~S'''
+    defmodule CredoSampleModule do
+      def some_fun do
+        %{a: 1, b: 2}
+        |> Map.put(:c, 3)
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{trigger: "|>"})
+  end
+
+  test "it should report a violation when piping a struct and :allow_maps is not set" do
+    ~S'''
+    defmodule CredoSampleModule do
+      def some_fun do
+        %MyStruct{name: "x"}
+        |> MyStruct.process()
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{trigger: "|>"})
+  end
+
+  test "it should report a violation when piping a list and :allow_lists is not set" do
+    ~S'''
+    defmodule CredoSampleModule do
+      def some_fun do
+        [1, 2, 3]
+        |> Enum.sum()
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{trigger: "|>"})
+  end
+
+  test "it should report a violation when piping a keyword list and :allow_lists is not set" do
+    ~S'''
+    defmodule CredoSampleModule do
+      def some_fun do
+        [key: :value, other: 1]
+        |> Keyword.get(:key)
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{trigger: "|>"})
   end
 end


### PR DESCRIPTION
Add a couple new params to `Credo.Check.Readability.SinglePipe`:
  * `:allow_lists` - Makes the check not raise issues on single pipes when the first element of the pipeline is a list literal.
  * `:allow_maps` - Makes the check not raise issues on single pipes when the first element of the pipeline is a map or struct.

### Context

This check is already flagged as "controversial" because it's more opinionated. 

We would love to enable single pipe checks at the place I work. But in our opinion, it's fine to have maps, structs or list literals on single pipelines. Especially when those are large. Here's an example:

```elixir
%{
  first_name: "John",
  last_name: "Doe",
  email: "johndoe@example.com",
  address: %{
    line1: "222333 Peachtree Place",
    city: "Atlanta",
    state: "GA",
    zip_code: "30318"
  }
}
|> create_person(authorize?: false)
```

We think the above looks better than this:

```elixir
create_person(
  %{
    first_name: "John",
    last_name: "Doe",
    email: "johndoe@example.com",
    address: %{
      line1: "222333 Peachtree Place",
      city: "Atlanta",
      state: "GA",
      zip_code: "30318"
    }
  },
  authorize?: false
)
```

But again -- understanding this is an opinionated and controversial check, we're proposing an additional param to this check, so that users can opt in or out of this exception. By default, the check behaves as usual -- no single pipes at all, except on macros.

I'd appreciate a review on this and I'd be happy to discuss it further.