### PR TITLE
fix: handle async option set to a non-boolean value

### DIFF
--- a/lib/credo/check/refactor/pass_async_in_test_cases.ex
+++ b/lib/credo/check/refactor/pass_async_in_test_cases.ex
@@ -38,11 +38,15 @@ defmodule Credo.Check.Refactor.PassAsyncInTestCases do
         :error ->
           {ast, put_issue(ctx, issue_for(ctx, meta, :default))}
 
-        {:ok, true} ->
-          {ast, ctx}
-
         {:ok, false} ->
           handle_explicit_async_false(ast, ctx)
+
+        # `true`, or a value that is only known at compile or run time, such as
+        # `Application.compile_env/3` or a module attribute. The option is
+        # passed, which is what this check asks for, and whether it resolves to
+        # `false` cannot be seen here.
+        {:ok, _passed} ->
+          {ast, ctx}
       end
     else
       {ast, ctx}

--- a/test/credo/check/refactor/pass_async_in_test_cases_test.exs
+++ b/test/credo/check/refactor/pass_async_in_test_cases_test.exs
@@ -59,6 +59,29 @@ defmodule Credo.Check.Refactor.PassAsyncInTestCasesTest do
       |> refute_issues()
     end
 
+    test "it allows `use #{@case_name}, async:` with a value from a function call" do
+      ~s'''
+      defmodule FooTest do
+        use #{@case_name}, async: Application.compile_env(:my_app, :async, true)
+      end
+      '''
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it allows `use #{@case_name}, async:` with a value from an attribute" do
+      ~s'''
+      defmodule FooTest do
+        @async false
+        use #{@case_name}, async: @async
+      end
+      '''
+      |> to_source_file()
+      |> run_check(@described_check, force_comment_on_explicit_false: true)
+      |> refute_issues()
+    end
+
     #
     # cases raising issues
     #


### PR DESCRIPTION
This fixes a CaseClauseError if the `async` option for `use ExUnit.Case` is set via function call or module attribute, which can make sense if the test suite runs the same test module multiple times with different parameters (e.g. using different adapters).

```
    ** (CaseClauseError) no case clause matching:

    {:ok,
     {{:., [line: 3, column: 23],
       [
         {:__aliases__, [last: [line: 3, column: 12], line: 3, column: 12],
          [:Application]},
         :compile_env
       ]}, [closing: [line: 3, column: 73], line: 3, column: 24],
      [:flop, :async_integration_tests, true]}}

        (credo 1.7.19) lib/credo/check/refactor/pass_async_in_test_cases.ex:37: Credo.Check.Refactor.PassAsyncInTestCases.walk/2
        (elixir 1.20.3) lib/macro.ex:661: anonymous fn/4 in Macro.do_traverse_args/4
        (stdlib 8.0.3) lists.erl:2673: :lists.mapfoldl_1/3
        (elixir 1.20.3) lib/macro.ex:626: Macro.do_traverse/4
        (elixir 1.20.3) lib/macro.ex:641: Macro.do_traverse/4
        (stdlib 8.0.3) lists.erl:2673: :lists.mapfoldl_1/3
        (elixir 1.20.3) lib/macro.ex:646: Macro.do_traverse/4
        (stdlib 8.0.3) lists.erl:2673: :lists.mapfoldl_1/3
```