### PR TITLE
Fix FunctionClauseError in Token.position/1 for Elixir 1.20 sigil tokens (missed clauses from #1275)

### DIFF
--- a/lib/credo/code/token.ex
+++ b/lib/credo/code/token.ex
@@ -112,7 +112,7 @@ defmodule Credo.Code.Token do
   end
 
   # Elixir >= 1.9.0 tuple syntax
-  def position({{line_no, col_start, nil}, {_line_no2, _col_start2, nil}, atom_or_charlist}) do
+  def position({{line_no, col_start, _end_position}, {_line_no2, _col_start2, _end_position2}, atom_or_charlist}) do
     position_tuple_for_quoted_string(atom_or_charlist, line_no, col_start)
   end
 
@@ -252,7 +252,7 @@ defmodule Credo.Code.Token do
   defp convert_to_col_end(
          _,
          _,
-         {{line_no, col_start, nil}, {_line_no2, _col_start2, nil}, list}
+         {{line_no, col_start, _end_position}, {_line_no2, _col_start2, _end_position2}, list}
        ) do
     {line_no_end, col_end, _terminator} = convert_to_col_end(line_no, col_start, list)
 
@@ -308,7 +308,7 @@ defmodule Credo.Code.Token do
     {line_no, to_col_end(col_start, value), nil}
   end
 
-  defp convert_to_col_end(_, _, {:sigil, {line_no, col_start, nil}, _, list, _, _})
+  defp convert_to_col_end(_, _, {:sigil, {line_no, col_start, _end_position}, _, list, _, _})
        when is_list(list) do
     Enum.reduce(list, {line_no, col_start, nil}, &reduce_to_col_end/2)
   end
@@ -323,7 +323,7 @@ defmodule Credo.Code.Token do
     Enum.reduce(list, {line_no, col_start, nil}, &reduce_to_col_end/2)
   end
 
-  defp convert_to_col_end(_, _, {:sigil, {line_no, col_start, nil}, _, value, _, _}) do
+  defp convert_to_col_end(_, _, {:sigil, {line_no, col_start, _end_position}, _, value, _, _}) do
     {line_no, to_col_end(col_start, value), nil}
   end
 

--- a/test/credo/check/consistency/space_around_operators_test.exs
+++ b/test/credo/check/consistency/space_around_operators_test.exs
@@ -459,4 +459,22 @@ defmodule Credo.Check.Consistency.SpaceAroundOperatorsTest do
     |> run_check(@described_check, ignore: [:+])
     |> refute_issues()
   end
+
+  test "it should not crash for issue #1289" do
+    [
+      ~S'''
+      defmodule Example do
+        def foo, do: ~D[0000-01-01]
+      end
+      ''',
+      ~S'''
+      defmodule Other do
+        def bar(x), do: x =~ ~r/foo/
+      end
+      '''
+    ]
+    |> to_source_files()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
 end

--- a/test/credo/code/token_test.exs
+++ b/test/credo/code/token_test.exs
@@ -402,6 +402,13 @@ defmodule Credo.Code.TokenTest do
     assert {1, 30, 1, 40} == Token.position({:sigil, {1, 30, nil}, :sigil_s, ["\\\"\\\"\\\""], [], nil, "("})
 
     assert {11, 28, 11, 39} == Token.position({:sigil, {11, 28, nil}, :sigil_XX, ["\\\"\\\"\\\""], [], nil, "("})
+
+    # Elixir >= 1.20 changed the third position element from nil to {end_line, end_col}
+    assert {1, 30, 1, 40} == Token.position({:sigil, {1, 30, {1, 40}}, :sigil_s, ["\\\"\\\"\\\""], [], nil, "("})
+    assert {11, 28, 11, 39} == Token.position({:sigil, {11, 28, {11, 39}}, :sigil_XX, ["\\\"\\\"\\\""], [], nil, "("})
+
+    # Elixir >= 1.20 interpolation tuple: third element is now {end_line, end_col} not nil
+    assert {1, 25, 1, 31} == Token.position({{1, 25, {1, 32}}, {1, 31, {1, 32}}, ["name"]})
   end
 
   test "should give correct token position for strings" do


### PR DESCRIPTION
## What broke

Running `mix credo` under Elixir 1.20-rc.5 / rc.6 crashes with a `FunctionClauseError` in `Credo.Code.Token.position/1`:

```
** (FunctionClauseError) no function clause matching in Credo.Code.Token.position/1
    lib/credo/code/token.ex:37: Credo.Code.Token.position({:sigil, {3, 10, {3, 17}}, :sigil_r, ["foo"], [], nil, "/"})
```

Reported in #1289.

## Root cause

Elixir 1.20 changed the sigil token position metadata: the third element of the `{line, col, _}` tuple changed from `nil` to `{end_line, end_col}`. Four clauses in `Credo.Code.Token` that explicitly pattern-matched `nil` in that position therefore fail to match and crash.

PR #1275 (released in 1.7.16) fixed the `>= 1.10.0` 7-element sigil clause at line ~101 but missed the older `>= 1.9.0` clauses that use the 6-element sigil tuple format and the 3-element interpolation tuple format.

## Clauses fixed

All four changes are mechanical: `nil` -> `_` in the third element of the position tuple.

| File | Function | Clause |
|------|----------|--------|
| `lib/credo/code/token.ex` | `position/1` | `>= 1.9.0` interpolation 3-tuple (line ~115) |
| `lib/credo/code/token.ex` | `convert_to_col_end/3` | `>= 1.9.0` interpolation 3-tuple (line ~255) |
| `lib/credo/code/token.ex` | `convert_to_col_end/3` | Old 6-element sigil tuple, list body (line ~311) |
| `lib/credo/code/token.ex` | `convert_to_col_end/3` | Old 6-element sigil tuple, non-list body (line ~326) |

## Minimal reproduction

```elixir
# lib/example.ex
defmodule Example do
  def run, do: ~D[0000-01-01]
end

# lib/other.ex
defmodule Other do
  def run, do: ~r/foo/
end
```

```
$ ASDF_ERLANG_VERSION=28.4.3 ASDF_ELIXIR_VERSION=1.20.0-rc.6-otp-28 mix credo --strict
# Before fix: FunctionClauseError crash
# After fix:  runs cleanly
```

## Tests

New assertions added to `test/credo/code/token_test.exs`:

- Two assertions covering the `>= 1.10.0` 7-element sigil tuple with `{end_line, end_col}` (the new 1.20 format)
- One assertion directly exercising the `>= 1.9.0` 3-element interpolation tuple with `{end_line, end_col}`

All existing tests continue to pass on both Elixir 1.19.5 and 1.20.0-rc.6.

Fixes #1289