### PR TITLE
fix: avoid arbitrary consistency warnings on tied conventions

### DIFF
--- a/lib/credo/check/consistency/collector.ex
+++ b/lib/credo/check/consistency/collector.ex
@@ -183,13 +183,14 @@ defmodule Credo.Check.Consistency.Collector do
   end
 
   defp most_frequent_match(frequencies, supress_issues_for_single_match?, nil) do
-    {value, frequency_of_match} = frequencies |> Enum.sort() |> Enum.max_by(&elem(&1, 1))
+    {value, frequency_of_match} = Enum.max_by(frequencies, &elem(&1, 1))
     single_match? = frequency_of_match == 1
+    tied_match? = Enum.count(frequencies, &(elem(&1, 1) == frequency_of_match)) > 1
 
-    if single_match? && supress_issues_for_single_match? do
-      :__only_single_match__
-    else
-      value
+    cond do
+      tied_match? -> :__no_most_frequent_match__
+      single_match? && supress_issues_for_single_match? -> :__only_single_match__
+      true -> value
     end
   end
 
@@ -202,6 +203,10 @@ defmodule Credo.Check.Consistency.Collector do
   end
 
   defp source_files_with_issues(_frequencies_per_file, :__only_single_match__) do
+    []
+  end
+
+  defp source_files_with_issues(_frequencies_per_file, :__no_most_frequent_match__) do
     []
   end
 

--- a/test/credo/check/consistency/collector_test.exs
+++ b/test/credo/check/consistency/collector_test.exs
@@ -1,0 +1,46 @@
+defmodule Credo.Check.Consistency.CollectorTest do
+  use Credo.Test.Case
+
+  alias Credo.Check.Consistency.Collector
+  alias Credo.SourceFile
+
+  defmodule TestCollector do
+    def collect_matches(source_file, _params) do
+      case SourceFile.source(source_file) do
+        ":mostly_foo" -> %{foo: 2}
+        ":only_bar" -> %{bar: 1}
+        ":mostly_bar" -> %{bar: 2}
+      end
+    end
+  end
+
+  test "reports files containing matches other than the unique most frequent match" do
+    source_files = source_files([":mostly_foo", ":only_bar"])
+
+    assert [%{expected: :foo, filename: "bar.ex"}] = find_issues(source_files)
+  end
+
+  test "does not report issues when the most frequent matches are tied" do
+    source_files = source_files([":mostly_foo", ":mostly_bar"])
+
+    assert [] == find_issues(source_files)
+  end
+
+  test "reports matches that differ from a forced convention when frequencies are tied" do
+    source_files = source_files([":mostly_foo", ":mostly_bar"])
+
+    assert [%{expected: :foo, filename: "bar.ex"}] = find_issues(source_files, force: :foo)
+  end
+
+  defp find_issues(source_files, params \\ []) do
+    issue_formatter = fn expected, source_file, _params ->
+      [%{expected: expected, filename: source_file.filename}]
+    end
+
+    Collector.find_issues(source_files, TestCollector, params, issue_formatter, false)
+  end
+
+  defp source_files([foo, bar]) do
+    [to_source_file(foo, "foo.ex"), to_source_file(bar, "bar.ex")]
+  end
+end

--- a/test/credo/check/consistency/exception_names_test.exs
+++ b/test/credo/check/consistency/exception_names_test.exs
@@ -99,6 +99,29 @@ defmodule Credo.Check.Consistency.ExceptionNamesTest do
     |> refute_issues()
   end
 
+  test "it should NOT infer a convention when prefixes and suffixes are tied" do
+    [
+      ~S'''
+      defmodule NervesHubWeb.Unauthorized do
+        defexception [:message]
+      end
+      ''',
+      ~S'''
+      defmodule NervesHubWeb.NotFoundError do
+        defexception [:message]
+      end
+      ''',
+      ~S'''
+      defmodule NervesHubWeb.UnauthorizedError do
+        defexception [:message]
+      end
+      '''
+    ]
+    |> to_source_files
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
   test "it should not report (prefixes)" do
     [
       ~S'''


### PR DESCRIPTION
Change the shared collector's convention inference so an unforced analysis produces issues only when exactly one match has the highest frequency; tied leaders represent an ambiguous convention and should yield no issues. Preserve the existing `force` path so checks with an explicitly configured convention continue reporting deviations even when observed counts are tied or uniform. `Credo.Check.Consistency.ExceptionNames` reports `NervesHubWeb.NotFoundError` as inconsistent when the sample contains two names sharing the `Unauthorized` prefix and two names sharing the `Error` suffix. The shared collector currently sorts frequency entries and chooses one entry with `Enum.max_by/2`, so equally prevalent conventions are resolved by term ordering rather than by evidence of a dominant project style.

A shared-collector input with one strictly most-frequent match still formats issues for source files containing less-frequent alternatives; A shared-collector input whose highest frequency is shared by two matches produces no issues instead of selecting a convention by term ordering.

Fixes #1174
