### PR TITLE
Enable UnsafeToAtom by default and frame it as a security check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -157,6 +157,7 @@
           {Credo.Check.Warning.SpecWithStruct, []},
           {Credo.Check.Warning.StructFieldAmount, []},
           {Credo.Check.Warning.UnsafeExec, []},
+          {Credo.Check.Warning.UnsafeToAtom, []},
           {Credo.Check.Warning.UnusedEnumOperation, []},
           {Credo.Check.Warning.UnusedFileOperation, []},
           {Credo.Check.Warning.UnusedKeywordOperation, []},
@@ -213,8 +214,7 @@
           {Credo.Check.Warning.LazyLogging, []},
           {Credo.Check.Warning.LeakyEnvironment, []},
           {Credo.Check.Warning.MapGetUnsafePass, []},
-          {Credo.Check.Warning.MixEnv, []},
-          {Credo.Check.Warning.UnsafeToAtom, []}
+          {Credo.Check.Warning.MixEnv, []}
 
           # {Credo.Check.Refactor.MapInto, []},
 

--- a/lib/credo/check/warning/unsafe_to_atom.ex
+++ b/lib/credo/check/warning/unsafe_to_atom.ex
@@ -3,11 +3,16 @@ defmodule Credo.Check.Warning.UnsafeToAtom do
     id: "EX5016",
     base_priority: :high,
     category: :warning,
-    tags: [:controversial],
     explanations: [
       check: """
-      Creating atoms from unknown or external sources dynamically is a potentially
-      unsafe operation because atoms are not garbage-collected by the runtime.
+      Creating atoms from unknown or external input is a security risk, not just a
+      style preference.
+
+      Atoms are not garbage-collected by the runtime and the number of atoms a node
+      can hold is capped (1_048_576 by default). Any code path that turns
+      attacker-controlled input into atoms can therefore exhaust the atom table and
+      crash the entire VM. That is a denial-of-service vulnerability, and in a
+      web-facing application it is a CVE waiting to happen.
 
       Creating an atom from a string or charlist should be done by using
 
@@ -33,6 +38,9 @@ defmodule Credo.Check.Warning.UnsafeToAtom do
 
           Jason.decode(str)
 
+      For more on atom exhaustion as an attack vector, see:
+
+      https://erlef.org/blog/security/atom-exhaustion
       """
     ]
 


### PR DESCRIPTION
Inspired by the excellent EEF security write up https://erlef.org/blog/security/atom-exhaustion I wondered why this was disabled by default.

I've moved `Credo.Check.Warning.UnsafeToAtom` from the disabled (opt-in) section of `.credo.exs` into the enabled section, drop its `:controversial` tag, and rewrite the explanation to explain the security risk.

Converting unknown or external input into atoms is a security risk. Atoms are never garbage-collected and a node's atom table is capped (1_048_576 by default), so any code path that turns attacker-controlled input into atoms can exhaust the table and crash the whole VM. That is a denial-of-service vulnerability, and in a web-facing application it is a potential CVE.

Leaving this off by default and tagging it `:controversial` sends the wrong message for a security check. The explanation now links to the EEF Security WG write-up.