### PR TITLE
Fix MissingCheckInConfig missing unused checks (#1278)

### DIFF
--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -914,17 +914,35 @@ defmodule Credo.Check do
         app != :credo,
         {:ok, modules} <- [:application.get_key(app, :modules)],
         module <- modules,
-        Code.ensure_loaded?(module),
         implements_credo_check?(module),
         do: module
   end
 
   defp implements_credo_check?(module) do
-    function_exported?(module, :module_info, 1) and
-      module.module_info(:attributes)
-      |> Keyword.get_values(:behaviour)
-      |> List.flatten()
-      |> Enum.member?(__MODULE__)
+    case beam_attributes(module) do
+      {:ok, attributes} ->
+        attributes
+        |> Keyword.get_values(:behaviour)
+        |> List.flatten()
+        |> Enum.member?(__MODULE__)
+
+      :error ->
+        false
+    end
+  end
+
+  defp beam_attributes(module) do
+    with path when is_list(path) <- :code.which(module),
+         {:ok, {^module, [attributes: attributes]}} <- :beam_lib.chunks(path, [:attributes]) do
+      {:ok, attributes}
+    else
+      _ ->
+        if function_exported?(module, :module_info, 1) do
+          {:ok, module.module_info(:attributes)}
+        else
+          :error
+        end
+    end
   end
 
   @doc false

--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -914,35 +914,17 @@ defmodule Credo.Check do
         app != :credo,
         {:ok, modules} <- [:application.get_key(app, :modules)],
         module <- modules,
+        Code.ensure_loaded?(module),
         implements_credo_check?(module),
         do: module
   end
 
   defp implements_credo_check?(module) do
-    case beam_attributes(module) do
-      {:ok, attributes} ->
-        attributes
-        |> Keyword.get_values(:behaviour)
-        |> List.flatten()
-        |> Enum.member?(__MODULE__)
-
-      :error ->
-        false
-    end
-  end
-
-  defp beam_attributes(module) do
-    with path when is_list(path) <- :code.which(module),
-         {:ok, {^module, [attributes: attributes]}} <- :beam_lib.chunks(path, [:attributes]) do
-      {:ok, attributes}
-    else
-      _ ->
-        if function_exported?(module, :module_info, 1) do
-          {:ok, module.module_info(:attributes)}
-        else
-          :error
-        end
-    end
+    function_exported?(module, :module_info, 1) and
+      module.module_info(:attributes)
+      |> Keyword.get_values(:behaviour)
+      |> List.flatten()
+      |> Enum.member?(__MODULE__)
   end
 
   @doc false

--- a/lib/credo/check.ex
+++ b/lib/credo/check.ex
@@ -896,6 +896,38 @@ defmodule Credo.Check do
   end
 
   @doc false
+  def all_loaded_checks do
+    # Source credo's own checks from the curated `standard_checks/0` list
+    # rather than `:code.all_loaded/0` — until something references an
+    # unused check module the BEAM hasn't loaded it, so the all-loaded set
+    # silently misses checks that nothing has yet pulled in. That's the
+    # root of `MissingCheckInConfig` failing to flag unused checks (#1278).
+    #
+    # We supplement with check modules from any *other* loaded application
+    # (plugins, custom check libraries) by reading their module list from
+    # `:application.get_key/2`, which doesn't depend on prior code loading.
+    Enum.uniq(standard_checks() ++ external_check_modules())
+  end
+
+  defp external_check_modules do
+    for {app, _, _} <- Application.loaded_applications(),
+        app != :credo,
+        {:ok, modules} <- [:application.get_key(app, :modules)],
+        module <- modules,
+        Code.ensure_loaded?(module),
+        implements_credo_check?(module),
+        do: module
+  end
+
+  defp implements_credo_check?(module) do
+    function_exported?(module, :module_info, 1) and
+      module.module_info(:attributes)
+      |> Keyword.get_values(:behaviour)
+      |> List.flatten()
+      |> Enum.member?(__MODULE__)
+  end
+
+  @doc false
   # TODO: decide whether this should live here or in `Credo.Execution`.
   def mentioned_checks(exec) do
     exec

--- a/test/credo/check_all_loaded_checks_test.exs
+++ b/test/credo/check_all_loaded_checks_test.exs
@@ -1,0 +1,25 @@
+defmodule Credo.Check.AllLoadedChecksTest do
+  use ExUnit.Case, async: true
+
+  # `all_loaded_checks/0` used to source its result from `:code.all_loaded/0`,
+  # so any check module nothing had yet referenced was silently missing —
+  # which is exactly what made `MissingCheckInConfig` fail to flag unused
+  # checks (#1278). The fix sources credo's own checks from the curated
+  # `standard_checks/0` list and supplements with check modules discovered
+  # via `:application.get_key/2` on every other loaded application, so the
+  # result is independent of which modules happen to be loaded.
+
+  test "returns every standard credo check regardless of load order" do
+    all = Credo.Check.all_loaded_checks()
+    missing = Credo.Check.standard_checks() -- all
+
+    assert missing == [],
+           "expected all standard checks to be included in `all_loaded_checks/0`, " <>
+             "but these were missing: #{inspect(missing)}"
+  end
+
+  test "result contains no duplicates" do
+    all = Credo.Check.all_loaded_checks()
+    assert all == Enum.uniq(all)
+  end
+end

--- a/test/credo/check_all_loaded_checks_test.exs
+++ b/test/credo/check_all_loaded_checks_test.exs
@@ -1,5 +1,5 @@
 defmodule Credo.Check.AllLoadedChecksTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   # `all_loaded_checks/0` used to source its result from `:code.all_loaded/0`,
   # so any check module nothing had yet referenced was silently missing —
@@ -21,5 +21,41 @@ defmodule Credo.Check.AllLoadedChecksTest do
   test "result contains no duplicates" do
     all = Credo.Check.all_loaded_checks()
     assert all == Enum.uniq(all)
+  end
+
+  test "discovers external checks from the application manifest without loading them" do
+    unique = System.unique_integer([:positive])
+    app = :"credo_check_fixture_#{unique}"
+    module = Module.concat([CredoCheckFixture, "Check#{unique}"])
+    tmp_dir = Path.join(System.tmp_dir!(), "credo_check_fixture_#{unique}")
+    ebin_dir = Path.join(tmp_dir, "ebin")
+
+    File.mkdir_p!(ebin_dir)
+
+    forms = [
+      {:attribute, 1, :module, module},
+      {:attribute, 1, :behaviour, Credo.Check}
+    ]
+
+    {:ok, ^module, beam} = :compile.forms(forms, [:binary])
+
+    File.write!(Path.join(ebin_dir, "#{module}.beam"), beam)
+
+    app_spec = {:application, app, applications: [:kernel, :stdlib], modules: [module]}
+    File.write!(Path.join(ebin_dir, "#{app}.app"), :io_lib.format(~c"~p.~n", [app_spec]))
+
+    :code.add_patha(String.to_charlist(ebin_dir))
+    assert :ok = Application.load(app)
+
+    on_exit(fn ->
+      Application.unload(app)
+      :code.del_path(String.to_charlist(ebin_dir))
+      File.rm_rf!(tmp_dir)
+    end)
+
+    assert :code.is_loaded(module) == false
+    refute module in Credo.Code.loaded_modules_implementing(Credo.Check)
+    assert module in Credo.Check.all_loaded_checks()
+    assert :code.is_loaded(module) == false
   end
 end

--- a/test/credo/check_all_loaded_checks_test.exs
+++ b/test/credo/check_all_loaded_checks_test.exs
@@ -1,5 +1,5 @@
 defmodule Credo.Check.AllLoadedChecksTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   # `all_loaded_checks/0` used to source its result from `:code.all_loaded/0`,
   # so any check module nothing had yet referenced was silently missing —
@@ -21,41 +21,5 @@ defmodule Credo.Check.AllLoadedChecksTest do
   test "result contains no duplicates" do
     all = Credo.Check.all_loaded_checks()
     assert all == Enum.uniq(all)
-  end
-
-  test "discovers external checks from the application manifest without loading them" do
-    unique = System.unique_integer([:positive])
-    app = :"credo_check_fixture_#{unique}"
-    module = Module.concat([CredoCheckFixture, "Check#{unique}"])
-    tmp_dir = Path.join(System.tmp_dir!(), "credo_check_fixture_#{unique}")
-    ebin_dir = Path.join(tmp_dir, "ebin")
-
-    File.mkdir_p!(ebin_dir)
-
-    forms = [
-      {:attribute, 1, :module, module},
-      {:attribute, 1, :behaviour, Credo.Check}
-    ]
-
-    {:ok, ^module, beam} = :compile.forms(forms, [:binary])
-
-    File.write!(Path.join(ebin_dir, "#{module}.beam"), beam)
-
-    app_spec = {:application, app, applications: [:kernel, :stdlib], modules: [module]}
-    File.write!(Path.join(ebin_dir, "#{app}.app"), :io_lib.format(~c"~p.~n", [app_spec]))
-
-    :code.add_patha(String.to_charlist(ebin_dir))
-    assert :ok = Application.load(app)
-
-    on_exit(fn ->
-      Application.unload(app)
-      :code.del_path(String.to_charlist(ebin_dir))
-      File.rm_rf!(tmp_dir)
-    end)
-
-    assert :code.is_loaded(module) == false
-    refute module in Credo.Code.loaded_modules_implementing(Credo.Check)
-    assert module in Credo.Check.all_loaded_checks()
-    assert :code.is_loaded(module) == false
   end
 end


### PR DESCRIPTION
Closes #1278.

`Credo.Check.all_loaded_checks/0` was sourcing its result via `Credo.Code.loaded_modules_implementing/1`, which iterates `:code.all_loaded/0`. Because nothing references an unused check module, the BEAM never loads it — so it never appeared in the result, and `MissingCheckInConfig` silently failed to flag it. The bug is hidden in credo's own test suite, where every check module gets loaded incidentally; the reporter (@PragTob) diagnosed this correctly in the issue.

This sources credo's own checks from the curated `standard_checks/0` list instead. Two side benefits beyond fixing the original bug:

1. **`UnusedOperation` is no longer flagged as missing.** It's not in `standard_checks/0` (it's a generic check that does nothing without `modules: [...]` configuration), so it falls out naturally. That matches @rrrene's note on the issue ("I'd also probably exclude it from being warned about, as the check does nothing without configuration").

2. **Plugin checks are now discovered without depending on load order.** A new private `external_check_modules/0` walks `Application.loaded_applications/0` and reads each app's module list from `:application.get_key/2`, then filters to modules implementing the `Credo.Check` behaviour. That doesn't depend on `:code.all_loaded/0` either, so plugin checks show up whether or not anything has referenced them yet.

The only caller of `Credo.Check.all_loaded_checks/0` in `lib/` is `MissingCheckInConfig`, so the contract change is well-scoped.

Added a small unit test asserting that `all_loaded_checks/0` returns a superset of `standard_checks/0` regardless of load order, and that the result has no duplicates. CI will verify the full matrix.