### PR TITLE
Fix disabled checks normalization

### DIFF
--- a/lib/credo/config_file.ex
+++ b/lib/credo/config_file.ex
@@ -391,7 +391,7 @@ defmodule Credo.ConfigFile do
     disabled = disable_check_tuples(checks_other[:disabled])
 
     %{
-      enabled: checks_other_enabled |> normalize_check_tuples() |> Keyword.merge(disabled),
+      enabled: checks_other_enabled |> normalize_check_tuples() |> Keyword.drop(Keyword.keys(disabled)),
       disabled: checks_other[:disabled] || []
     }
   end

--- a/test/credo/check/design/deprecated_checks_config_test.exs
+++ b/test/credo/check/design/deprecated_checks_config_test.exs
@@ -2,6 +2,7 @@ defmodule Credo.Check.Design.DeprecatedChecksConfigTest do
   use Credo.Test.Case
 
   alias Credo.Execution
+  alias Credo.ConfigFile
 
   @described_check Credo.Check.Design.DeprecatedChecksConfig
 
@@ -43,6 +44,36 @@ defmodule Credo.Check.Design.DeprecatedChecksConfigTest do
       }
     }
 
+    exec = Execution.put_assign(Execution.build(), "credo.validated_config", config)
+
+    [source_file]
+    |> run_check(@described_check, [], exec)
+    |> assert_issue(%{trigger: Credo.Issue.no_trigger(), message: ~r/false/})
+  end
+
+  test "it should not report a violation for disabled checks after config merging" do
+    base = %ConfigFile{checks: %{enabled: [{Credo.Check.Foo.BarCheck, []}]}}
+
+    other = %ConfigFile{
+      checks: %{enabled: [{Credo.Check.Foo.BarCheck, []}], disabled: [{Credo.Check.Foo.BarCheck, []}]}
+    }
+
+    config = %{checks: ConfigFile.merge_checks(base, other)}
+    source_file = to_source_file("", @described_check.source_file_stub().filename)
+    exec = Execution.put_assign(Execution.build(), "credo.validated_config", config)
+
+    [source_file]
+    |> run_check(@described_check, [], exec)
+    |> refute_issues()
+
+    assert config.checks == %{enabled: [], disabled: [{Credo.Check.Foo.BarCheck, []}]}
+  end
+
+  test "it should still report a violation for a legacy false tuple after config merging" do
+    base = %ConfigFile{checks: %{enabled: [{Credo.Check.Foo.BarCheck, []}]}}
+    other = %ConfigFile{checks: [{Credo.Check.Bar.BazCheck, false}]}
+    config = %{checks: ConfigFile.merge_checks(base, other)}
+    source_file = to_source_file("", @described_check.source_file_stub().filename)
     exec = Execution.put_assign(Execution.build(), "credo.validated_config", config)
 
     [source_file]


### PR DESCRIPTION
Fixes #1302

## Summary

- keep map-format `:disabled` checks out of the normalized `:enabled` list
- preserve disabled check parameters in the existing `:disabled` list
- retain detection of legacy `{Check, false}` configuration

## Root cause

`ConfigFile.merge_checks/2` converted every explicit `:disabled` entry to `{Check, false}` and merged it into `:enabled`. `DeprecatedChecksConfig` then correctly interpreted those synthetic tuples as deprecated user configuration, so a generated map-format config reported one false positive per disabled check.

The merge now drops disabled check names from the normalized enabled list, matching the behavior of the sibling map-merge clause.

## Validation

- current `master` with the new integration test: 5 tests, 1 expected failure
- `mix test test/credo/config_file_test.exs test/credo/check/design/deprecated_checks_config_test.exs`: 24 tests, 0 failures
- `mix test`: 1,858 tests and 21 doctests, 0 failures, 56 excluded
- `mix format --check-formatted` on both changed files: passed
- upstream-tree comparison: exactly 2 changed files

## AI assistance

This change was prepared with OpenAI Codex assistance and reviewed and validated by the contributor.