### PR TITLE
Fix `already_started` error when `:credo` is started after a Credo run

### DIFF
--- a/lib/credo/cli.ex
+++ b/lib/credo/cli.ex
@@ -11,7 +11,7 @@ defmodule Credo.CLI do
   See `Credo.run/1` if you want to run Credo programmatically.
   """
   def main(argv \\ []) do
-    Credo.Application.start(nil, nil)
+    Application.ensure_all_started(:credo)
 
     {options, _argv_rest, _errors} = OptionParser.parse(argv, strict: [watch: :boolean])
 


### PR DESCRIPTION
`Credo.CLI.main/1` starts the supervision tree with `Credo.Application.start/2`, bypassing the application controller, so `Credo.Supervisor` is alive while `:credo` is not a started application.

That leaks into any BEAM where something later starts `:credo` properly, such as a Mix alias running `credo` and `test` in one invocation, which is how I ran into it. On master:

```
$ mix do credo lib/credo/cli.ex --mute-exit-status + run --no-start -e 'IO.inspect(Application.ensure_all_started(:credo))'
{:error, {:credo, {{:already_started, #PID<0.190.0>}, {Credo.Application, :start, [:normal, []]}}}}
```

The start callback runs again and collides on the registered supervisor name. With this change the same command returns `{:ok, []}`.

`Application.ensure_all_started/1` covers both entrypoints:

- Under the Mix task, `@requirements ["loadpaths"]` puts the app spec on the code path, so the app starts normally.
- In the escript it is already started, since `mix escript.build` starts the app unless `:app` is nil. That also made the direct call a no-op there, with its error discarded.

The return value stays unmatched, as before, so startup failures behave as they do today.

`mix test` passes (1813 tests). I did not add a test: `main/1` halts the VM, and asserting on application state would mean stopping `:credo` inside the suite that depends on it. The 20 failures under `--include slow` are on master too, from `.credo.exs` deactivating checks with `false`.
