### PR TITLE
fix(alias_usage): flag unaliased struct literals

### DIFF
--- a/lib/credo/check/design/alias_usage.ex
+++ b/lib/credo/check/design/alias_usage.ex
@@ -119,6 +119,12 @@ defmodule Credo.Check.Design.AliasUsage do
     do_find_issues(ast, mod_list, meta, ctx)
   end
 
+  # Struct literals: %Foo.Bar.Baz{} — the module is a reference, not a function call
+  defp find_issues({:%, _, [{:__aliases__, meta, mod_list}, _]} = ast, ctx)
+       when is_list(mod_list) do
+    do_find_issues(ast, mod_list, meta, ctx)
+  end
+
   defp find_issues(ast, ctx) do
     {ast, ctx}
   end

--- a/test/credo/check/design/alias_usage_test.exs
+++ b/test/credo/check/design/alias_usage_test.exs
@@ -407,6 +407,51 @@ defmodule Credo.Check.Design.AliasUsageTest do
   # cases raising issues
   #
 
+  #
+  # struct literal cases
+  #
+
+  test "it should NOT report struct literal when module is already aliased" do
+    ~S'''
+    defmodule Foo do
+      alias Foo.Bar.Baz
+
+      def run do
+        %Baz{}
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
+  test "it should report struct literal with unaliased nested module" do
+    ~S'''
+    defmodule Foo do
+      def run do
+        %Foo.Bar.Baz{}
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{line_no: 3, trigger: "Foo.Bar.Baz"})
+  end
+
+  test "it should report struct literal with fields and unaliased nested module" do
+    ~S'''
+    defmodule Foo do
+      def run do
+        %Foo.Bar.Baz{key: :value}
+      end
+    end
+    '''
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue(%{line_no: 3, trigger: "Foo.Bar.Baz"})
+  end
+
   test "it should report violation on impossible additional alias when using multi alias" do
     ~S'''
     defmodule Test do


### PR DESCRIPTION
`%Foo.Bar.Baz{}` was silently ignored because the `:%` AST node didn't match any `find_issues` clause. Add a clause for struct literals so they're treated as module references.

Closes #1303.