### PR TITLE
Add --format github for GitHub Actions annotations

### DIFF
--- a/guides/commands/suggest_command.md
+++ b/guides/commands/suggest_command.md
@@ -29,7 +29,7 @@ $ mix credo suggest --checks-without-tag formatter --checks-without-tag controve
 | [`--enable-disabled-checks`](#enable-disabled-checks)                                              | Re-enable disabled checks that match the given comma-seperated patterns  |
 | [`--files-included`](#files-included)                                                              | Only include these files                                                 |
 | [`--files-excluded`](#files-excluded)                                                              | Exclude these files                                                      |
-| [`--format`](#format)                                                                              | Display the list in a specific format (json, flycheck, sarif or oneline) |
+| [`--format`](#format)                                                                              | Display the list in a specific format (github, json, flycheck, sarif or oneline) |
 | [`--ignore-checks`](#ignore-checks-aliased-as-ignore)                                              | Ignore checks that match the given comma-seperated patterns              |
 | [`--ignore`](#ignore)                                                                              | Alias for [`--ignore-checks`](#ignore-checks-aliased-as-ignore)          |
 | [`--min-priority`](#min-priority)                                                                  | Minimum priority to show issues                                          |
@@ -151,7 +151,7 @@ $ mix credo --files-excluded "./test/**/*.exs"
 
 ### `--format`
 
-Display the list in a specific format (json, flycheck, sarif or oneline)
+Display the list in a specific format (github, json, flycheck, sarif or oneline)
 
 ```bash
 $ mix credo --format json

--- a/guides/configuration/cli_switches.md
+++ b/guides/configuration/cli_switches.md
@@ -13,6 +13,7 @@ Here are a couple of common use case and their respective command line switches:
 Use `--format` to format the output in one of the following formats:
 
 - `--format flycheck` for [Flycheck](http://www.flycheck.org/) output
+- `--format github` for [GitHub Actions annotation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-warning-message) output
 - `--format json` for [JSON](https://www.json.org/) output
 - `--format sarif` for [SARIF](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=sarif) output
 
@@ -140,7 +141,7 @@ Suggest options:
       --enable-disabled-checks  Re-enable disabled checks that match the given strings
       --files-included          Only include these files (accepts globs, can be used multiple times)
       --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-      --format                  Display the list in a specific format (json,flycheck,sarif,oneline)
+      --format                  Display the list in a specific format (github,json,flycheck,sarif,oneline)
   -i, --ignore-checks           Ignore checks that match the given strings
       --ignore                  Alias for --ignore-checks
       --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)

--- a/lib/credo/cli/command/diff/diff_output.ex
+++ b/lib/credo/cli/command/diff/diff_output.ex
@@ -4,6 +4,7 @@ defmodule Credo.CLI.Command.Diff.DiffOutput do
   use Credo.CLI.Output.FormatDelegator,
     default: Credo.CLI.Command.Diff.Output.Default,
     flycheck: Credo.CLI.Command.Diff.Output.FlyCheck,
+    github: Credo.CLI.Command.Diff.Output.GitHub,
     oneline: Credo.CLI.Command.Diff.Output.Oneline,
     json: Credo.CLI.Command.Diff.Output.Json
 
@@ -41,7 +42,7 @@ defmodule Credo.CLI.Command.Diff.DiffOutput do
             --enable-disabled-checks  Re-enable disabled checks that match the given strings
             --files-included          Only include these files (accepts globs, can be used multiple times)
             --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-            --format                  Display the list in a specific format (json)
+            --format                  Display the list in a specific format (github,json)
             --from-dir                Diff from the given directory
             --from-git-ref            Diff from the given Git ref
             --from-git-merge-base     Diff from where the current HEAD branched off from the given merge base

--- a/lib/credo/cli/command/diff/output/github.ex
+++ b/lib/credo/cli/command/diff/output/github.ex
@@ -1,0 +1,15 @@
+defmodule Credo.CLI.Command.Diff.Output.GitHub do
+  @moduledoc false
+
+  alias Credo.CLI.Output.Formatter.GitHub
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> Enum.filter(&(&1.diff_marker == :new))
+    |> GitHub.print_issues()
+  end
+end

--- a/lib/credo/cli/command/list/list_output.ex
+++ b/lib/credo/cli/command/list/list_output.ex
@@ -4,6 +4,7 @@ defmodule Credo.CLI.Command.List.ListOutput do
   use Credo.CLI.Output.FormatDelegator,
     default: Credo.CLI.Command.List.Output.Default,
     flycheck: Credo.CLI.Command.List.Output.FlyCheck,
+    github: Credo.CLI.Command.List.Output.GitHub,
     oneline: Credo.CLI.Command.List.Output.Oneline,
     json: Credo.CLI.Command.List.Output.Json,
     sarif: Credo.CLI.Command.List.Output.Sarif
@@ -42,7 +43,7 @@ defmodule Credo.CLI.Command.List.ListOutput do
             --enable-disabled-checks  Re-enable disabled checks that match the given strings
             --files-included          Only include these files (accepts globs, can be used multiple times)
             --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-            --format                  Display the list in a specific format (json,flycheck,sarif,oneline)
+            --format                  Display the list in a specific format (github,json,flycheck,sarif,oneline)
         -i, --ignore-checks           Ignore checks that match the given strings
             --ignore                  Alias for --ignore-checks
             --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)

--- a/lib/credo/cli/command/list/output/github.ex
+++ b/lib/credo/cli/command/list/output/github.ex
@@ -1,0 +1,14 @@
+defmodule Credo.CLI.Command.List.Output.GitHub do
+  @moduledoc false
+
+  alias Credo.CLI.Output.Formatter.GitHub
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> GitHub.print_issues()
+  end
+end

--- a/lib/credo/cli/command/suggest/output/github.ex
+++ b/lib/credo/cli/command/suggest/output/github.ex
@@ -1,0 +1,14 @@
+defmodule Credo.CLI.Command.Suggest.Output.GitHub do
+  @moduledoc false
+
+  alias Credo.CLI.Output.Formatter.GitHub
+  alias Credo.Execution
+
+  def print_before_info(_source_files, _exec), do: nil
+
+  def print_after_info(_source_files, exec, _time_load, _time_run) do
+    exec
+    |> Execution.get_issues()
+    |> GitHub.print_issues()
+  end
+end

--- a/lib/credo/cli/command/suggest/suggest_output.ex
+++ b/lib/credo/cli/command/suggest/suggest_output.ex
@@ -4,6 +4,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
   use Credo.CLI.Output.FormatDelegator,
     default: Credo.CLI.Command.Suggest.Output.Default,
     flycheck: Credo.CLI.Command.Suggest.Output.FlyCheck,
+    github: Credo.CLI.Command.Suggest.Output.GitHub,
     oneline: Credo.CLI.Command.Suggest.Output.Oneline,
     json: Credo.CLI.Command.Suggest.Output.Json,
     jsonl: Credo.CLI.Command.Suggest.Output.Jsonl,
@@ -43,7 +44,7 @@ defmodule Credo.CLI.Command.Suggest.SuggestOutput do
             --enable-disabled-checks  Re-enable disabled checks that match the given strings
             --files-included          Only include these files (accepts globs, can be used multiple times)
             --files-excluded          Exclude these files (accepts globs, can be used multiple times)
-            --format                  Display the list in a specific format (json,flycheck,sarif,oneline)
+            --format                  Display the list in a specific format (github,json,flycheck,sarif,oneline)
         -i, --ignore-checks           Ignore checks that match the given strings
             --ignore                  Alias for --ignore-checks
             --min-priority            Minimum priority to show issues (higher,high,normal,low,ignore or number)

--- a/lib/credo/cli/output/formatter/github.ex
+++ b/lib/credo/cli/output/formatter/github.ex
@@ -1,0 +1,74 @@
+defmodule Credo.CLI.Output.Formatter.GitHub do
+  @moduledoc false
+
+  alias Credo.CLI.Output.UI
+  alias Credo.Issue
+  alias Credo.Priority
+
+  def print_issues(issues) do
+    Enum.each(issues, fn issue ->
+      issue
+      |> to_annotation()
+      |> UI.puts()
+    end)
+  end
+
+  @doc """
+  Converts the given `issue` to a GitHub Actions workflow command, e.g.
+
+      ::warning file=lib/foo.ex,line=10,col=5,title=Credo.Check.Readability.ModuleDoc::message
+  """
+  @spec to_annotation(Issue.t()) :: String.t()
+  def to_annotation(
+        %Issue{
+          message: message,
+          filename: filename,
+          column: column,
+          line_no: line_no
+        } = issue
+      ) do
+    properties =
+      [
+        {"file", to_string(filename)},
+        {"line", line_no},
+        {"col", column},
+        {"endColumn", column_end(issue)},
+        {"title", Credo.Code.Name.full(issue.check)}
+      ]
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Enum.map_join(",", fn {key, value} ->
+        "#{key}=#{escape_property(to_string(value))}"
+      end)
+
+    "::#{severity(issue)} #{properties}::#{escape_message(message)}"
+  end
+
+  defp severity(issue) do
+    case Priority.to_atom(issue.priority) do
+      :higher -> "error"
+      :high -> "error"
+      :normal -> "warning"
+      _priority -> "notice"
+    end
+  end
+
+  defp column_end(%Issue{column: column, trigger: trigger}) do
+    if column && trigger && trigger != Issue.no_trigger() do
+      column + String.length(to_string(trigger))
+    end
+  end
+
+  defp escape_message(value) do
+    value
+    |> String.replace("%", "%25")
+    |> String.replace("\r", "%0D")
+    |> String.replace("\n", "%0A")
+  end
+
+  defp escape_property(value) do
+    value
+    |> escape_message()
+    |> String.replace(":", "%3A")
+    |> String.replace(",", "%2C")
+  end
+end

--- a/test/credo/cli/output/formatter/github_test.exs
+++ b/test/credo/cli/output/formatter/github_test.exs
@@ -1,0 +1,63 @@
+defmodule Credo.CLI.Output.Formatter.GitHubTest do
+  use Credo.Test.Case
+
+  alias Credo.CLI.Output.Formatter.GitHub
+  alias Credo.Issue
+
+  setup do
+    %{
+      issue: %Issue{
+        check: Credo.Check.Readability.ModuleDoc,
+        category: :readability,
+        priority: 1,
+        message: "Modules should have a @moduledoc tag.",
+        filename: "lib/foo.ex",
+        line_no: 10,
+        column: 5,
+        trigger: Issue.no_trigger()
+      }
+    }
+  end
+
+  describe "to_annotation/1" do
+    test "renders a warning for a normal priority issue", %{issue: %Issue{} = issue} do
+      assert GitHub.to_annotation(issue) ==
+               "::warning file=lib/foo.ex,line=10,col=5,title=Credo.Check.Readability.ModuleDoc::Modules should have a @moduledoc tag."
+    end
+
+    test "renders an error for high and higher priority issues", %{issue: %Issue{} = issue} do
+      assert GitHub.to_annotation(%Issue{issue | priority: 12}) =~ ~r/^::error /
+      assert GitHub.to_annotation(%Issue{issue | priority: 20}) =~ ~r/^::error /
+    end
+
+    test "renders a notice for low and ignored priority issues", %{issue: %Issue{} = issue} do
+      assert GitHub.to_annotation(%Issue{issue | priority: -1}) =~ ~r/^::notice /
+      assert GitHub.to_annotation(%Issue{issue | priority: -11}) =~ ~r/^::notice /
+    end
+
+    test "omits line and column properties when they are nil", %{issue: %Issue{} = issue} do
+      assert GitHub.to_annotation(%Issue{issue | line_no: nil, column: nil}) ==
+               "::warning file=lib/foo.ex,title=Credo.Check.Readability.ModuleDoc::Modules should have a @moduledoc tag."
+    end
+
+    test "includes endColumn when a trigger is present", %{issue: %Issue{} = issue} do
+      assert GitHub.to_annotation(%Issue{issue | trigger: "@impl"}) ==
+               "::warning file=lib/foo.ex,line=10,col=5,endColumn=10,title=Credo.Check.Readability.ModuleDoc::Modules should have a @moduledoc tag."
+    end
+
+    test "omits endColumn when column is nil", %{issue: %Issue{} = issue} do
+      assert GitHub.to_annotation(%Issue{issue | column: nil, trigger: "@impl"}) ==
+               "::warning file=lib/foo.ex,line=10,title=Credo.Check.Readability.ModuleDoc::Modules should have a @moduledoc tag."
+    end
+
+    test "escapes the message", %{issue: %Issue{} = issue} do
+      assert GitHub.to_annotation(%Issue{issue | message: "50% of lines,\nare: too long\r\n"}) ==
+               "::warning file=lib/foo.ex,line=10,col=5,title=Credo.Check.Readability.ModuleDoc::50%25 of lines,%0Aare: too long%0D%0A"
+    end
+
+    test "escapes property values", %{issue: %Issue{} = issue} do
+      assert GitHub.to_annotation(%Issue{issue | filename: "lib/foo,bar:baz%.ex"}) ==
+               "::warning file=lib/foo%2Cbar%3Abaz%25.ex,line=10,col=5,title=Credo.Check.Readability.ModuleDoc::Modules should have a @moduledoc tag."
+    end
+  end
+end


### PR DESCRIPTION
Emits GitHub Actions workflow commands so that issues show up as inline annotations on pull requests.

Addresses https://github.com/rrrene/credo-proposals/issues/98.