### PR TITLE
Add markdown formatter to docs output

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Credo.Mixfile do
       logo: "assets/credo-logo-with-trail.png",
       extra_section: "GUIDES",
       assets: %{"guides/assets" => "doc/assets"},
-      formatters: ["html"],
+      formatters: ["html", "markdown"],
       nest_modules_by_prefix: nest_modules_by_prefix(),
       groups_for_modules: groups_for_modules(),
       extras: extras(),


### PR DESCRIPTION
ex_doc v0.40.0 added a Markdown formatter and generates `llms.txt` by default. Because Credo pins an explicit `formatters:` list that predates that release, the new default does not apply.

This adds only `"markdown"` to the existing list. HTML output is unchanged, and no other formatter is added or removed. After the next docs publish, `hexdocs.pm/credo/llms.txt` and individual `.md` pages will be available.

Verified with `mix docs` (including generated `doc/llms.txt` and Markdown pages), `mix test` (1,850 tests and 21 doctests), and the runtime-warning and smoke-test scripts.

This PR was generated from [Elixir's retrieval gap is a rollout problem, not an access problem](https://phxagents.dev/research/elixir-retrieval-gap/).

— Oliver’s AMP